### PR TITLE
union: carry issue 2031, issue 2032, issue 2033 and issue 2035 as one merge

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -821,6 +821,79 @@ export async function scrollbackDistanceFromBottom(page: Page): Promise<number |
   });
 }
 
+// Issue 2031 — where one scrollback row sits relative to the pane that clips
+// it, and to the compose below.
+//
+// 🔴 The reason this exists rather than `distanceFromBottom <= 50` or
+// `toBeInViewport()`, which are the two assertions already in the tree and
+// which BOTH pass while the reported defect is on screen:
+//
+//   * `scrollbackDistanceFromBottom` is the pane's distance from its own tail,
+//     and `SCROLL_BOTTOM_THRESHOLD_PX` declares 50px of that to be "at the
+//     tail". A message row is shorter than 50px, so a row can be entirely
+//     below the fold inside a pane that every existing assertion calls tailed.
+//     That tolerance is the thing under accusation; an assertion cannot be
+//     written in terms of it.
+//   * `toBeInViewport()` defaults to `ratio: 0`, i.e. ANY non-empty
+//     intersection. A row showing one pixel passes it. It also measures
+//     against the browser viewport rather than against the scroller, so it
+//     cannot speak about a row clipped by the pane at all.
+//
+// So the reading is the row's box against the PANE's box, in CSS pixels, and
+// it is returned rather than asserted: the caller owns the tolerance, and the
+// numbers are what make a failure legible.
+//
+// `composeTopPx` / `hiddenBehindComposePx` are here to DISCRIMINATE two
+// mechanisms that produce the same complaint ("the line is hidden under the
+// compose"), because the cure is different for each and the report cannot tell
+// them apart:
+//   (a) SCROLL — the pane is short of its own tail, so the row is below the
+//       pane's own bottom edge: `overflowBelowPx > 0`.
+//   (b) LAYOUT — the pane is genuinely at its tail and the row is inside the
+//       pane's box, but the painted pane extends under the compose, so the row
+//       is covered: `overflowBelowPx <= 0` while `hiddenBehindComposePx > 0`.
+// (b) is not hypothetical: `themes/default.css` records exactly it on iOS
+// WebKit ("last messages hide behind BottomBar", UX-6 bucket D v2), cured
+// there with `min-height: 0`. A spec that only knew (a) would misattribute it.
+export type RowClearance = {
+  readonly rowTopPx: number;
+  readonly rowBottomPx: number;
+  readonly paneTopPx: number;
+  readonly paneBottomPx: number;
+  // Positive ⇒ that many CSS px of the row are past the pane's bottom edge.
+  readonly overflowBelowPx: number;
+  // Positive ⇒ that many CSS px of the row are above the pane's top edge.
+  readonly overflowAbovePx: number;
+  // The pane's own distance from its tail, for cross-reading against the
+  // threshold that is under accusation.
+  readonly distanceFromBottomPx: number;
+  // `null` when no compose is mounted (a read-only window).
+  readonly composeTopPx: number | null;
+  readonly hiddenBehindComposePx: number | null;
+};
+
+export async function rowClearance(row: Locator): Promise<RowClearance> {
+  return await row.evaluate((el) => {
+    const pane = document.querySelector('[data-testid="scrollback"]') as HTMLElement | null;
+    if (!pane) throw new Error("rowClearance: scrollback container not found");
+    const r = el.getBoundingClientRect();
+    const p = pane.getBoundingClientRect();
+    const compose = document.querySelector(".compose-box") as HTMLElement | null;
+    const composeTop = compose ? compose.getBoundingClientRect().top : null;
+    return {
+      rowTopPx: r.top,
+      rowBottomPx: r.bottom,
+      paneTopPx: p.top,
+      paneBottomPx: p.bottom,
+      overflowBelowPx: r.bottom - p.bottom,
+      overflowAbovePx: p.top - r.top,
+      distanceFromBottomPx: pane.scrollHeight - pane.scrollTop - pane.clientHeight,
+      composeTopPx: composeTop,
+      hiddenBehindComposePx: composeTop === null ? null : r.bottom - composeTop,
+    };
+  });
+}
+
 // #237 — the on-JOIN inline topic line. NOT a `scrollback-line` (it is a
 // presentational, non-message row derived from the topic store — no server
 // message id, so it never enters the unread/cursor math). Its own testid

--- a/cicchetto/e2e/fixtures/scrollWriteProbe.ts
+++ b/cicchetto/e2e/fixtures/scrollWriteProbe.ts
@@ -1,0 +1,166 @@
+// The scrollback scroll-write spy, extracted from
+// `issue625-single-send-scroll-jump.spec.ts` when issue 2031 needed the same
+// instrument.
+//
+// It answers a question no position sampler can: WHO WROTE, and WHEN. #625's
+// defect is a second `scrollIntoView` landing ~0.5s after the send, and a
+// recorder of positions cannot tell a delayed write apart from a delayed
+// layout — both show up as "the number changed late". So this wraps the two
+// doors a scroll write can come through (`Element.prototype.scrollIntoView`
+// and the `scrollTop` setter) and timestamps each one.
+//
+// It is a FIXTURE and not a copy in each spec because two specs now assert
+// against the same recording, and a second copy is how the two drift into
+// disagreeing about what a write is. The page-context globals are namespaced
+// away from any one issue number for the same reason.
+//
+// Page-context only: nothing here changes production behaviour. The wrap is
+// installed on the live page and never restored — each spec gets a fresh page,
+// so there is nothing to leak into.
+
+import type { Page } from "@playwright/test";
+
+// One geometry reading of the scrollback container.
+export type ScrollSample = {
+  readonly t: number;
+  readonly top: number;
+  readonly height: number;
+  readonly client: number;
+};
+
+// One observed scroll write, with the position it found the pane at.
+export type ScrollWrite = {
+  readonly t: number;
+  readonly kind: string;
+  readonly detail: string;
+  readonly before: number;
+};
+
+export type ScrollProbeReading = {
+  readonly samples: readonly ScrollSample[];
+  readonly writes: readonly ScrollWrite[];
+};
+
+// Distance from the tail for one sample. The raw float, like
+// `scrollbackDistanceFromBottom` — the caller owns the rounding, because the
+// caller owns the threshold it is compared against.
+export function distanceOf(s: ScrollSample): number {
+  return s.height - s.top - s.client;
+}
+
+// The writes that landed more than `graceMs` after the FIRST one.
+//
+// Measured from the first write and not from probe-install on purpose: the
+// send's own latency (the CDP round-trip plus the WS echo) floats the
+// legitimate write's absolute timestamp, so an absolute cutoff false-REDs on a
+// slow run. The defect IS the gap between two writes, so the gap is what is
+// measured.
+export function delayedWrites(
+  writes: readonly ScrollWrite[],
+  graceMs: number,
+): readonly ScrollWrite[] {
+  const first = writes[0];
+  if (first === undefined) return [];
+  return writes.filter((w) => w.t - first.t > graceMs);
+}
+
+// Install the sampler + write spy on the scrollback container. Call BEFORE the
+// action under test.
+//
+// The sampler records on every native `scroll` event AND on a rAF tick: a
+// programmatic write that lands between two scroll events is invisible to the
+// event alone, and that write is exactly the one under accusation.
+export async function installScrollProbe(page: Page, windowMs: number): Promise<void> {
+  await page.evaluate((windowMsArg) => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (!el) throw new Error("scrollWriteProbe: scrollback container not found");
+    type Sample = { t: number; top: number; height: number; client: number };
+    type WriteEvent = { t: number; kind: string; detail: string; before: number };
+    const w = window as unknown as {
+      __scrollProbeSamples: Sample[];
+      __scrollProbeWrites: WriteEvent[];
+    };
+    w.__scrollProbeSamples = [];
+    w.__scrollProbeWrites = [];
+    const t0 = performance.now();
+    const now = () => performance.now() - t0;
+
+    // Read through the PROTOTYPE descriptor, not `el.scrollTop`: the own
+    // property installed below would otherwise make the spy read itself.
+    const desc = Object.getOwnPropertyDescriptor(Element.prototype, "scrollTop");
+    const getTop = () => (desc?.get ? (desc.get.call(el) as number) : el.scrollTop);
+
+    if (desc?.get && desc?.set) {
+      Object.defineProperty(el, "scrollTop", {
+        configurable: true,
+        get() {
+          return desc.get?.call(this);
+        },
+        set(v: number) {
+          w.__scrollProbeWrites.push({
+            t: Math.round(now()),
+            kind: "scrollTop=",
+            detail: String(Math.round(v)),
+            before: Math.round(getTop()),
+          });
+          desc.set?.call(this, v);
+        },
+      });
+    }
+
+    const rawSIV = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = function (arg?: boolean | ScrollIntoViewOptions) {
+      // Only writes that move THIS scroller count — `scrollIntoView` on a node
+      // elsewhere in the document is somebody else's business.
+      if (this === el || el.contains(this as Node)) {
+        w.__scrollProbeWrites.push({
+          t: Math.round(now()),
+          kind: "scrollIntoView",
+          detail: JSON.stringify(arg ?? null),
+          before: Math.round(getTop()),
+        });
+      }
+      return rawSIV.call(this, arg as ScrollIntoViewOptions);
+    };
+
+    const sample = () => {
+      w.__scrollProbeSamples.push({
+        t: Math.round(now()),
+        top: Math.round(getTop()),
+        height: el.scrollHeight,
+        client: el.clientHeight,
+      });
+    };
+    sample();
+    el.addEventListener("scroll", sample, { passive: true });
+    const loop = () => {
+      sample();
+      if (now() < windowMsArg) requestAnimationFrame(loop);
+    };
+    requestAnimationFrame(loop);
+  }, windowMs);
+}
+
+// Read the recording back and print it. On a failure this dump is the whole
+// story: `writes` names every write and its timestamp (a delayed double-scroll
+// shows as a second entry ~0.5s in), `topChanges` is the compressed scrollTop
+// timeline with only the frames where the position actually moved.
+export async function dumpScrollProbe(page: Page, tag: string): Promise<ScrollProbeReading> {
+  const samples = await page.evaluate(
+    () => (window as unknown as { __scrollProbeSamples: ScrollSample[] }).__scrollProbeSamples,
+  );
+  const writes = await page.evaluate(
+    () => (window as unknown as { __scrollProbeWrites: ScrollWrite[] }).__scrollProbeWrites,
+  );
+  const compact: Array<{ t: number; top: number; d: number }> = [];
+  let prevTop = Number.NaN;
+  for (const s of samples) {
+    if (s.top !== prevTop) {
+      compact.push({ t: s.t, top: s.top, d: Math.round(distanceOf(s)) });
+      prevTop = s.top;
+    }
+  }
+  console.log(`[scroll-probe ${tag}] writes=${JSON.stringify(writes)}`);
+  console.log(`[scroll-probe ${tag}] topChanges=${JSON.stringify(compact)}`);
+  return { samples, writes };
+}

--- a/cicchetto/e2e/tests/cursor-forward-only.spec.ts
+++ b/cicchetto/e2e/tests/cursor-forward-only.spec.ts
@@ -38,6 +38,7 @@ import type { Page } from "@playwright/test";
 import {
   loginAs,
   pageScrollbackBy,
+  scrollbackDistanceFromBottom,
   scrollbackLines,
   selectChannel,
 } from "../fixtures/cicchettoPage";
@@ -150,6 +151,41 @@ async function scrollToBottom(page: Page): Promise<void> {
   // #1336: this one was watched by NOBODY — deleting it left all six tests
   // green. Through the shared door a wheel that moves nothing is a named
   // failure instead of a silent pass.
+  //
+  // Issue 2031 — this helper's name states a POSTCONDITION ("be at the
+  // bottom"), and until now it asserted a SIDE EFFECT instead ("something
+  // moved"). Those agreed only for as long as the pane stopped ~7px short of
+  // its own maximum: the tail write aligned the last row's bottom with the
+  // scrollport EDGE and left `.scrollback`'s own bottom padding unscrolled, so
+  // there was always a little run left for the wheel to consume. Issue 2031
+  // finished that write at `scrollHeight - clientHeight`, the run went to
+  // ZERO, and `scrollByGesture` — correctly, by its own contract — rejected a
+  // gesture the pane cannot honour. Measured: `remaining` 7 → 0, and the spec
+  // moved from 5/5 green to 5/5 red across that one change.
+  //
+  // 🔴 This is NOT a widened tolerance, and reading it as one in six months
+  // would be the wrong lesson. Nothing was relaxed: no timeout grew, no
+  // threshold moved, no assertion was deleted, and `scrollByGesture` is
+  // untouched — its rejection is a real guard for every other caller, and
+  // softening it there would blind all of them to buy comfort for one. What
+  // changed is WHICH claim this helper makes. Already being at the bottom
+  // satisfies "scroll to bottom" completely; demanding a displacement on top
+  // of that asserts the mechanism rather than the outcome, and an assertion
+  // about a mechanism goes stale the moment the mechanism is improved. It
+  // just did.
+  //
+  // The guard #1336 bought is kept where it still bites: whenever there IS run
+  // left, the gesture goes through the same rejecting door as before, so a
+  // wheel that fails to be delivered is still a named failure and not a silent
+  // pass. Only the already-satisfied case skips it — and it skips it because
+  // there is nothing left to deliver, not because we stopped looking.
+  //
+  // The sentinel points the same way as the branch it feeds: an unmounted pane
+  // reads as "run left", so it takes the gesture path and fails there with
+  // that path's own diagnosis, instead of being silently treated as done.
+  const remaining = (await scrollbackDistanceFromBottom(page)) ?? Number.POSITIVE_INFINITY;
+  if (remaining <= 0) return;
+
   await pageScrollbackBy(page, 5000, GESTURE_TIMEOUT_MS);
 }
 

--- a/cicchetto/e2e/tests/issue2031-send-with-marker-row-clipped.spec.ts
+++ b/cicchetto/e2e/tests/issue2031-send-with-marker-row-clipped.spec.ts
@@ -1,0 +1,261 @@
+// Issue 2031 — sending with the `── XX unread messages ──` marker on screen
+// leaves the just-sent row CLIPPED at the bottom of the scrollback.
+//
+// ## Why this spec exists next to issue625, which already sends with a marker
+//
+// `issue625-single-send-scroll-jump.spec.ts` second case builds the SAME
+// shape — mid-page cursor, marker rendered, send from history — and it is
+// green. So the defect does not live in what that spec asserts; it lives in
+// the gap between those assertions and "the reader can see what they sent".
+// Both of its visibility assertions pass with the row mostly off-screen:
+//
+//   * `distance-to-tail <= SCROLL_BOTTOM_THRESHOLD_PX` is 50px of declared
+//     slack, and a message row is shorter than that. A pane every existing
+//     assertion calls "at the tail" can hold a whole row below the fold.
+//   * `toBeInViewport()` defaults to `ratio: 0` — ANY non-empty intersection
+//     passes, so a row showing one pixel is "in viewport". It also measures
+//     against the browser viewport, not the scroller, so it cannot describe a
+//     row the pane itself clips.
+//
+// This spec asserts the row's BOX against the PANE's BOX (`rowClearance`), and
+// that is the whole point: the 50px tolerance is the thing under accusation,
+// so the assertion may not be written in terms of it.
+//
+// ## The second face, from the report
+//
+// vjt's comment adds: when the row sits slightly off, "after a moment it
+// shifts by a few pixels on its own". That is a scroll write landing AFTER the
+// send settled, which is #625's own signature, so it is asserted here too —
+// on the reported platform, which #625 never runs on.
+//
+// ## What this actually measured, before any cure existed
+//
+// Nine runs on the untouched tree (`--repeat-each 3`), and the terminal state
+// is two-valued:
+//
+//   webkit-iphone-15   3/3   distanceFromBottom = 7   overflowBelow = +0.203
+//   chromium           2/3   distanceFromBottom = 7   overflowBelow = +0.359
+//   chromium           1/3   distanceFromBottom = 0   overflowBelow = -6.640
+//
+// So the pane does NOT stop inside the 50px slack by a wide margin — it stops
+// SEVEN pixels short of its own tail, which is the extent of the scroller's
+// own `padding-bottom`. `scrollIntoView({ block: "end" })` brings the row's
+// bottom to the pane's bottom EDGE and leaves that padding unscrolled; the row
+// then sits flush, with zero clearance and a fraction of a pixel cut off. The
+// remaining 7px is never corrected, because 7 <= 50 makes the #625 fail-safe
+// read the pane as "at the tail" and skip its write.
+//
+// That is the issue's own candidate mechanism, now MEASURED rather than
+// inherited — with one correction to it: the marker collapse is not what
+// leaves the pane short. `scrollIntoView`'s padding blind spot is.
+//
+// The report's SECOND face did NOT reproduce. Every one of the nine runs
+// recorded exactly ONE scroll write, so nothing moved the pane after the send
+// settled and assertion (b) below is green on the untouched tree. It is
+// asserted anyway: it is the invariant #625 bought, this is the first spec to
+// state it on webkit, and a cure that reintroduced a delayed write would
+// otherwise land unnoticed. A green there is a guard, not a reproduction.
+//
+// ## Platform
+//
+// Reported from iPhone, and not a regression. On webkit the shortfall is
+// DETERMINISTIC (3/3); on chromium it is 2/3, so the desktop case is expected
+// to be an unreliable red before the cure and a solid green after. Both are
+// kept: the defect is geometry rather than engine, and that is worth pinning
+// on both rather than assuming.
+//
+// ## Two hypotheses this spec falsified — kept because a dead end that is
+// ## written down is not walked twice
+//
+// 1. THE SOFT KEYBOARD IS NOT INVOLVED. A third case sent with
+//    `visualViewport` shrunk to 300px the way issue253 stubs it, and produced
+//    numbers IDENTICAL to its keyboard-less twin to the third decimal
+//    (distance 7, overflow +0.203, 3/3). The case and its fixture were removed
+//    rather than kept green-and-meaningless.
+// 2. THE LAYOUT MECHANISM IS NOT THIS ONE. `themes/default.css` records "last
+//    messages hide behind BottomBar" on iOS WebKit (UX-6 bucket D v2), which
+//    is the same complaint from a different cause — a pane painted past its
+//    own box. Measured, `composeTopPx` equals `paneBottomPx` exactly on both
+//    engines, so nothing is painted under the compose and that cure is not the
+//    one needed here. `rowClearance` still reports the field, so the next
+//    reader can tell the two apart instead of re-deriving it.
+
+import type { Page } from "@playwright/test";
+import {
+  composeSend,
+  loginAs,
+  rowClearance,
+  scrollbackDistanceFromBottom,
+  scrollbackLines,
+  selectChannel,
+  waitForScrollbackRefreshed,
+} from "../fixtures/cicchettoPage";
+import { fetchScrollbackPage, setReadCursorToId } from "../fixtures/grappaApi";
+import { delayedWrites, dumpScrollProbe, installScrollProbe } from "../fixtures/scrollWriteProbe";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Mirror of `lib/scrollThresholds.ts` SCROLL_BOTTOM_THRESHOLD_PX — used ONLY
+// to build the precondition (the pane parked in history is more than this from
+// the tail) and to cross-read a failure. Never as the visibility assertion:
+// that is the tolerance under accusation.
+const SCROLL_BOTTOM_THRESHOLD_PX = 50;
+
+// REST default page size (Grappa.Web.MessagesController.@default_limit).
+const REST_PAGE_SIZE = 50;
+
+// 🔴 ZERO, and the first draft of this spec got it wrong at 1px.
+//
+// A 1px "sub-pixel slack" was written in defensively, and MEASURED over nine
+// runs it swallowed the defect whole: the clipped state overflows the pane's
+// bottom edge by +0.203px (webkit) / +0.359px (chromium), so the spec passed
+// while photographing exactly what it was written to catch.
+//
+// Zero is not a knife edge here, which is the reason it is safe. The two
+// states are ~7px apart and neither is near the boundary:
+//   correct   distanceFromBottom = 0, overflowBelow = -6.64 … -7.44  (clear)
+//   defective distanceFromBottom = 7, overflowBelow = +0.20 … +0.36  (clipped)
+// There is no sub-pixel path from -6.6 to +0.2, so rounding cannot flip the
+// verdict; only the shortfall can.
+const SUBPIXEL_TOLERANCE_PX = 0;
+
+// Must outlast every #608 deferred writer: SETTLE_MAX_FRAMES (30) ≈ 0.5s,
+// SCROLL_SETTLE_DEBOUNCE_MS = 500, PRESENCE_CURSOR_SETTLE_MS = 500. Same
+// window issue625 samples over, for the same reason.
+const SAMPLE_WINDOW_MS = 2500;
+
+// A send's ONE legitimate tail-follow fires at frame 0 of its poll; the
+// delayed one lands SETTLE_MAX_FRAMES ≈ 0.5s later. Measured from the first
+// observed write, never from probe-install — see `delayedWrites`.
+const SETTLE_GRACE_MS = 300;
+
+// Park the reader in history with the unread marker rendered, then assert the
+// marker is REALLY on screen — the issue's precondition is "with the marker
+// visible", and a marker that exists below the fold is a different scenario.
+async function parkOnVisibleMarker(page: Page): Promise<void> {
+  const vjt = specUser();
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+
+  const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
+  expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+  const cursorRow = page0[25];
+  if (!cursorRow) throw new Error("seeded page too short for cursor placement");
+  await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
+
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await waitForScrollbackRefreshed(page, NETWORK_SLUG, CHANNEL);
+
+  await expect
+    .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+    .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+
+  const marker = page.locator('[data-testid="unread-marker"]');
+  await expect(marker).toHaveCount(1);
+  // ON SCREEN, not merely present: the report's trigger is a visible marker.
+  await expect(marker).toBeInViewport();
+
+  // Parked in history: the pane is above the fold when the send happens.
+  await expect
+    .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 0, { timeout: 10_000 })
+    .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
+}
+
+// The body of both cases. Kept as one function because the two differ ONLY in
+// the engine they run on, and a copy would let them drift into testing
+// different things on the two platforms — which is the one comparison the
+// pair exists to make.
+async function sendWithMarkerAndAssertVisible(page: Page, tag: string): Promise<void> {
+  await parkOnVisibleMarker(page);
+
+  await installScrollProbe(page, SAMPLE_WINDOW_MS);
+  const body = `i2031 ${tag} ${Date.now()}`;
+  await composeSend(page, body);
+
+  const sentLine = scrollbackLines(page).filter({ hasText: body });
+  await expect(sentLine).toHaveCount(1, { timeout: 10_000 });
+
+  // VACUITY GUARD. The scenario is "a send that collapses a visible marker",
+  // and the marker collapse is the follow-on rows change the candidate
+  // mechanism turns on. If the re-latch never ran, the run under test never
+  // happened and a green below would mean nothing. `lastOwnSend` fires after
+  // the POST resolves, so this is also the barrier that the send CONFIRMED.
+  await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(0, {
+    timeout: 10_000,
+  });
+
+  // Let every deferred writer land before reading the terminal geometry.
+  await page.waitForTimeout(SAMPLE_WINDOW_MS + 200);
+
+  const { samples, writes } = await dumpScrollProbe(page, tag);
+  expect(samples.length).toBeGreaterThan(10);
+
+  // ── (a) the sent row is FULLY visible in the pane that clips it ──────────
+  const clearance = await rowClearance(sentLine);
+  console.log(`[#2031 ${tag}] clearance=${JSON.stringify(clearance)}`);
+  expect(
+    clearance.overflowBelowPx,
+    `the sent row is clipped at the pane's bottom edge. ` +
+      `overflowBelow=${clearance.overflowBelowPx.toFixed(1)}px, ` +
+      `distanceFromBottom=${clearance.distanceFromBottomPx.toFixed(1)}px ` +
+      `(threshold ${SCROLL_BOTTOM_THRESHOLD_PX}), ` +
+      `hiddenBehindCompose=${clearance.hiddenBehindComposePx?.toFixed(1) ?? "n/a"}px. ` +
+      `overflowBelow>0 ⇒ SCROLL (pane short of its tail); ` +
+      `overflowBelow<=0 with hiddenBehindCompose>0 ⇒ LAYOUT (pane painted under the compose).`,
+  ).toBeLessThanOrEqual(SUBPIXEL_TOLERANCE_PX);
+
+  // The same row must not be covered by the compose either — the LAYOUT face
+  // of the identical complaint, which the pane-box comparison alone cannot see.
+  //
+  // ⚠️ Today this is DEGENERATE and says nothing the assertion above did not:
+  // measured, `composeTopPx === paneBottomPx` exactly on both engines (the two
+  // are flush flex siblings), so `hiddenBehindCompose` equals `overflowBelow`
+  // to the bit. It earns its place only in the state it exists to catch — a
+  // pane painted PAST its own box, where `composeTop < paneBottom` and the two
+  // numbers separate. Stated rather than dropped: a reader who finds two
+  // assertions agreeing on every run deserves to know which one is load-bearing
+  // now and which is a tripwire for later.
+  if (clearance.hiddenBehindComposePx !== null) {
+    expect(
+      clearance.hiddenBehindComposePx,
+      `the sent row is inside the pane but painted under the compose: ` +
+        `rowBottom=${clearance.rowBottomPx.toFixed(1)}, composeTop=${clearance.composeTopPx?.toFixed(1)}`,
+    ).toBeLessThanOrEqual(SUBPIXEL_TOLERANCE_PX);
+  }
+
+  // ── (b) nothing writes scroll after the send settled ─────────────────────
+  // The report's second face: "after a moment it shifts by a few pixels on its
+  // own". Same invariant #625 pins on chromium; asserted here on the reported
+  // platform too.
+  expect(
+    writes.length,
+    `expected the send's tail-follow write; writes=${JSON.stringify(writes)}`,
+  ).toBeGreaterThanOrEqual(1);
+  expect(
+    delayedWrites(writes, SETTLE_GRACE_MS),
+    `scroll write(s) landed after the send settled: ${JSON.stringify(writes)}`,
+  ).toEqual([]);
+}
+
+test.describe("issue 2031 — a send with the unread marker on screen (desktop)", () => {
+  // Tiny viewport so the seeded buffer overflows and the geometry is real —
+  // the same 800×300 issue580 / issue625 use.
+  test.use({ viewport: { width: 800, height: 300 } });
+
+  test("the sent row lands fully inside the pane, and nothing scrolls after", async ({ page }) => {
+    await sendWithMarkerAndAssertVisible(page, "desktop");
+  });
+});
+
+test.describe("issue 2031 — a send with the unread marker on screen (iPhone)", () => {
+  // No `test.use({ viewport })` here on purpose: the `webkit-iphone-15`
+  // project's device descriptor owns the viewport, and overriding it would
+  // throw away the fidelity that makes this the reported platform's case.
+  test("@webkit the sent row lands fully inside the pane, and nothing scrolls after", async ({
+    page,
+  }) => {
+    await sendWithMarkerAndAssertVisible(page, "iphone");
+  });
+});

--- a/cicchetto/e2e/tests/issue2032-visibility-return-preserve-position.spec.ts
+++ b/cicchetto/e2e/tests/issue2032-visibility-return-preserve-position.spec.ts
@@ -1,0 +1,290 @@
+// issue 2032 — returning from an EXTERNAL link must leave the reader exactly
+// where they were, even when an unread divider renders on the return.
+//
+// Reported: tapping a link that leaves the app (external browser / another tab)
+// and coming back moves the reader off the position they were reading at.
+// Desktop AND mobile, long-standing. Modals are unaffected — they never hide the
+// document, so the pane holds position through `overlay-freeze` (a different
+// writer).
+//
+// ## What this file adds that issue535-visibility-return-preserve-scroll.spec.ts
+// ## could not catch
+//
+// #535 shipped `"marker-or-preserve"`, a mode that PRESERVES only when NO
+// divider renders — with a divider present it `scrollIntoView`s it, i.e. it
+// moves the reader. Its own spec pinned that as the contract ("return lands ON
+// the divider"), so the whole divider-present half of the space was green by
+// construction. The discriminating case is therefore the one with a divider
+// PRESENT on the return; without one the code already preserves and any test is
+// vacuous.
+//
+// Two writers move the reader on a visibility-return, and BOTH must be held:
+//
+//   1. the divider JUMP — `scrollToActivation` reads the `unread-marker` node
+//      for `"marker-or-preserve"` exactly as it does for a deliberate switch;
+//   2. the divider RE-LATCH — the visibility arm re-pointed `markerCursorId` at
+//      the LIVE read cursor, which recomputes `rows()`; `<For>` is keyed by
+//      reference and every row is a fresh object, so the DOM list is recreated
+//      and scrollTop collapses to 0. Today that reset is MASKED by writer 1
+//      landing somewhere immediately after it.
+//
+// The test below exercises BOTH: the reader reads DOWNWARD past the frozen
+// divider, which arms the input-gated scroll-settle (`SCROLL_SETTLE_DEBOUNCE_MS`
+// = 500) and advances the LIVE cursor past the divider — so on return the
+// re-latch has somewhere new to point. Removing only writer 1 leaves the reader
+// at scrollTop 0; removing only writer 2 leaves them on the divider. The
+// contract holds only when both are gone.
+//
+// ## Contract
+//
+// A visibility-return is a RESUME, not a window change: it preserves the
+// reader's scroll position and leaves the frozen divider where it was. Only a
+// DELIBERATE activation (switch / cold-mount) lands on the divider — guarded by
+// the second test here, and more fully by scroll-on-window-switch.spec.ts
+// ("SWITCH into channel-with-unreads", "fresh focus / cold-mount") which this
+// file deliberately does not restate.
+//
+// ## Oracle
+//
+// scrollTop in RAW PIXELS against a sub-pixel epsilon — NOT
+// `SCROLL_BOTTOM_THRESHOLD_PX`. That constant is a product threshold for
+// classifying follow INTENT (50px, deliberately generous); reusing it as a
+// tolerance would swallow any defect smaller than the band. The defect here is
+// a viewport-scale jump, but the epsilon is sized to the MEASUREMENT, not to the
+// defect, so the spec stays honest if the jump ever shrinks.
+//
+// ## Fixture shape (matches issue535 / scroll-on-window-switch / cp14-b1)
+//
+// The 200 DB-seeded rows on `(specUser, bahamut-test, #spec-wN)` plus an 800×300
+// viewport so the 50-row REST page overflows — without overflow "not at the
+// tail" is vacuous. The per-spec subject (sha1 of the title path) owns its own
+// cursor, so no afterAll restore is needed.
+
+import type { Page } from "@playwright/test";
+import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
+import { fetchScrollbackPage, setReadCursorToId } from "../fixtures/grappaApi";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+const REST_PAGE_SIZE = 50;
+
+// Sub-pixel measurement epsilon. Deliberately NOT SCROLL_BOTTOM_THRESHOLD_PX
+// (50) — see the "Oracle" note above.
+const SCROLL_EPS_PX = 2;
+
+// Clear of LOAD_MORE_THRESHOLD_PX (200) so paging older rows in never churns
+// the buffer under the assertions.
+const CLEAR_OF_TAIL_PX = 200;
+
+// ScrollbackPane.SCROLL_SETTLE_DEBOUNCE_MS = 500 (not exported; kept in lockstep
+// the same way issue535 mirrors SCROLL_BOTTOM_THRESHOLD_PX). The settle POST is
+// what advances the LIVE cursor past the frozen divider — the whole premise of
+// the re-latch case — so the wait must clear it with margin.
+const SCROLL_SETTLE_WAIT_MS = 900;
+
+async function scrollbackGeometry(
+  page: Page,
+): Promise<{ scrollTop: number; scrollHeight: number; clientHeight: number }> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (!el) throw new Error("scrollback container not found");
+    return {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    };
+  });
+}
+
+async function distanceFromBottom(page: Page): Promise<number> {
+  const g = await scrollbackGeometry(page);
+  return g.scrollHeight - g.scrollTop - g.clientHeight;
+}
+
+// The divider's offset from the top of the scroll container's VIEWPORT.
+// ~0 → the reader is parked on it (block:"start"); negative → the reader has
+// read PAST it and it is above the fold.
+async function markerViewportOffset(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLElement | null;
+    const m = document.querySelector('[data-testid="unread-marker"]') as HTMLElement | null;
+    if (!el) throw new Error("scrollback container not found");
+    if (!m) throw new Error("unread-marker not rendered");
+    return m.getBoundingClientRect().top - el.getBoundingClientRect().top;
+  });
+}
+
+// WHERE the frozen divider sits in the row list, independent of scroll. The
+// re-latch MOVES it; the freeze contract on a resume must not. Index among the
+// container's element children is stable under a tail append (the async
+// `refreshScrollback` co-trigger), which a pixel offset is not.
+async function markerRowIndex(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLElement | null;
+    if (!el) throw new Error("scrollback container not found");
+    const kids = Array.from(el.children);
+    const idx = kids.findIndex((c) => c.getAttribute("data-testid") === "unread-marker");
+    if (idx < 0) throw new Error("unread-marker not among scrollback children");
+    return idx;
+  });
+}
+
+// A REAL Chromium wheel gesture. Required twice over: `onScroll` only flips the
+// follow state on a genuine gesture, and the cursor scroll-settle is gated on a
+// recent INPUT event (`INPUT_EVENT_RECENCY_MS`) — a synthetic scroll event is
+// deliberately gated out (BUGHUNT-2), so it would never advance the cursor and
+// the re-latch premise would silently not hold. Same idiom as issue535.
+async function wheelBy(page: Page, deltaY: number): Promise<void> {
+  const box = await page.locator('[data-testid="scrollback"]').boundingBox();
+  if (!box) throw new Error("scrollback bounding box null");
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.wheel(0, deltaY);
+}
+
+// Flip document visibility deterministically. documentVisibility.ts reads BOTH
+// `document.visibilityState` AND `document.hasFocus()`, so both are overridden;
+// the production listeners' events are dispatched so the Solid signal updates.
+// Identical idiom to issue535 / freshness-on-activation.
+async function setTabHidden(page: Page, hidden: boolean): Promise<void> {
+  await page.evaluate((isHidden) => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => (isHidden ? "hidden" : "visible"),
+    });
+    Object.defineProperty(document, "hasFocus", {
+      configurable: true,
+      value: () => !isHidden,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event(isHidden ? "blur" : "focus"));
+  }, hidden);
+  await page.waitForTimeout(150);
+}
+
+// Seed a cursor `back` rows from the tail so an unread divider injects, then log
+// in and land on the channel. Returns nothing — callers assert their own
+// preconditions off the live DOM.
+async function seedCursorAndOpen(page: Page, back: number): Promise<void> {
+  const vjt = specUser();
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+
+  const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
+  expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+  const cursorRow = page0[back];
+  if (!cursorRow) throw new Error(`seeded page too short for a cursor ${back} rows back`);
+  await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
+
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await expect
+    .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+    .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+}
+
+test.describe("issue 2032 — a visibility-return resumes, it does not re-activate", () => {
+  test.use({ viewport: { width: 800, height: 300 } });
+
+  test("reader who read PAST the divider: returning preserves scrollTop and leaves the divider frozen", async ({
+    page,
+  }) => {
+    // 45 rows of unread puts the divider near the TOP of the 50-row REST page,
+    // leaving room to read a long way DOWN past it without reaching the tail.
+    await seedCursorAndOpen(page, 45);
+
+    const marker = page.locator('[data-testid="unread-marker"]');
+    await expect(marker).toHaveCount(1);
+
+    // PREMISE 1 (and the #168 contract): the deliberate activation that opened
+    // this window landed ON the divider. If this ever stops holding, the case
+    // below is not the one this file claims to test and must die here rather
+    // than pass for the wrong reason.
+    const g0 = await scrollbackGeometry(page);
+    expect(g0.scrollHeight).toBeGreaterThan(g0.clientHeight);
+    // Poll the LANDING itself (the activation scroll settles inside a rAF×2),
+    // not a bound the pre-landing state would also satisfy.
+    await expect
+      .poll(async () => await markerViewportOffset(page), { timeout: 10_000 })
+      .toBeLessThan(g0.clientHeight / 2);
+    expect(await markerViewportOffset(page)).toBeGreaterThanOrEqual(-5);
+
+    // PREMISE 2: there is enough unread content BELOW the divider to read into
+    // without landing at the tail. Measured, not assumed — a shorter buffer
+    // would make the scroll-down below a no-op.
+    const room = await distanceFromBottom(page);
+    expect(room).toBeGreaterThan(2 * CLEAR_OF_TAIL_PX);
+
+    // The reader reads DOWNWARD through the unread run — a real wheel gesture,
+    // sized from the MEASURED room so it never depends on a row height. Half the
+    // remaining distance keeps them clear of the tail.
+    await wheelBy(page, Math.floor(room / 2));
+    await expect.poll(async () => await distanceFromBottom(page)).toBeGreaterThan(CLEAR_OF_TAIL_PX);
+
+    // Let the input-gated scroll-settle fire: it POSTs the visible-tail id and
+    // advances the LIVE read cursor PAST the frozen divider. This is what gives
+    // the visibility re-latch a new place to point.
+    await page.waitForTimeout(SCROLL_SETTLE_WAIT_MS);
+
+    // PREMISE 3: the reader is now BELOW the divider (it is above the fold) and
+    // the divider has NOT moved while they read — the freeze contract. Both are
+    // what make the re-latch on return observable.
+    expect(await markerViewportOffset(page)).toBeLessThan(0);
+    const beforeIndex = await markerRowIndex(page);
+    const before = await scrollbackGeometry(page);
+    expect(before.scrollTop).toBeGreaterThan(CLEAR_OF_TAIL_PX);
+
+    // Tap the link, leave the app, come back.
+    await setTabHidden(page, true);
+    await setTabHidden(page, false);
+    // Generous enough to contain the visibility effect's rAF×2 AND the async
+    // refreshScrollback append that can follow it.
+    await page.waitForTimeout(700);
+
+    // CONTRACT: the reader is exactly where they left off.
+    //
+    // RED pre-cure, two ways at once: the re-latch recomputes `rows()` and the
+    // ref-keyed `<For>` drops scrollTop to 0, then the divider jump lands the
+    // reader on the re-latched divider — neither is `before.scrollTop`.
+    const after = await scrollbackGeometry(page);
+    expect(Math.abs(after.scrollTop - before.scrollTop)).toBeLessThanOrEqual(SCROLL_EPS_PX);
+
+    // Not tail-snapped (the #535 regression) and not stranded at the top (the
+    // <For> recreation), stated as outcomes in their own right so a failure
+    // names WHICH way the reader was moved.
+    expect(after.scrollHeight - after.scrollTop - after.clientHeight).toBeGreaterThan(
+      CLEAR_OF_TAIL_PX,
+    );
+    expect(after.scrollTop).toBeGreaterThan(CLEAR_OF_TAIL_PX);
+
+    // The frozen divider stayed frozen: a resume is not a focus acquisition, so
+    // it does not re-latch to the live cursor.
+    await expect(marker).toHaveCount(1);
+    expect(await markerRowIndex(page)).toBe(beforeIndex);
+    expect(await markerViewportOffset(page)).toBeLessThan(0);
+  });
+
+  test("a DELIBERATE activation still lands on the divider (#168 must not regress)", async ({
+    page,
+  }) => {
+    // The cure narrows the divider query in `scrollToActivation` to the
+    // deliberate modes only. This is the guard that the narrowing did not take
+    // the deliberate arm with it. The pure window-SWITCH arm of the same mode is
+    // guarded by scroll-on-window-switch.spec.ts ("SWITCH into
+    // channel-with-unreads") and is not restated here.
+    await seedCursorAndOpen(page, 25);
+
+    const marker = page.locator('[data-testid="unread-marker"]');
+    await expect(marker).toHaveCount(1);
+    await expect(marker).toBeInViewport();
+
+    // Landed ON it (block:"start" → at/near the top of the viewport), not at the
+    // tail. The pane must overflow, or "did not land at the tail" is vacuous.
+    const g = await scrollbackGeometry(page);
+    expect(g.scrollHeight).toBeGreaterThan(g.clientHeight);
+    await expect
+      .poll(async () => await markerViewportOffset(page), { timeout: 10_000 })
+      .toBeLessThan(g.clientHeight / 2);
+    expect(await markerViewportOffset(page)).toBeGreaterThanOrEqual(-5);
+  });
+});

--- a/cicchetto/e2e/tests/issue2035-topic-editor-height.spec.ts
+++ b/cicchetto/e2e/tests/issue2035-topic-editor-height.spec.ts
@@ -1,0 +1,234 @@
+// issue 2035 — the topic edit box opens EIGHT text lines tall, and Enter sets
+// the topic instead of inserting a line break.
+//
+// Both halves of the issue, and both need a real engine for a different
+// reason:
+//
+//   (1) HEIGHT is geometry. jsdom has no layout engine, so vitest can only
+//       pin the `rows={8}` ATTRIBUTE (it does — TopicBar.test.tsx); whether
+//       eight LINES of text actually fit in the rendered box is a question
+//       only a browser answers. It is also the exact question the issue got
+//       wrong on paper: the old `min-height: 4.5em` was read as 4.5 / 1.25 =
+//       3.6 lines, but `* { box-sizing: border-box }` makes that figure
+//       include the padding and the border, so it rendered 3.0 — "solo tre
+//       righe", as reported — and the `10em` the issue derived for "8 lines"
+//       would have rendered 7.4 the same way. This spec measures the box
+//       instead of trusting arithmetic: content height ÷ computed
+//       line-height, which is drift-proof against both properties moving.
+//
+//   (2) ENTER's key handling is unit-covered (the preventDefault and the
+//       Shift+Enter pairing are jsdom's, per #974's every-Enter-sends rule),
+//       but what reaches the WIRE is not. Here an in-channel peer witnesses
+//       the real `TOPIC #chan :<flattened>`, which proves in one action both
+//       that Enter went through the send door and that the flatten SURVIVED
+//       the reversal: the draft is seeded via `fill()` — the paste-shaped
+//       route newlines still take now that Enter no longer types one — and a
+//       body with a raw \r/\n is rejected upstream (:invalid_line), so an
+//       unflattened submit never resolves the witness.
+//
+// The Enter behaviour REVERSES #263's documented decision ("Enter in the
+// textarea must stay a newline"). It is reversed because the product owner
+// ruled the asserted behaviour wrong, not because it was awkward to test —
+// and the premise was weak anyway, since the flatten spends the newline
+// before the send door regardless.
+//
+// 🔴 What this spec must NOT do: grow an Escape case. #232 makes the shared
+// overlay stack the single Esc authority and `issue263-topic-modal-edit.spec
+// .ts:114-124` already proves the edit-aware branch in a real browser with
+// the textarea focused. vjt confirmed Esc works (2026-09-10); that spec stays
+// untouched.
+//
+// Channel: a fresh per-run one, founded by vjt so he is chanop and the ✏️ is
+// offered past the default +t — the same reason `issue263-topic-modal-edit`
+// does it, and the same reason it does not mutate the shared autojoin
+// channel's topic (seed-expansion cascade hazard). PARTed in `finally`.
+//
+// Parity matrix per `feedback_e2e_user_class_parity_matrix`: a CSS layout
+// contract plus a topic send both users take through the same door —
+// registered vjt suffices, no visitor twin.
+
+import type { Locator, Page } from "@playwright/test";
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+// The decided line count (vjt, 2026-09-10: "8 o 10", low end taken for the
+// phone viewport). It is the SAME number `rows={8}` carries in TopicBar.tsx —
+// stated once here so a future re-ruling has one place to move on this side.
+// NOT a #1646 mirror and deliberately not in that table: a mirror is a
+// production INPUT hand-copied into a fixture, where drift goes silently
+// green. This is the spec's ORACLE — production moving to ten turns this red,
+// which is the whole point of writing it down.
+const WANTED_TEXT_LINES = 8;
+
+type EditorGeometry = {
+  rows: number;
+  fontSizePx: number;
+  lineHeightPx: number;
+  paddingTopPx: number;
+  paddingBottomPx: number;
+  borderTopPx: number;
+  borderBottomPx: number;
+  // clientHeight excludes the border and INCLUDES the padding — the content
+  // box is what the text actually gets, and it is what "eight lines" is
+  // about. Subtracting them here is the whole correction the issue needed.
+  clientHeightPx: number;
+  contentHeightPx: number;
+  textLines: number;
+};
+
+async function measureEditor(editor: Locator): Promise<EditorGeometry> {
+  return await editor.evaluate((el) => {
+    const ta = el as HTMLTextAreaElement;
+    const cs = getComputedStyle(ta);
+    const num = (v: string): number => Math.round(Number.parseFloat(v) * 100) / 100;
+    const paddingTopPx = num(cs.paddingTop);
+    const paddingBottomPx = num(cs.paddingBottom);
+    const lineHeightPx = num(cs.lineHeight);
+    const contentHeightPx =
+      Math.round((ta.clientHeight - paddingTopPx - paddingBottomPx) * 100) / 100;
+    return {
+      rows: ta.rows,
+      fontSizePx: num(cs.fontSize),
+      lineHeightPx,
+      paddingTopPx,
+      paddingBottomPx,
+      borderTopPx: num(cs.borderTopWidth),
+      borderBottomPx: num(cs.borderBottomWidth),
+      clientHeightPx: ta.clientHeight,
+      contentHeightPx,
+      textLines: Math.round((contentHeightPx / lineHeightPx) * 100) / 100,
+    };
+  });
+}
+
+// Found a fresh channel, select it, and open the modal in EDIT mode. Returns
+// the editor locator. The retry absorbs the members/modes seed race (the op
+// sigil is not cached the instant the JOIN lands, so the ✏️ is not yet
+// rendered) — same shape as issue263-topic-modal-edit.
+async function openEditor(page: Page, channel: string): Promise<Locator> {
+  await composeSend(page, `/join ${channel}`);
+  await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toBeVisible({ timeout: 10_000 });
+  await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
+
+  const strip = page.locator('[data-testid="topic-strip"]');
+  const modal = page.locator(".topic-modal");
+  const editToggle = page.locator('[data-testid="topic-modal-edit"]');
+
+  await expect(async () => {
+    if (!(await modal.isVisible().catch(() => false))) {
+      await strip.click();
+    }
+    await expect(modal).toBeVisible({ timeout: 1_000 });
+    await expect(editToggle).toBeVisible({ timeout: 1_000 });
+  }).toPass({ timeout: 20_000 });
+
+  await editToggle.click();
+  const editor = page.locator('[data-testid="topic-modal-editor"]');
+  await expect(editor).toBeVisible();
+  return editor;
+}
+
+test.describe("issue 2035 topic editor: eight lines, Enter sets", () => {
+  test("the editor opens eight text lines tall, and Enter sends the flattened topic upstream", async ({
+    page,
+  }, testInfo) => {
+    const vjt = specUser();
+    const channel = `#e2e2035-${crypto.randomUUID().slice(0, 8)}`;
+    const line1 = `enter sets ${crypto.randomUUID().slice(0, 6)}`;
+    const multiline = `${line1}\nsecond line`;
+    const flattened = `${line1} second line`;
+
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+
+    const peer = await IrcPeer.connect({ nick: `e2e2035-${crypto.randomUUID().slice(0, 4)}` });
+    try {
+      const editor = await openEditor(page, channel);
+      await peer.join(channel);
+
+      // (1) HEIGHT — measured, not asserted from the stylesheet.
+      const geometry = await measureEditor(editor);
+      console.log(`[issue2035 desktop] ${JSON.stringify(geometry)}`);
+      await testInfo.attach("issue2035-editor-geometry-desktop", {
+        body: JSON.stringify(geometry, null, 2),
+        contentType: "application/json",
+      });
+      expect(geometry.rows, JSON.stringify(geometry)).toBe(WANTED_TEXT_LINES);
+      // Eight, not "at least eight": the low end of vjt's 8-or-10 was picked
+      // deliberately for the phone, so a silent drift UP is as wrong as down.
+      expect(geometry.textLines, JSON.stringify(geometry)).toBeGreaterThan(WANTED_TEXT_LINES - 0.1);
+      expect(geometry.textLines, JSON.stringify(geometry)).toBeLessThan(WANTED_TEXT_LINES + 0.1);
+
+      // (2) ENTER — `fill` seeds the newline the way a PASTE does (Enter no
+      // longer types one); `locator.press` focuses the box itself before the
+      // key, so the send door under test is the editor's own keydown and
+      // nothing else. The peer witness resolves ONLY on the flattened line.
+      await editor.fill(multiline);
+      const witnessed = peer.waitForTopic(channel, flattened);
+      await editor.press("Enter");
+      await witnessed;
+
+      // Enter took the same door ✅ takes, so it inherits the #263
+      // save-closes contract and the no-optimistic-write rule: the bar
+      // repaints only from the server's relayed topic_changed.
+      await expect(page.locator(".topic-modal")).toHaveCount(0, { timeout: 10_000 });
+      await expect(page.locator(".topic-bar-topic")).toContainText(flattened, { timeout: 10_000 });
+    } finally {
+      await peer.disconnect("e2e2035 done");
+      await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
+    }
+  });
+
+  // The mobile-fit measurement the issue explicitly did NOT make ("no
+  // measurement of how the taller box lays out on any real viewport"). The
+  // failure it guards is the operator-visible one: a modal that is
+  // `position: fixed; top: 4rem` with no max-height and no scroller can push
+  // its own ✅ off the bottom of a phone, and the taller editor is the thing
+  // that would do it. @webkit is the reporter's platform family; @touch is
+  // the orthogonal Blink-mobile opt-in per the config's tag rules.
+  //
+  // 🔴 What this does NOT measure: the SOFT KEYBOARD. Focusing the editor on
+  // a real phone shrinks the visual viewport by roughly half, and Playwright
+  // raises no keyboard — so this proves the layout viewport fits, which is
+  // strictly weaker than "reachable while typing".
+  test("@webkit @touch on a phone viewport the modal — ✅ included — stays on screen", async ({
+    page,
+  }, testInfo) => {
+    const vjt = specUser();
+    const channel = `#e2e2035m-${crypto.randomUUID().slice(0, 8)}`;
+
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+
+    try {
+      const editor = await openEditor(page, channel);
+      const geometry = await measureEditor(editor);
+
+      const fit = await page.locator(".topic-modal").evaluate((modal) => {
+        const box = modal.getBoundingClientRect();
+        const round = (n: number): number => Math.round(n * 10) / 10;
+        return {
+          viewportHeight: window.innerHeight,
+          modalTop: round(box.top),
+          modalBottom: round(box.bottom),
+          modalHeight: round(box.height),
+          slackBelow: round(window.innerHeight - box.bottom),
+        };
+      });
+      console.log(`[issue2035 phone] ${JSON.stringify({ ...geometry, ...fit })}`);
+      await testInfo.attach("issue2035-modal-fit-phone", {
+        body: JSON.stringify({ ...geometry, ...fit }, null, 2),
+        contentType: "application/json",
+      });
+
+      expect(geometry.textLines, JSON.stringify(geometry)).toBeGreaterThan(WANTED_TEXT_LINES - 0.2);
+      expect(fit.modalBottom, JSON.stringify(fit)).toBeLessThanOrEqual(fit.viewportHeight);
+      await expect(page.locator('[data-testid="topic-modal-save"]')).toBeInViewport();
+    } finally {
+      await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
+    }
+  });
+});

--- a/cicchetto/e2e/tests/issue2035-topic-editor-height.spec.ts
+++ b/cicchetto/e2e/tests/issue2035-topic-editor-height.spec.ts
@@ -17,7 +17,8 @@
 //       line-height, which is drift-proof against both properties moving.
 //
 //   (2) ENTER's key handling is unit-covered (the preventDefault and the
-//       Shift+Enter pairing are jsdom's, per #974's every-Enter-sends rule),
+//       Shift+Enter pairing are jsdom's — the chord is RULED, vjt 2026-09-10,
+//       and agrees with #974's every-Enter-sends rule one surface over),
 //       but what reaches the WIRE is not. Here an in-channel peer witnesses
 //       the real `TOPIC #chan :<flattened>`, which proves in one action both
 //       that Enter went through the send door and that the flatten SURVIVED
@@ -71,10 +72,16 @@ type EditorGeometry = {
   paddingBottomPx: number;
   borderTopPx: number;
   borderBottomPx: number;
-  // clientHeight excludes the border and INCLUDES the padding — the content
-  // box is what the text actually gets, and it is what "eight lines" is
-  // about. Subtracting them here is the whole correction the issue needed.
+  // The BORDER box, fractional. `clientHeight` was the obvious reader and is
+  // the wrong one: it is an INTEGER, so it rounded 148.4 to 148 and reported
+  // 7.98 lines for a box that holds exactly eight — a measurement artefact
+  // arriving as a near miss, which is the one shape a height pin must not
+  // have. `getBoundingClientRect` keeps the subpixels.
+  borderBoxHeightPx: number;
   clientHeightPx: number;
+  // What the TEXT gets: border box less padding less border. Doing that
+  // subtraction is the whole correction the issue needed, since
+  // `* { box-sizing: border-box }` means neither is free.
   contentHeightPx: number;
   textLines: number;
 };
@@ -83,23 +90,29 @@ async function measureEditor(editor: Locator): Promise<EditorGeometry> {
   return await editor.evaluate((el) => {
     const ta = el as HTMLTextAreaElement;
     const cs = getComputedStyle(ta);
-    const num = (v: string): number => Math.round(Number.parseFloat(v) * 100) / 100;
+    const round = (n: number): number => Math.round(n * 100) / 100;
+    const num = (v: string): number => round(Number.parseFloat(v));
     const paddingTopPx = num(cs.paddingTop);
     const paddingBottomPx = num(cs.paddingBottom);
+    const borderTopPx = num(cs.borderTopWidth);
+    const borderBottomPx = num(cs.borderBottomWidth);
     const lineHeightPx = num(cs.lineHeight);
-    const contentHeightPx =
-      Math.round((ta.clientHeight - paddingTopPx - paddingBottomPx) * 100) / 100;
+    const borderBoxHeightPx = round(ta.getBoundingClientRect().height);
+    const contentHeightPx = round(
+      borderBoxHeightPx - paddingTopPx - paddingBottomPx - borderTopPx - borderBottomPx,
+    );
     return {
       rows: ta.rows,
       fontSizePx: num(cs.fontSize),
       lineHeightPx,
       paddingTopPx,
       paddingBottomPx,
-      borderTopPx: num(cs.borderTopWidth),
-      borderBottomPx: num(cs.borderBottomWidth),
+      borderTopPx,
+      borderBottomPx,
+      borderBoxHeightPx,
       clientHeightPx: ta.clientHeight,
       contentHeightPx,
-      textLines: Math.round((contentHeightPx / lineHeightPx) * 100) / 100,
+      textLines: round(contentHeightPx / lineHeightPx),
     };
   });
 }

--- a/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
+++ b/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
@@ -17,10 +17,15 @@
 // re-anchor already uses (ScrollbackPane onMount, ~:1495):
 //   * atBottom() true  → follow-live reader → keep "tail-only" (#46 resume
 //     family). Guarded by the third test below (must NOT regress).
-//   * atBottom() false → the reader deliberately left the tail → land on the
-//     re-latched unread divider if one renders, else preserve their scrollTop.
-//     NEVER tail-snap (owner ruling 2026-07-29: the only legitimate jump to the
-//     bottom is the operator's own send in the active window).
+//   * atBottom() false → the reader deliberately left the tail → preserve their
+//     scrollTop. NEVER tail-snap (owner ruling 2026-07-29: the only legitimate
+//     jump to the bottom is the operator's own send in the active window).
+//
+// ⚠️ AMENDED by issue 2032. #535 shipped that second arm as "land on the
+// re-latched unread divider if one renders, else preserve" — the divider half
+// was a defect (it moves a reader who asked for nothing) and has been removed
+// along with the re-latch that fed it. The mode is now `preserve-only`. The
+// second test below was rewritten accordingly; the other three are unchanged.
 //
 // This is the "resume ≠ switch" family, one-shot, no latch — the marker branch
 // stays scoped by the explicit `atBottom()` condition, so #168's collapse of
@@ -184,7 +189,18 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(0);
   });
 
-  test("scrolled-up reader, unread divider present: return lands ON the divider, never tail-snaps", async ({
+  // ⚠️ REWRITTEN by issue 2032. This case used to assert "return lands ON the
+  // divider" — i.e. it PINNED the defect 2032 reports. #535 put
+  // `marker-or-preserve` in the divider query on the reading that a re-latched
+  // divider always sits at the reader's own position, so landing on it WAS
+  // landing where they were; the hide-edge cursor write is forward-only (#233),
+  // so that does not hold for a reader parked above the live cursor. The mode is
+  // now `preserve-only` and the contract below is the one 2032 settled: a
+  // visibility-return preserves, divider or no divider. The divider landing that
+  // used to be asserted here belongs to DELIBERATE activation only — see
+  // issue2032-visibility-return-preserve-position.spec.ts and
+  // scroll-on-window-switch.spec.ts.
+  test("scrolled-up reader, unread divider present: return preserves scrollTop, never jumps to the divider", async ({
     page,
   }) => {
     const vjt = specUser();
@@ -215,30 +231,29 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     expect(g.scrollHeight).toBeGreaterThan(g.clientHeight);
     await wheelBy(page, -400);
     await expect.poll(async () => await distanceFromBottom(page)).toBeGreaterThan(200);
+    const before = await scrollbackGeometry(page);
 
     // Leave the app and come back.
     await setTabHidden(page, true);
     await setTabHidden(page, false);
     await page.waitForTimeout(700);
 
-    // Contract: return lands the reader ON the re-latched unread divider —
-    // "the messages still to be read" — NOT at the tail. The marker is
-    // on-screen in the upper region (block:"start"); distance-to-bottom is
-    // ABOVE threshold. RED pre-fix: the tail snap pushed the divider off the
-    // top and distance collapsed to <= threshold.
+    // Contract (issue 2032): the reader is exactly where they were. A divider
+    // renders — that is the whole point of this case — and it must NOT be a
+    // scroll anchor on a resume. RED against the #535 code, which
+    // `scrollIntoView`d the divider and moved the reader off their position.
+    //
+    // Raw pixels against a sub-pixel epsilon, NOT SCROLL_BOTTOM_THRESHOLD_PX:
+    // that constant is a 50px product band for classifying follow INTENT, and
+    // reusing it as a tolerance would let a sub-band jump pass.
+    const after = await scrollbackGeometry(page);
+    expect(Math.abs(after.scrollTop - before.scrollTop)).toBeLessThanOrEqual(2);
+
+    // Still a divider, still above the reader, still not at the tail.
     await expect(marker).toHaveCount(1);
-    await expect(marker).toBeInViewport();
     await expect
       .poll(async () => await distanceFromBottom(page))
       .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
-    const markerOffset = await page.evaluate(() => {
-      const el = document.querySelector('[data-testid="scrollback"]') as HTMLElement | null;
-      const m = document.querySelector('[data-testid="unread-marker"]') as HTMLElement | null;
-      if (!el || !m) throw new Error("scrollback/marker not found");
-      return m.getBoundingClientRect().top - el.getBoundingClientRect().top;
-    });
-    expect(markerOffset).toBeGreaterThanOrEqual(-5);
-    expect(markerOffset).toBeLessThan(g.clientHeight / 2);
   });
 
   test("follow-live reader (at the tail): return still snaps to the newest row (#46 preserved)", async ({

--- a/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
+++ b/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
@@ -78,6 +78,26 @@ async function distanceFromBottom(page: Page): Promise<number> {
   return g.scrollHeight - g.scrollTop - g.clientHeight;
 }
 
+// `page.mouse.wheel` DISPATCHES the gesture and returns; it does not wait for
+// the resulting scroll to finish. A `before` snapshot taken while the glide is
+// still running makes any later comparison measure the tail of OUR OWN gesture
+// rather than the product's behaviour — measured: it read a 400px "jump" on a
+// -400 wheel. Wait for scrollTop to stop moving before pinning a baseline.
+async function waitForScrollSettled(page: Page): Promise<void> {
+  let last = Number.NaN;
+  await expect
+    .poll(
+      async () => {
+        const { scrollTop } = await scrollbackGeometry(page);
+        const stable = scrollTop === last;
+        last = scrollTop;
+        return stable;
+      },
+      { timeout: 5_000, intervals: [100] },
+    )
+    .toBe(true);
+}
+
 // A REAL Chromium wheel gesture over the scrollback — the ONLY way to flip
 // `atBottom` false: onScroll gates the false-flip on `st < lastScrollTop`
 // (a genuine upward scroll), and the settle/loadMore paths gate on a real
@@ -231,6 +251,7 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     expect(g.scrollHeight).toBeGreaterThan(g.clientHeight);
     await wheelBy(page, -400);
     await expect.poll(async () => await distanceFromBottom(page)).toBeGreaterThan(200);
+    await waitForScrollSettled(page);
     const before = await scrollbackGeometry(page);
 
     // Leave the app and come back.

--- a/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
+++ b/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
@@ -29,7 +29,6 @@
 // Harness mirrors issue580 (DB-seeded 200-row #spec-wN; tiny 800×300 viewport so
 // the buffer overflows and scroll geometry is measurable).
 
-import type { Page } from "@playwright/test";
 import {
   composeSend,
   loginAs,
@@ -43,6 +42,12 @@ import {
   restoreReadCursorToTail,
   setReadCursorToId,
 } from "../fixtures/grappaApi";
+import {
+  delayedWrites,
+  distanceOf,
+  dumpScrollProbe,
+  installScrollProbe,
+} from "../fixtures/scrollWriteProbe";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -68,114 +73,9 @@ const SAMPLE_WINDOW_MS = 2500;
 // false-RED on a slow run. The defect IS the ~0.5s gap between two writes.
 const SETTLE_GRACE_MS = 300;
 
-// The delayed double-scroll: any container scroll write that lands more than the
-// grace window AFTER the send's first (legitimate) tail-follow write.
-function delayedWrites(writes: readonly WriteEvent[]): WriteEvent[] {
-  if (writes.length === 0) return [];
-  const first = writes[0] as WriteEvent;
-  return writes.filter((w) => w.t - first.t > SETTLE_GRACE_MS);
-}
-
-type Sample = { t: number; top: number; height: number; client: number };
-type WriteEvent = { t: number; kind: string; detail: string; before: number };
-
-// Install an in-page sampler + a scroll-write spy on the scrollback container,
-// BEFORE the send. The sampler records the geometry on every native `scroll`
-// event AND on a rAF tick (to catch a programmatic write that lands between
-// scroll events), for SAMPLE_WINDOW_MS. The spy wraps `scrollIntoView` + the
-// `scrollTop` setter (page-context only — no production behaviour changes).
-async function installScrollProbe(page: Page, windowMs: number): Promise<void> {
-  await page.evaluate((windowMsArg) => {
-    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
-    if (!el) throw new Error("scrollback container not found for probe");
-    type Sample = { t: number; top: number; height: number; client: number };
-    type WriteEvent = { t: number; kind: string; detail: string; before: number };
-    const w = window as unknown as { __i625samples: Sample[]; __i625writes: WriteEvent[] };
-    w.__i625samples = [];
-    w.__i625writes = [];
-    const t0 = performance.now();
-    const now = () => performance.now() - t0;
-
-    const desc = Object.getOwnPropertyDescriptor(Element.prototype, "scrollTop");
-    const getTop = () => (desc?.get ? (desc.get.call(el) as number) : el.scrollTop);
-
-    if (desc?.get && desc?.set) {
-      Object.defineProperty(el, "scrollTop", {
-        configurable: true,
-        get() {
-          return desc.get?.call(this);
-        },
-        set(v: number) {
-          w.__i625writes.push({
-            t: Math.round(now()),
-            kind: "scrollTop=",
-            detail: String(Math.round(v)),
-            before: Math.round(getTop()),
-          });
-          desc.set?.call(this, v);
-        },
-      });
-    }
-
-    const rawSIV = Element.prototype.scrollIntoView;
-    Element.prototype.scrollIntoView = function (arg?: boolean | ScrollIntoViewOptions) {
-      if (this === el || el.contains(this as Node)) {
-        w.__i625writes.push({
-          t: Math.round(now()),
-          kind: "scrollIntoView",
-          detail: JSON.stringify(arg ?? null),
-          before: Math.round(getTop()),
-        });
-      }
-      return rawSIV.call(this, arg as ScrollIntoViewOptions);
-    };
-
-    const sample = () => {
-      w.__i625samples.push({
-        t: Math.round(now()),
-        top: Math.round(getTop()),
-        height: el.scrollHeight,
-        client: el.clientHeight,
-      });
-    };
-    sample();
-    el.addEventListener("scroll", sample, { passive: true });
-    const loop = () => {
-      sample();
-      if (now() < windowMsArg) requestAnimationFrame(loop);
-    };
-    requestAnimationFrame(loop);
-  }, windowMs);
-}
-
-// On failure this dump is the whole story: `writes` names every container scroll
-// write + its timestamp (the delayed double-scroll shows as a second entry ~0.5s
-// in), `topChanges` is the compressed scrollTop timeline.
-async function dumpEvidence(
-  page: Page,
-  tag: string,
-): Promise<{ samples: Sample[]; writes: WriteEvent[] }> {
-  const samples = await page.evaluate(
-    () => (window as unknown as { __i625samples: Sample[] }).__i625samples,
-  );
-  const writes = await page.evaluate(
-    () => (window as unknown as { __i625writes: WriteEvent[] }).__i625writes,
-  );
-  const dist = (s: Sample) => Math.round(s.height - s.top - s.client);
-  const compact: Array<{ t: number; top: number; d: number }> = [];
-  let prevTop = Number.NaN;
-  for (const s of samples) {
-    if (s.top !== prevTop) {
-      compact.push({ t: s.t, top: s.top, d: dist(s) });
-      prevTop = s.top;
-    }
-  }
-  console.log(`[#625 ${tag}] writes=${JSON.stringify(writes)}`);
-  console.log(`[#625 ${tag}] topChanges=${JSON.stringify(compact)}`);
-  return { samples, writes };
-}
-
-const distOf = (s: Sample) => s.height - s.top - s.client;
+// The sampler + scroll-write spy moved to `fixtures/scrollWriteProbe.ts` when
+// issue 2031 needed the same instrument — one recorder, so the two specs
+// cannot drift into disagreeing about what counts as a write.
 
 test.describe("issue #625 — a single send must not jump the pane up before settling", () => {
   test.use({ viewport: { width: 800, height: 300 } });
@@ -204,7 +104,7 @@ test.describe("issue #625 — a single send must not jump the pane up before set
     await expect(sentLine).toHaveCount(1, { timeout: 10_000 });
     await page.waitForTimeout(SAMPLE_WINDOW_MS + 200);
 
-    const { samples, writes } = await dumpEvidence(page, "at-tail");
+    const { samples, writes } = await dumpScrollProbe(page, "at-tail");
     expect(samples.length).toBeGreaterThan(10);
 
     // #625 CORE — no DELAYED second scroll write. A single send performs ONE
@@ -214,14 +114,14 @@ test.describe("issue #625 — a single send must not jump the pane up before set
       writes.length,
       `expected the send's tail-follow write; writes=${JSON.stringify(writes)}`,
     ).toBeGreaterThanOrEqual(1);
-    const late = delayedWrites(writes);
+    const late = delayedWrites(writes, SETTLE_GRACE_MS);
     expect(
       late,
       `delayed scroll write(s) after the send's tail-follow: ${JSON.stringify(writes)}`,
     ).toEqual([]);
 
     // Visible-symptom guard: following a send, the pane never travels UP.
-    const maxDist = Math.max(...samples.map(distOf));
+    const maxDist = Math.max(...samples.map(distanceOf));
     expect(maxDist).toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
     await expect(sentLine).toBeInViewport();
   });
@@ -261,7 +161,7 @@ test.describe("issue #625 — a single send must not jump the pane up before set
     await expect(sentLine).toHaveCount(1, { timeout: 10_000 });
     await page.waitForTimeout(SAMPLE_WINDOW_MS + 200);
 
-    const { samples, writes } = await dumpEvidence(page, "from-history");
+    const { samples, writes } = await dumpScrollProbe(page, "from-history");
     expect(samples.length).toBeGreaterThan(10);
 
     // #625 CORE — same invariant as the at-tail case: a single send must not fire
@@ -271,7 +171,7 @@ test.describe("issue #625 — a single send must not jump the pane up before set
       writes.length,
       `expected the send's tail-follow write; writes=${JSON.stringify(writes)}`,
     ).toBeGreaterThanOrEqual(1);
-    const late = delayedWrites(writes);
+    const late = delayedWrites(writes, SETTLE_GRACE_MS);
     expect(
       late,
       `delayed scroll write(s) after the send's tail-follow: ${JSON.stringify(writes)}`,
@@ -279,10 +179,10 @@ test.describe("issue #625 — a single send must not jump the pane up before set
 
     // #608: a send follows the tail unconditionally → the pane reaches the bottom.
     // Once there, it STAYS (a delayed writer would drag it back UP).
-    const firstAtTail = samples.findIndex((s) => distOf(s) <= SCROLL_BOTTOM_THRESHOLD_PX);
+    const firstAtTail = samples.findIndex((s) => distanceOf(s) <= SCROLL_BOTTOM_THRESHOLD_PX);
     expect(firstAtTail).toBeGreaterThanOrEqual(0);
     const afterSettle = samples.slice(firstAtTail);
-    const maxAfterSettle = Math.max(...afterSettle.map(distOf));
+    const maxAfterSettle = Math.max(...afterSettle.map(distanceOf));
     expect(maxAfterSettle).toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
     await expect(sentLine).toBeInViewport();
   });

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -417,6 +417,50 @@ const readMentionGeom = (listRef: HTMLDivElement): ScrollbackLineGeom[] => {
   return out;
 };
 
+// THE tail write, shared by the three appliers that mean "put the pane at the
+// tail": activation's no-marker branch, the settle-wait's tail-follow, and the
+// operator tail. One function because those three were three VERBATIM copies of
+// the same five lines (measured: one md5 once indentation is stripped), so the
+// defect below had to be found three times and fixed three times.
+//
+// Two steps, and both are load-bearing:
+//
+//  1. The native walk. UX-8(a3) chose `lastElementChild.scrollIntoView` over
+//     `scrollTop = scrollHeight` math because the browser scrolls the container
+//     from the element's real box — layout-aware even while scrollHeight
+//     bookkeeping is mid-update (the channel-back path: a cached window whose
+//     scrollback store reload races the key-effect even after rAF×2). It also
+//     walks scrollable ANCESTORS, which the setter does not. Both kept: this is
+//     the step that must NOT be traded away, and trading it away is exactly what
+//     "just use the setter, it reaches the real tail" would have done.
+//
+//  2. #2031 — but that walk aligns the ROW's bottom with the scrollport's bottom
+//     EDGE, and that is not the tail. `.scrollback` carries
+//     `padding: 0.5rem 1rem`, so the scroller's own 8px of bottom padding is
+//     left unscrolled: the row lands FLUSH against the edge with a fraction of a
+//     pixel clipped. Nothing repairs it afterwards, because ~7px is well inside
+//     `SCROLL_BOTTOM_THRESHOLD_PX` and so every "am I at the tail" reader — the
+//     #625 fail-safe included — answers yes and skips its write. Finish the job
+//     against the scroller's own maximum.
+//
+// The maximum is spelled `scrollHeight - clientHeight` rather than leaning on
+// the browser to clamp `scrollTop = scrollHeight`, which is the call #1121
+// already made for `restoreTo`: a number that has to be clamped before it is
+// true cannot be measured against.
+//
+// The top-up only ever scrolls DOWN, and that guard is step 1's insurance rather
+// than generic caution — a stale `scrollHeight` is the precise condition the
+// native walk exists to survive, so writing a stale maximum over a good walk
+// would undo it. `max <= scrollTop` means the read cannot be trusted (or we are
+// already there) and the walk stands. Down-only also keeps `followMode` out of
+// it: the pane leaves the tail only when scrollTop DECREASES (the #168 guard).
+const scrollToTail = (list: HTMLDivElement): void => {
+  const tail = list.lastElementChild as HTMLElement | null;
+  tail?.scrollIntoView?.({ block: "end" });
+  const max = list.scrollHeight - list.clientHeight;
+  if (max > list.scrollTop) list.scrollTop = max;
+};
+
 // Wire-shape source-of-truth: the server's `Grappa.Scrollback.Message.kind()`
 // enum is the canonical producer (lib/grappa/scrollback/message.ex).
 // `MessageKind` mirrors it; this switch must stay exhaustive over the
@@ -2503,13 +2547,14 @@ const ScrollbackPane: Component<Props> = (props) => {
     // skip — the length-effect below catches the bottom-snap on the
     // first non-empty length transition.
     //
-    // UX-8(a3): `lastElementChild?.scrollIntoView` is more reliable than
-    // `scrollTop = scrollHeight` math — the browser walks the element's
-    // box and scrolls its container natively, which is layout-aware even
-    // when scrollHeight bookkeeping is mid-update (channel-back path:
+    // UX-8(a3): the tail write is `scrollToTail`, and the reason it walks the
+    // element's box instead of doing `scrollTop = scrollHeight` math lives with
+    // it — the browser scrolls the container natively, which is layout-aware
+    // even when scrollHeight bookkeeping is mid-update (channel-back path:
     // query → #bofh cached, scrollback store reload races key-effect even
-    // after rAF×2). Fallback scrollHeight write is preserved if scrollback
-    // is empty (no element to scroll into view).
+    // after rAF×2). That property is exactly why #2031 COMPLETED that write
+    // rather than swapping it for the setter, which would have reached the true
+    // tail and lost the walk.
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         // #130 — reveal in EVERY exit path so the pane is never stranded
@@ -2559,12 +2604,7 @@ const ScrollbackPane: Component<Props> = (props) => {
           // append preserves a scrolled-up viewport — guarded by the #535 gap
           // e2e case.)
         } else {
-          const tail = listRef.lastElementChild as HTMLElement | null;
-          if (tail?.scrollIntoView) {
-            tail.scrollIntoView({ block: "end" });
-          } else {
-            listRef.scrollTop = listRef.scrollHeight;
-          }
+          scrollToTail(listRef);
           setFollowMode(true);
           setAtBottomNow(true);
         }
@@ -3177,11 +3217,7 @@ const ScrollbackPane: Component<Props> = (props) => {
         const atTail =
           currScrollHeight - listRef.scrollTop - listRef.clientHeight <= SCROLL_BOTTOM_THRESHOLD_PX;
         if (settled || !atTail) {
-          if (tail?.scrollIntoView) {
-            tail.scrollIntoView({ block: "end" });
-          } else {
-            listRef.scrollTop = listRef.scrollHeight;
-          }
+          scrollToTail(listRef);
         }
         lastTailScrollHeight = listRef.scrollHeight;
         return;
@@ -3265,12 +3301,7 @@ const ScrollbackPane: Component<Props> = (props) => {
         // needed. Re-arm follow + geometry, exactly as the former scrollToBottom()
         // helper did; running SYNC keeps the caller's post-scroll
         // `lastFullyVisibleRowId` read on the pinned tail.
-        const tail = listRef.lastElementChild as HTMLElement | null;
-        if (tail?.scrollIntoView) {
-          tail.scrollIntoView({ block: "end" });
-        } else {
-          listRef.scrollTop = listRef.scrollHeight;
-        }
+        scrollToTail(listRef);
         setFollowMode(true);
         setAtBottomNow(true);
         return;

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -138,8 +138,9 @@ import WhowasCard from "./WhowasCard";
 //
 // FREEZE CONTRACT (2026-06-08): the divider derives from a FROZEN snapshot
 // of the cursor (`markerCursorId`), NOT the live value — it does not move
-// while the operator reads. It re-latches on focus acquisition
-// (channel-switch, visibility-return). The live cursor advances + POSTs to
+// while the operator reads. It re-latches on focus ACQUISITION (channel-switch,
+// cold-mount, own send) — but NOT on a visibility-return, which is a resume
+// (issue 2032). The live cursor advances + POSTs to
 // the server on settle events (scroll-settle, focus-leave, blur, send) via
 // setCursorIfAdvances / setReadCursor; see the markerCursorId signal doc
 // below for the full contract.
@@ -1411,9 +1412,12 @@ const ScrollbackPane: Component<Props> = (props) => {
   // snapshot, NOT the live `getReadCursor`, so a mid-view cursor advance
   // (own scroll-settle echo OR cross-device `read_cursor_set`) does not
   // yank the divider under the operator's eyes while they read. Re-latched
-  // to the live cursor on every focus acquisition — channel-switch (key
-  // effect) and tab/app visibility-return (option b) — so the divider
-  // settles to the new position when the operator steps away and back.
+  // to the live cursor on every focus ACQUISITION — channel-switch (key
+  // effect), cold-mount, and an own send — so the divider settles to the new
+  // position when the operator genuinely changes window. A tab/app
+  // visibility-return does NOT re-latch (issue 2032, reversing the former
+  // "option (b)"): a resume must leave the reader, and the divider they were
+  // reading against, exactly where they were.
   // `null` = not yet latched / no cursor known (cold-load pre-hydration);
   // the cold-latch effect below picks up the first non-null cursor,
   // mirroring the sessionTopId cold-mount latch. The live signal map stays
@@ -2397,9 +2401,9 @@ const ScrollbackPane: Component<Props> = (props) => {
   //      re-opened (the effect below tracks `isDocumentVisible` false→true).
   //      GATED on the follow-state at hide time (#535), no latch: resume ≠
   //      switch (#46). followMode() true → "tail-only" (the reader was following
-  //      live). followMode() false → "marker-or-preserve" (the reader had
-  //      deliberately scrolled up; land on the divider or hold their scrollTop
-  //      — NEVER tail-snap them).
+  //      live). followMode() false → "preserve-only" (the reader had
+  //      deliberately scrolled up; hold their scrollTop — never tail-snap them,
+  //      and since issue 2032 never divider-snap them either).
   //
   // Single source of truth for the DOM read/scroll mechanics: any future
   // activation trigger plugs into `scrollToActivation` and picks its mode.
@@ -2431,22 +2435,28 @@ const ScrollbackPane: Component<Props> = (props) => {
   //     visibility-return. Never the divider; `followMode`/`atBottomNow=true`; no
   //     latch (the length-effect's `followMode` tail-follow already re-establishes
   //     the tail).
-  //   * "marker-or-preserve" — the scrolled-up arm of visibility-return (#535).
-  //     Same marker DOM read as "marker-or-tail", but when NO divider renders it
-  //     PRESERVES the reader's scrollTop instead of tailing. It is safe to skip
-  //     the scroll then: the re-latch (`setMarkerCursorId`) only recomputes
-  //     `rows()` — which resets scrollTop to 0 via the ref-keyed `<For>` — when
-  //     it MOVES the cursor, and a moved cursor still below the tail always
-  //     renders a divider, so "no marker" means the re-latch left scrollTop
-  //     untouched. The sibling `refreshScrollback` (fired one line before this)
-  //     is an ASYNC co-trigger that CAN recompute `rows()` later by appending
-  //     rows missed while hidden, but a TAIL append preserves a scrolled-up
-  //     reader's position (the length-effect's `followMode` gate does nothing +
-  //     browser scroll anchoring holds the viewport) — empirically pinned by the
-  //     #535 "messages missed while hidden" e2e case, not just asserted here. No
-  //     latch (one-shot resume). Owner ruling 2026-07-29 (#535): the only
-  //     legitimate jump-to-bottom is the operator's own send in the active
-  //     window; every other trigger preserves position or lands on the divider.
+  //   * "preserve-only" — the scrolled-up arm of visibility-return (#535, then
+  //     issue 2032). Writes NOTHING: no tail, no divider. It does not read the
+  //     marker node at all, and its sibling arm no longer re-latches
+  //     `markerCursorId`, so `rows()` is not recomputed and the ref-keyed
+  //     `<For>` never recreates the list — scrollTop is untouched by
+  //     construction rather than by luck. The sibling `refreshScrollback` (fired
+  //     one line before this) is an ASYNC co-trigger that CAN recompute `rows()`
+  //     later by appending rows missed while hidden, but a TAIL append preserves
+  //     a scrolled-up reader's position (the length-effect's `followMode` gate
+  //     does nothing + browser scroll anchoring holds the viewport) —
+  //     empirically pinned by the #535 "messages missed while hidden" e2e case,
+  //     not just asserted here. No latch (one-shot resume).
+  //
+  //     ⚠️ This REVERSES the second half of #535 (DESIGN_NOTES 2026-07-30).
+  //     That entry read vjt's ruling — "l'unico caso in cui scrolliamo to bottom
+  //     è quando si scrive un messaggio nella finestra attiva" — as "everything
+  //     else preserves the reader's position OR LANDS ON THE DIVIDER", and put
+  //     this mode in the divider query on that authority. vjt's words constrain
+  //     scroll-to-BOTTOM only; the divider clause was the entry's own gloss, and
+  //     it made the mode's name a lie. issue 2032 is the owner ruling that
+  //     settles it: a visibility-return is a RESUME, and only a DELIBERATE
+  //     window change lands on the divider (#168, 2026-07-03).
   // Post-send / live-append stay at the BOTTOM via the length-effect: the send
   // ARMS `followMode` (#608 STEP 5, clearing the marker latch first) and the
   // applier tail-follows the echo when it mounts. The divider still RENDERS at
@@ -2463,7 +2473,7 @@ const ScrollbackPane: Component<Props> = (props) => {
   // pre-paint, so the intermediate scrollTop=0 is never painted — no hide
   // needed, and toggling `activating` on every rows change would itself flicker.
   const scrollToActivation = (
-    mode: "marker-or-tail" | "tail-only" | "marker-or-preserve",
+    mode: "marker-or-tail" | "tail-only" | "preserve-only",
     withHide: boolean,
   ): void => {
     if (!listRef) return;
@@ -2525,15 +2535,24 @@ const ScrollbackPane: Component<Props> = (props) => {
           if (withHide) setActivating(false);
           return;
         }
-        // #168 regression fix — the channel-SWITCH trigger jumps to the
-        // RENDERED frozen unread divider when one exists; every other trigger
-        // (cold-mount, visibility-return, resize) lands at the tail. Read the
-        // marker's DOM node the `rows()` memo already injected (same
-        // data-testid the render emits) — do NOT recompute the cursor
-        // geometry a second way. Its ABSENCE (fully-read channel, or a cold
-        // switch whose rows haven't landed) naturally falls to the tail.
+        // #168 + issue 2032 — the DELIBERATE activations (channel-SWITCH and
+        // cold-mount, both "marker-or-tail") jump to the RENDERED frozen unread
+        // divider when one exists. Every RESUME does not: "tail-only" (resize,
+        // follow-live return) goes to the tail, "preserve-only" (scrolled-up
+        // return) goes nowhere. Read the marker's DOM node the `rows()` memo
+        // already injected (same data-testid the render emits) — do NOT recompute
+        // the cursor geometry a second way. Its ABSENCE (fully-read channel, or a
+        // cold switch whose rows haven't landed) naturally falls to the tail.
+        //
+        // The comment this replaces asserted the OPPOSITE of the code: it said
+        // "every other trigger (cold-mount, visibility-return, resize) lands at
+        // the tail". Neither clause was true — cold-mount has been a marker
+        // activation since #168's own 2026-07-03b completion, and
+        // visibility-return's scrolled-up arm was IN this query, which is exactly
+        // the defect issue 2032 reported. Routing is what ships; the comment had
+        // been stale for two releases.
         const marker =
-          mode === "marker-or-tail" || mode === "marker-or-preserve"
+          mode === "marker-or-tail"
             ? (listRef.querySelector('[data-testid="unread-marker"]') as HTMLElement | null)
             : null;
         if (marker?.scrollIntoView) {
@@ -2548,16 +2567,27 @@ const ScrollbackPane: Component<Props> = (props) => {
           const near = distance <= SCROLL_BOTTOM_THRESHOLD_PX;
           setFollowMode(near);
           setAtBottomNow(near);
-        } else if (mode === "marker-or-preserve") {
-          // #535 — scrolled-up visibility-return with NO divider to land on
-          // (e.g. a fully-read channel the reader paged up into). The re-latch
-          // left `markerCursorId` — hence this synchronous `rows()`, hence
-          // scrollTop — untouched. PRESERVE the reader's position: do NOT
-          // tail-snap, and leave `followMode`/`atBottomNow` false (they are
-          // still parked above the tail). Nothing to scroll here. (A later async
-          // `refreshScrollback` append can still recompute `rows()`, but a tail
-          // append preserves a scrolled-up viewport — guarded by the #535 gap
-          // e2e case.)
+        } else if (mode === "preserve-only") {
+          // #535 + issue 2032 — the scrolled-up arm of visibility-return.
+          // PRESERVE the reader's position UNCONDITIONALLY: do not tail-snap, do
+          // not jump to a divider, and leave `followMode`/`atBottomNow` false
+          // (they are still parked above the tail). Nothing to scroll here.
+          //
+          // #535 shipped this branch reachable ONLY when no divider rendered, on
+          // the reasoning that the sibling re-latch had by then moved the divider
+          // ONTO the reader's own position, so landing on it WAS landing where
+          // they were. That reasoning holds only while the hide-edge cursor write
+          // reaches the reader's row, and `setCursorIfAdvances` is forward-only
+          // (#233): a reader parked ABOVE the live cursor leaves it untouched, so
+          // the divider sits somewhere else and `scrollIntoView` moves them.
+          // issue 2032 removed BOTH halves — this mode no longer reads the
+          // divider node, and the visibility arm no longer re-latches — so
+          // `rows()` is not recomputed and scrollTop is genuinely untouched
+          // rather than incidentally so.
+          //
+          // A later async `refreshScrollback` append can still recompute `rows()`,
+          // but a tail append preserves a scrolled-up viewport — guarded by the
+          // #535 gap e2e case.
         } else {
           const tail = listRef.lastElementChild as HTMLElement | null;
           if (tail?.scrollIntoView) {
@@ -2570,7 +2600,7 @@ const ScrollbackPane: Component<Props> = (props) => {
         }
         // #981 — every branch above ran INSIDE the rAF×2, i.e. against settled
         // layout: the marker branch read the distance-to-tail, the else branch
-        // placed the pane AT the tail, and `marker-or-preserve` deliberately
+        // placed the pane AT the tail, and `preserve-only` deliberately
         // left the reader where they were (above the tail). All three are
         // answers about THIS window's geometry, so the suppression may act on
         // `atBottomNow` from here on. The early returns above are not: they
@@ -2752,17 +2782,27 @@ const ScrollbackPane: Component<Props> = (props) => {
   // false→true (clearBadgesForWindow); this effect owns the scroll
   // settle AND the freeze-contract bottom-boundary re-latch.
   //
-  // Top/bottom boundaries diverge on visibility-return (deliberate, see
-  // the markerCursorId / sessionTopId doc comments):
+  // Both frozen boundaries are PRESERVED on visibility-return (issue 2032;
+  // see the markerCursorId / sessionTopId doc comments):
   //   * sessionTopId (TOP) is PRESERVED — a brief tab-blur is not
   //     "leaving the window"; messages that arrived while hidden stay
   //     live-read, no fresh marker. (Re-latching it would mis-classify
   //     them.)
-  //   * markerCursorId (BOTTOM) is RE-LATCHED to the live cursor —
-  //     option (b): a step-away-and-back settles the divider to wherever
-  //     the cursor reached while frozen. The re-latch runs BEFORE
-  //     scrollToActivation so the activation scroll sees the updated
-  //     marker state.
+  //   * markerCursorId (BOTTOM) is PRESERVED TOO, since issue 2032. It used
+  //     to be RE-LATCHED to the live cursor here — freeze-contract "option
+  //     (b)", a step-away-and-back settling the divider to wherever the
+  //     cursor reached. Two measured consequences killed it. (1) It
+  //     MATERIALISES a divider that was not on screen before the app switch,
+  //     which the reader never asked for. (2) A re-latch that MOVES the
+  //     cursor recomputes `rows()`, and every row is a fresh object under a
+  //     ref-keyed `<For>`, so the whole list is recreated and scrollTop
+  //     collapses to 0 — a reset the old divider jump happened to paper over
+  //     by scrolling somewhere immediately afterwards. Remove the jump alone
+  //     and the reader lands at the TOP of the buffer, which is worse than
+  //     the bug being fixed. A resume is not a focus acquisition, so the
+  //     honest fix is that neither boundary moves: the divider stays frozen
+  //     exactly where the reader left it. It still re-latches on a deliberate
+  //     switch, on cold-mount and on an own send.
   //
   // `prev === undefined` guards the initial-mount run (signal owns
   // the prev sentinel pattern; mirrors selection.ts's identical guard
@@ -2789,7 +2829,6 @@ const ScrollbackPane: Component<Props> = (props) => {
         // (Shell.tsx `<Match>`), so `props` is always a real /messages
         // channel — no synthetic-window 404.
         void refreshScrollback(props.networkSlug, props.channelName);
-        setMarkerCursorId(getReadCursor(props.networkSlug, props.channelName));
         // #535 — gate the resume scroll on the follow-state that was in effect
         // when the document hid. `followMode()` (#608: the follow INTENT, not
         // the geometric `atBottomNow`) turns false ONLY on a real operator
@@ -2800,14 +2839,16 @@ const ScrollbackPane: Component<Props> = (props) => {
         // marker jump (#168, 2026-07-03).
         //   * followMode() true  → the reader was following live → TAIL (#46).
         //   * followMode() false → the reader deliberately scrolled up mid-backlog
-        //     → land on the re-latched divider if one renders, else PRESERVE
-        //     their scrollTop. NEVER tail-snap them (the pre-#535 bug: the
-        //     unconditional "tail-only" here dropped a mid-backlog reader at the
-        //     tail on every return from an external link).
+        //     → PRESERVE their scrollTop, full stop. NEVER tail-snap them (the
+        //     pre-#535 bug: the unconditional "tail-only" here dropped a
+        //     mid-backlog reader at the tail on every return from an external
+        //     link) and never divider-snap them either (issue 2032: #535's
+        //     replacement traded the tail yank for a divider yank, which is the
+        //     same class of defect pointing the other way).
         if (followMode()) {
           applyActivation("tail-only", true);
         } else {
-          applyActivation("marker-or-preserve", true);
+          applyActivation("preserve-only", true);
         }
       }
     }),
@@ -2886,9 +2927,10 @@ const ScrollbackPane: Component<Props> = (props) => {
   // No false→true arm HERE — the hide edge is this effect's whole job. The
   // return edge is owned by the #887 read-at-the-tail arm below, which reaches
   // the same door under a geometry gate this one does not need. (The DISPLAY
-  // snapshot is re-latched on focus-regain by the sibling activation effect
-  // above — freeze contract option (b) — by re-reading the cursor, not
-  // advancing it; that stays true whichever arm advances it.)
+  // snapshot is NOT re-latched on focus-regain — issue 2032 removed the sibling
+  // activation effect's re-read, so the divider this arm's cursor write feeds
+  // only moves on a genuine focus acquisition. This arm still advances the LIVE
+  // cursor on hide, which is a different axis and unchanged.)
   //
   // `prev === undefined` guards the initial-mount run (mirrors the
   // sibling effect's identical guard).
@@ -3470,23 +3512,22 @@ const ScrollbackPane: Component<Props> = (props) => {
   // resolves precedence and logs the decision. Behaviour-IDENTICAL to the
   // pre-STEP-3 direct calls: `scrollToActivation` already bails on
   // `isOverlayFrozen()` (= overlay-freeze precedence) and still owns the
-  // marker-or-tail / tail-only / marker-or-preserve write mechanics + the #130
+  // marker-or-tail / tail-only / preserve-only write mechanics + the #130
   // flicker hide (`withHide`) + the follow/geometry signals — this only moves the
   // DECISION into the pure `resolveIntent` core, making `scrollToActivation` an
   // applier-internal write routine (reached ONLY here and from
   // `dispatchScrollWrite`'s marker-activation case).
   //
   // The activation kind maps by mode: "tail-only" is the tail-follow intent
-  // (resize resume + the follow-live visibility arm); "marker-or-tail" /
-  // "marker-or-preserve" are marker-activation (jump to the rendered divider, or
-  // tail/preserve when none). The intent is UNCONDITIONAL per mode — NOT gated on
+  // (resize resume + the follow-live visibility arm); "marker-or-tail" and
+  // "preserve-only" are marker-activation. The intent is UNCONDITIONAL per mode — NOT gated on
   // the marker latch — because a direct `scrollToActivation` always ran when not
   // frozen; gating it would be a behaviour change. When overlay-freeze outranks
   // the activation intent we skip the delegate: `scrollToActivation`'s own frozen
   // bail produced the identical no-op, so no activation authority moves a covered
   // pane (the #219 / #219-general freeze), and the decision is now logged.
   const applyActivation = (
-    mode: "marker-or-tail" | "tail-only" | "marker-or-preserve",
+    mode: "marker-or-tail" | "tail-only" | "preserve-only",
     withHide: boolean,
   ): void => {
     if (!listRef) return;
@@ -3496,6 +3537,14 @@ const ScrollbackPane: Component<Props> = (props) => {
       intents.push({ kind: "overlay-freeze", key: k, lifetime: "sticky" });
     }
     intents.push({
+      // issue 2032 — "preserve-only" keeps declaring `marker-activation` even
+      // though it writes nothing. The kind is a PRECEDENCE CLASS, not a
+      // description of the write, and this one must outrank `tail-follow`
+      // (rank 4) or a concurrent tail-follow would snap the resuming reader to
+      // the tail — precisely the #535 defect. `prepend-preserve`, the only
+      // other preserve-shaped kind, sits BELOW tail-follow and would reinstate
+      // it. No new kind was minted: the union + PRECEDENCE array are shared
+      // with the whole applier, so widening them is a separate change.
       kind: mode === "tail-only" ? "tail-follow" : "marker-activation",
       key: k,
       lifetime: "sticky",

--- a/cicchetto/src/TopicBar.tsx
+++ b/cicchetto/src/TopicBar.tsx
@@ -39,7 +39,8 @@ import PaneTopBar, { PaneTopBarRailOpener } from "./PaneTopBar";
 // modal shows a ✏️ toggle. ✏️ swaps the topic text for a multi-line
 // <textarea> + ❌ cancel + ✅ save; the ✏️ disappears. ❌ cancel DISCARDS the
 // draft, reverts to read-only, brings the ✏️ back, and KEEPS the modal open.
-// ✅ save flattens newlines → submits via the EXISTING send doors (postTopic
+// ✅ save — or Enter inside the textarea, issue 2035 — flattens newlines →
+// submits via the EXISTING send doors (postTopic
 // REST for a non-empty set, pushChannelTopicClear WS verb for an empty clear —
 // one-feature-every-door, the same doors the `/topic` slashes use) and CLOSES
 // the modal on success. A server reject surfaces inline (S21 no-false-success)
@@ -54,6 +55,8 @@ import PaneTopBar, { PaneTopBarRailOpener } from "./PaneTopBar";
 // → :invalid_line). The <textarea> is a display/editing affordance only —
 // `flattenTopicNewlines` collapses every newline run to one space on submit
 // BEFORE the send door, so a multi-line edit reaches upstream as one line.
+// Still true after issue 2035 stopped Enter from inserting one: a PASTE
+// carries newlines in, and the flatten is what spends them.
 //
 // UX-4 bucket L (2026-05-19): the settings cog AND the left channel-
 // sidebar hamburger moved out of TopicBar into the cluster-wide
@@ -242,6 +245,35 @@ const TopicBar: Component<Props> = (props) => {
     }
   };
 
+  // issue 2035 — Enter SETS the topic. This REVERSES the #263 decision that
+  // used to be recorded a few lines down ("Enter in the textarea must stay a
+  // newline, save is the ✅ button only"): the product owner ruled the
+  // asserted behaviour wrong. The premise was weak besides — an IRC topic is
+  // ONE wire line, and `flattenTopicNewlines` spends every newline BEFORE the
+  // send door, so the break Enter bought was worth exactly one space and could
+  // never reach the wire as a break.
+  //
+  // EVERY Enter submits, modifier or not — #974, vjt's 2026-08-07 ruling on
+  // `ComposeBox`, the sibling surface with the same one-wire-line domain: a
+  // Shift+Enter that refuses also EATS the keystroke, and on his device the
+  // modifier arms itself on presses he never meant as Shift+Enter, so the send
+  // silently does not happen. Same operator, same chord, same answer here
+  // rather than a second semantics for it.
+  //
+  // 🔴 Escape is NOT handled here and must never be: #232 makes the shared
+  // overlay stack the SINGLE Esc authority (it deleted every per-dialog
+  // handler), and this modal's edit-aware close verb already lives on it —
+  // see `createOverlayLock` below. An element-level keydown for Enter is
+  // allowed to exist; one that grows an Escape branch is a second authority.
+  //
+  // `preventDefault` is what stops the textarea inserting its own break; the
+  // flatten STAYS regardless, because a PASTE still carries newlines in.
+  const onEditorKeyDown = (e: KeyboardEvent): void => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    void submitEdit();
+  };
+
   // #71 INC-2 — the per-channel presence-filter toggle (👁/🙈, #222) MOVED OUT
   // of the topic bar into the right-rail RailActions drawer (channel-gated). Q2
   // ruling: "one design" wants that toggle in the rail drawer on both form
@@ -264,10 +296,9 @@ const TopicBar: Component<Props> = (props) => {
   // `cancelEdit` (revert the draft, stay open, ✏️ back — the #263 cancel
   // contract), NOT `closeModal`. A naive `closeModal` here would tear down the
   // draft, violating #263. In read-only, Esc runs `closeModal` (the same verb
-  // the × / backdrop use). No element-level keydown on the textarea — the
-  // shared stack is the single ESC authority (#232 deleted all per-dialog
-  // handlers), and Enter in the textarea must stay a newline (save is the ✅
-  // button only), the flatten collapses it on submit.
+  // the × / backdrop use). The textarea's own keydown (issue 2035, above)
+  // handles Enter and NOTHING else — this stack remains the single ESC
+  // authority (#232 deleted all per-dialog handlers).
   createOverlayLock(
     () => modalState() === "open",
     ".topic-modal",
@@ -446,21 +477,28 @@ const TopicBar: Component<Props> = (props) => {
               }
             >
               {/* #263 — multi-line editor. IRC topics are one wire line, so
-                  newlines are flattened on submit (see submitEdit). NO
-                  Enter-to-submit: Enter inserts a newline; ✅ is the only save.
-                  NO element-level Esc handler — the shared #232 overlay stack
+                  newlines are flattened on submit (see submitEdit); a paste is
+                  the route they still arrive by. Enter SETS the topic (issue
+                  2035 — see onEditorKeyDown), ✅ is the other door. NO
+                  element-level Esc handler — the shared #232 overlay stack
                   owns Esc (edit-aware onEscape → cancelEdit). Seeded with the
-                  raw topic. */}
+                  raw topic.
+                  `rows` is the height knob (issue 2035): the platform's own
+                  "how many text lines", which tracks font-size + line-height
+                  by itself. See `.topic-modal-editor` for the min-height it
+                  replaced and the arithmetic that one got wrong. */}
               <textarea
                 class="topic-modal-editor"
                 data-testid="topic-modal-editor"
                 aria-label="edit topic"
                 placeholder="Set a topic…"
+                rows={8}
                 value={draft()}
                 ref={(el) => {
                   editorRef = el;
                 }}
                 onInput={(e) => setDraft(e.currentTarget.value)}
+                onKeyDown={onEditorKeyDown}
               />
               {/* #263 — inline submit-error surface (S21 no-false-success). */}
               <Show when={editError()}>

--- a/cicchetto/src/TopicBar.tsx
+++ b/cicchetto/src/TopicBar.tsx
@@ -253,12 +253,18 @@ const TopicBar: Component<Props> = (props) => {
   // send door, so the break Enter bought was worth exactly one space and could
   // never reach the wire as a break.
   //
-  // EVERY Enter submits, modifier or not — #974, vjt's 2026-08-07 ruling on
-  // `ComposeBox`, the sibling surface with the same one-wire-line domain: a
-  // Shift+Enter that refuses also EATS the keystroke, and on his device the
-  // modifier arms itself on presses he never meant as Shift+Enter, so the send
-  // silently does not happen. Same operator, same chord, same answer here
-  // rather than a second semantics for it.
+  // EVERY Enter submits, modifier or not. The issue left Shift+Enter
+  // explicitly unruled; vjt then ruled it FOR THIS SURFACE — "anche
+  // shift-invio setta il topic" (2026-09-10, his words on #grappa, relayed
+  // in session; not observed on IRC by the author of this line).
+  //
+  // It agrees with #974, which is why the code predates the ruling rather
+  // than waiting on it: that is vjt's 2026-08-07 ruling on `ComposeBox`, the
+  // sibling surface with the same one-wire-line domain, reversing his own
+  // day-old split because a Shift+Enter that refuses also EATS the keystroke,
+  // and on his device the modifier arms itself on presses he never meant as
+  // Shift+Enter — so the send silently does not happen. One chord, one
+  // semantics, across both surfaces.
   //
   // 🔴 Escape is NOT handled here and must never be: #232 makes the shared
   // overlay stack the SINGLE Esc authority (it deleted every per-dialog

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -2545,6 +2545,83 @@ describe("ScrollbackPane", () => {
     });
   });
 
+  // #2031 — the tail write's SECOND step, which has no other coverage anywhere.
+  //
+  // `scrollIntoView({block:"end"})` aligns the tail ROW's bottom with the
+  // scrollport's bottom EDGE and leaves the scroller's own `padding-bottom`
+  // unscrolled, so the pane stops ~7px short of its tail and the just-sent row
+  // sits flush against the edge with a fraction of a pixel clipped. The cure
+  // finishes the write against `scrollHeight - clientHeight`.
+  //
+  // Why this belongs in jsdom and not only in the e2e: the e2e measures the
+  // OUTCOME in a real layout, but it cannot construct the one input that makes
+  // the down-only guard matter — a `scrollHeight` read that is STALE, which is
+  // the UX-8(a3) condition the native walk exists to survive. Here that input is
+  // just a `defineProperty`. Without these two, the guard is an untested branch.
+  //
+  // The whole jsdom suite is otherwise blind to the top-up: `scrollHeight` and
+  // `clientHeight` both default to 0, so `max` is 0 and the write never fires
+  // unless a test defines geometry BEFORE the tail write — measured, which is
+  // why the W6 loadMore-preserve block above (which defines its geometry after
+  // `render`) is untouched by this change.
+  describe("#2031 — the tail write finishes at the scroller's own maximum", () => {
+    let origScrollIntoView: typeof Element.prototype.scrollIntoView;
+    beforeEach(() => {
+      // jsdom has no `scrollIntoView`. Stub it to a NO-OP so the assertion below
+      // measures the top-up alone: in a real engine the walk would already have
+      // moved the pane most of the way, and what is under test is the remainder.
+      origScrollIntoView = Element.prototype.scrollIntoView;
+      Element.prototype.scrollIntoView = vi.fn();
+    });
+    afterEach(() => {
+      Element.prototype.scrollIntoView = origScrollIntoView;
+    });
+
+    const geometry = (list: HTMLDivElement, scrollHeight: number, scrollTop: number): void => {
+      Object.defineProperty(list, "scrollHeight", { value: scrollHeight, configurable: true });
+      Object.defineProperty(list, "clientHeight", { value: 300, configurable: true });
+      Object.defineProperty(list, "scrollTop", {
+        value: scrollTop,
+        writable: true,
+        configurable: true,
+      });
+    };
+
+    it("tops the pane up to scrollHeight - clientHeight, not to the tail row's edge", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      await waitFor(() => expect(screen.getAllByTestId("scrollback-line")).toHaveLength(3));
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+      // A pane parked above the tail, with a real extent. 1000 - 300 = 700.
+      geometry(list, 1000, 120);
+
+      // The operator tail — the same `scrollToBottomGesture` the floating button
+      // invokes, and the shortest path to the shared write.
+      requestScrollToBottom();
+      await Promise.resolve();
+
+      expect(list.scrollTop).toBe(700);
+    });
+
+    it("never scrolls UP: a stale, too-small maximum leaves the native walk's position alone", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      await waitFor(() => expect(screen.getAllByTestId("scrollback-line")).toHaveLength(3));
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+      // The UX-8(a3) shape: `scrollHeight` reads SMALLER than where the pane
+      // actually is, because the bookkeeping is mid-update. max = 700 < 900.
+      // Writing that maximum would drag the reader 200px back UP and undo the
+      // very walk the first step performed — and, since the pane leaves the tail
+      // only when scrollTop DECREASES (#168), it would also drop followMode.
+      geometry(list, 1000, 900);
+
+      requestScrollToBottom();
+      await Promise.resolve();
+
+      expect(list.scrollTop).toBe(900);
+    });
+  });
+
   // #608 STEP 6 (RED-GREEN behaviour change) — the tail-follow write waits for a
   // MEASURED settle (isSettled: the appended content's extent has GROWN vs the
   // last tail AND the new tail row has a laid-out box) before scrolling, instead
@@ -5074,7 +5151,15 @@ describe("ScrollbackPane", () => {
       // queueMicrotask delays the DOM read+write; wait for it to flush.
       await new Promise((r) => queueMicrotask(() => r(undefined)));
 
-      // No marker → routine takes the scrollTop branch, not scrollIntoView.
+      // No marker → the routine's tail path, which since #2031 is the shared
+      // `scrollToTail` and no longer an inline `scrollTop = scrollHeight` branch.
+      //
+      // ⚠️ What this assertion actually pins is WEAKER than the title says, and
+      // it pre-dates #2031: `scrollToActivation` defers into rAF×2 while this
+      // waits ONE microtask, so a green here means "nothing has been written
+      // YET" rather than "the tail path was taken instead of the marker's".
+      // Named rather than rewritten — correcting it is a change to what this
+      // test measures, and it does not ride in on #2031's back.
       expect(scrollIntoViewSpy).not.toHaveBeenCalled();
       // atBottom branch sets atBottom=true → scroll-to-bottom button hidden.
       expect(screen.queryByTestId("scroll-to-bottom")).toBeNull();

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -3281,7 +3281,7 @@ describe("ScrollbackPane", () => {
     // `applyReadCursorSet` boundary (same wire bytes), so the freeze is
     // uniform: cross-device reads reflect on the next refocus, not
     // mid-stare. Accepted tradeoff (vjt: "consistency").
-    it("Bug A (revised): bare cursor advance keeps the marker frozen; refocus releases it", async () => {
+    it("Bug A (revised): bare cursor advance keeps the marker frozen; so does a visibility-return; an own send releases it", async () => {
       const { applyReadCursorSet } = await import("../lib/readCursor");
       const proto = fixture[0];
       if (!proto) throw new Error("fixture[0] missing");
@@ -3304,11 +3304,24 @@ describe("ScrollbackPane", () => {
       // FROZEN: marker unchanged despite the live cursor reaching sessionTopId.
       expect(screen.getByTestId("unread-marker")).toHaveTextContent("4 unread");
 
-      // Refocus (tab/app visibility-return) re-latches the marker baseline
-      // to the live cursor → cursor caught up to sessionTopId → marker gone.
+      // issue 2032 — a tab/app visibility-return is a RESUME, not a focus
+      // acquisition, so it does NOT re-latch: the divider still reads its
+      // frozen count after a full hide→show cycle.
+      //
+      // This block used to assert the divider VANISHED here (freeze-contract
+      // "option (b)"). That is the behaviour 2032 reversed: re-latching
+      // materialises a divider move the reader never asked for, and the
+      // `rows()` recompute it triggers recreates the ref-keyed `<For>` list,
+      // collapsing their scrollTop to 0.
       setDocVisible(false);
       await new Promise((r) => queueMicrotask(() => r(undefined)));
       setDocVisible(true);
+      await new Promise((r) => queueMicrotask(() => r(undefined)));
+      expect(screen.getByTestId("unread-marker")).toHaveTextContent("4 unread");
+
+      // An own send IS an explicit caught-up acquisition and still releases it
+      // (the live cursor already reached sessionTopId above).
+      pushOwnSend("freenode #grappa");
       await waitFor(() => {
         expect(screen.queryByTestId("unread-marker")).toBeNull();
       });
@@ -3337,7 +3350,12 @@ describe("ScrollbackPane", () => {
       expect(screen.getByTestId("unread-marker")).toHaveTextContent("4 unread");
     });
 
-    it("marker re-latches to the advanced cursor on visibility-return (option b)", async () => {
+    // issue 2032 — the INVERSE of what this case used to pin. It was
+    // "marker re-latches to the advanced cursor on visibility-return (option
+    // b)"; the owner ruling on 2032 made a visibility-return a RESUME, so the
+    // frozen divider must survive it untouched. A deliberate switch, a
+    // cold-mount and an own send still re-latch — covered by their own cases.
+    it("marker does NOT re-latch on visibility-return — a resume is not a focus acquisition", async () => {
       const { applyReadCursorSet } = await import("../lib/readCursor");
       const proto = fixture[0];
       if (!proto) throw new Error("fixture[0] missing");
@@ -3358,14 +3376,15 @@ describe("ScrollbackPane", () => {
       await new Promise((r) => queueMicrotask(() => r(undefined)));
       expect(screen.getByTestId("unread-marker")).toHaveTextContent("4 unread");
 
-      // Step away + back: divider re-latches to the live cursor (62) → only
-      // id 63 remains in (62, 63] → "1 unread".
+      // Step away + back. Pre-2032 the divider re-latched to the live cursor
+      // (62) and collapsed to "1 unread" — moving under a reader who only
+      // stepped away. It must now hold at "4 unread": same rows, same frozen
+      // boundary, nothing moved.
       setDocVisible(false);
       await new Promise((r) => queueMicrotask(() => r(undefined)));
       setDocVisible(true);
-      await waitFor(() => {
-        expect(screen.getByTestId("unread-marker")).toHaveTextContent("1 unread");
-      });
+      await new Promise((r) => queueMicrotask(() => r(undefined)));
+      expect(screen.getByTestId("unread-marker")).toHaveTextContent("4 unread");
     });
 
     // Send-relatch (2026-06-09, vjt prod report): a focused OWN send must
@@ -3622,16 +3641,17 @@ describe("ScrollbackPane", () => {
 
       // FREEZE CONTRACT (2026-06-08): a bare cursor advance no longer removes
       // the divider — it's frozen. The divider row unmounts when a FOCUS
-      // acquisition re-latches the frozen boundary past the unread block.
-      // Advance the live cursor, then drive ONE visibility-return: that
-      // re-latches markerCursorId=53 → divider unmounts. (Yield between
-      // transitions so SolidJS flushes the false state — effect captures
-      // prev=false — before we flip back to true; otherwise both writes
-      // batch and the effect's prev=undefined guard returns early.)
+      // ACQUISITION re-latches the frozen boundary past the unread block.
+      // Advance the live cursor, then drive an OWN SEND: that re-latches
+      // markerCursorId=53 → divider unmounts.
+      //
+      // issue 2032 — this used to drive a visibility-return instead. A resume
+      // no longer re-latches, so it can no longer remove the divider; the
+      // property under test here is the #168 display-only one (removal leaves
+      // the pane following the tail), not which trigger does the removing, so
+      // the trigger was swapped for one that still qualifies.
       applyReadCursorSet("freenode", "#grappa", 53);
-      setDocVisible(false);
-      await new Promise((r) => queueMicrotask(() => r(undefined)));
-      setDocVisible(true);
+      pushOwnSend("freenode #grappa");
       await waitFor(() => {
         expect(screen.queryByTestId("unread-marker")).toBeNull();
       });

--- a/cicchetto/src/__tests__/TopicBar.test.tsx
+++ b/cicchetto/src/__tests__/TopicBar.test.tsx
@@ -476,6 +476,100 @@ describe("TopicBar", () => {
       expect(screen.queryByTestId("topic-modal-editor")).toBeNull();
       expect(screen.getByTestId("topic-modal-edit")).toBeInTheDocument();
     });
+
+    // issue 2035 — Enter SETS the topic. This REVERSES #263's own decision
+    // ("Enter in the textarea must stay a newline, save is the ✅ button
+    // only"): vjt ruled the asserted behaviour wrong, and the premise it
+    // rested on was weak anyway — `flattenTopicNewlines` spends every newline
+    // BEFORE the send door, so the line break Enter bought could never reach
+    // the wire as anything but a space.
+    describe("Enter sets the topic (issue 2035)", () => {
+      it("Enter submits the FLATTENED draft through the same door ✅ uses, and closes", async () => {
+        withTopic("Old topic");
+        render(() => <TopicBar {...baseProps()} />);
+        enterEdit();
+        const editor = screen.getByTestId("topic-modal-editor") as HTMLTextAreaElement;
+        // A draft that already CARRIES newlines (a paste — the route that
+        // survives Enter no longer inserting one). The flatten must still run.
+        fireEvent.input(editor, { target: { value: "line one\nline two" } });
+        fireEvent.keyDown(editor, { key: "Enter" });
+        expect(postTopicMock).toHaveBeenCalledWith(
+          "tok-test",
+          "freenode",
+          "#italia",
+          "line one line two",
+        );
+        await settle();
+        expect(screen.queryByRole("dialog")).toBeNull();
+      });
+
+      it("Enter is preventDefault'd, so the textarea never inserts the line break", () => {
+        withTopic("Old topic");
+        render(() => <TopicBar {...baseProps()} />);
+        enterEdit();
+        const editor = screen.getByTestId("topic-modal-editor") as HTMLTextAreaElement;
+        fireEvent.input(editor, { target: { value: "one line" } });
+        // fireEvent returns false when the event was cancelled. jsdom does not
+        // insert the break itself, so the cancellation IS the observable.
+        expect(fireEvent.keyDown(editor, { key: "Enter" })).toBe(false);
+      });
+
+      it("Shift+Enter sets the topic too — EVERY Enter sends (#974)", () => {
+        // Not invented here: #974 is vjt's 2026-08-07 ruling on the SIBLING
+        // surface (ComposeBox), reversing his own day-old split. A Shift+Enter
+        // that refuses also EATS the keystroke, and on his device the modifier
+        // arms itself on presses he never meant as Shift+Enter — so the
+        // message silently does not go. Same operator, same device, same
+        // one-wire-line domain: the topic editor answers it the same way
+        // rather than growing a second semantics for the same chord.
+        withTopic("Old topic");
+        render(() => <TopicBar {...baseProps()} />);
+        enterEdit();
+        const editor = screen.getByTestId("topic-modal-editor") as HTMLTextAreaElement;
+        fireEvent.input(editor, { target: { value: "shifted" } });
+        expect(fireEvent.keyDown(editor, { key: "Enter", shiftKey: true })).toBe(false);
+        expect(postTopicMock).toHaveBeenCalledWith("tok-test", "freenode", "#italia", "shifted");
+      });
+
+      // #232 guardrail — the new element-level keydown may exist, but it must
+      // NOT become a second ESC authority. The isolation is that `keybindings`
+      // (the ONE global keydown listener, which drives the shared overlay
+      // stack) is never installed in this file, so the element handler is the
+      // only thing an Escape can reach here: an Escape branch smuggled into it
+      // kills the draft right here, and nothing else can.
+      //
+      // 🔴 The event MUST bubble. Solid DELEGATES `onKeyDown` to the document
+      // root, so a `bubbles: false` dispatch never reaches the handler at all
+      // and this test passes with the smuggled branch in place — measured, it
+      // is how the first version of it survived its own mutant.
+      it("the editor's keydown ignores Escape — the shared stack keeps that authority", () => {
+        withTopic("Old topic");
+        render(() => <TopicBar {...baseProps()} />);
+        enterEdit();
+        const editor = screen.getByTestId("topic-modal-editor") as HTMLTextAreaElement;
+        fireEvent.input(editor, { target: { value: "still here" } });
+        expect(fireEvent.keyDown(editor, { key: "Escape" })).toBe(true);
+        expect((screen.getByTestId("topic-modal-editor") as HTMLTextAreaElement).value).toBe(
+          "still here",
+        );
+        // Still EDITING — no revert, no close.
+        expect(screen.queryByTestId("topic-modal-edit")).toBeNull();
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      // issue 2035 height half. `rows` is the production knob — the platform's
+      // own "how many text lines", which tracks font-size and line-height by
+      // itself, where the `min-height` it replaces had to restate both and got
+      // the arithmetic wrong (see the CSS comment). jsdom has no layout, so
+      // this pins the ATTRIBUTE only; the rendered pixels are measured in
+      // e2e/tests/issue2035-topic-editor-height.spec.ts.
+      it("the editor opens eight text lines tall", () => {
+        withTopic("Old topic");
+        render(() => <TopicBar {...baseProps()} />);
+        enterEdit();
+        expect((screen.getByTestId("topic-modal-editor") as HTMLTextAreaElement).rows).toBe(8);
+      });
+    });
   });
 
   // #219-general — the topic modal COVERS the ScrollbackPane (fixed

--- a/cicchetto/src/__tests__/TopicBar.test.tsx
+++ b/cicchetto/src/__tests__/TopicBar.test.tsx
@@ -514,14 +514,15 @@ describe("TopicBar", () => {
         expect(fireEvent.keyDown(editor, { key: "Enter" })).toBe(false);
       });
 
-      it("Shift+Enter sets the topic too — EVERY Enter sends (#974)", () => {
-        // Not invented here: #974 is vjt's 2026-08-07 ruling on the SIBLING
-        // surface (ComposeBox), reversing his own day-old split. A Shift+Enter
-        // that refuses also EATS the keystroke, and on his device the modifier
-        // arms itself on presses he never meant as Shift+Enter — so the
-        // message silently does not go. Same operator, same device, same
-        // one-wire-line domain: the topic editor answers it the same way
-        // rather than growing a second semantics for the same chord.
+      it("Shift+Enter sets the topic too — EVERY Enter sends", () => {
+        // RULED, not derived. The issue left this chord open; vjt settled it
+        // for this surface — "anche shift-invio setta il topic" (2026-09-10,
+        // relayed in session). It agrees with #974, his 2026-08-07 ruling on
+        // the SIBLING surface (ComposeBox), which reversed his own day-old
+        // split: a Shift+Enter that refuses also EATS the keystroke, and on
+        // his device the modifier arms itself on presses he never meant as
+        // Shift+Enter — so the message silently does not go. One chord, one
+        // semantics, on both surfaces.
         withTopic("Old topic");
         render(() => <TopicBar {...baseProps()} />);
         enterEdit();

--- a/cicchetto/src/__tests__/addQuote.test.ts
+++ b/cicchetto/src/__tests__/addQuote.test.ts
@@ -255,3 +255,62 @@ describe("addQuoteToCompose", () => {
     expect(document.activeElement).toBe(ta);
   });
 });
+
+// issue 2033 — the same relay defect at the second door. An archived quote that
+// names `Gazzurbo` credits a bot forever, and by the time the quote is recalled
+// the channel context that would have explained it is gone.
+//
+// vjt's ruling 4: `!addquote` STRIPS ONLY — no `@`. An archive addresses
+// nobody, so it takes no mention; the wrapped author stays wrapped and only the
+// outer relay nick goes. Detection itself is shared with Reply, one predicate,
+// so the two doors cannot disagree about what a relay looks like.
+describe("addQuoteCommand — a bridged message is archived under its AUTHOR (issue 2033)", () => {
+  it("drops the relay's nick and keeps the author wrapped", () => {
+    expect(addQuoteCommand(msg({ sender: "Gazzurbo", body: "<THREADelli> ciao mondo" }))).toBe(
+      "!addquote <THREADelli> ciao mondo",
+    );
+  });
+
+  // The divergence from Reply is the POINT of ruling 4, so it is asserted as a
+  // difference rather than as two independent literals: an implementation that
+  // shared the mention would archive `@THREADelli` and pass a strip-only check
+  // that merely looked for the author's name.
+  it("takes no mention, where Reply takes one", () => {
+    const relayed = msg({ sender: "Gazzurbo", body: "<THREADelli> ciao" });
+    expect(addQuoteCommand(relayed)).not.toContain("@");
+    expect(replyQuote(relayed)).toContain("@THREADelli");
+  });
+
+  it("leaves an unbridged row exactly as it was", () => {
+    expect(addQuoteCommand(msg({}))).toBe("!addquote <vjt> ciao mondo");
+  });
+
+  it("refuses a head that is not nick-shaped", () => {
+    expect(addQuoteCommand(msg({ body: "<3 you" }))).toBe("!addquote <vjt> <3 you");
+  });
+
+  // Same #1126 carve-out Reply makes, and the reason it exists lives on THIS
+  // side: rendering `* Gazzurbo <THREADelli> waves` as `<THREADelli> waves`
+  // would archive an action as something the person SAID.
+  it("never reads an ACTION as bridged — #1126 outranks the heuristic", () => {
+    expect(
+      addQuoteCommand(
+        msg({ kind: "action", sender: "Gazzurbo", body: "\x01ACTION <THREADelli> waves\x01" }),
+      ),
+    ).toBe("!addquote * Gazzurbo <THREADelli> waves");
+  });
+
+  it("refuses a body that is only the wrapping", () => {
+    expect(addQuoteCommand(msg({ sender: "Gazzurbo", body: "<THREADelli> " }))).toBeNull();
+  });
+
+  // The accumulating door (#1356) shares the payload builder, so it inherits
+  // the strip. Pinned because it is a SECOND call site of `attributionHead`,
+  // and a fix applied only to `addQuoteCommand` would leave it behind.
+  it("strips the relay when accumulating a second payload too", () => {
+    mountCompose();
+    addQuoteToCompose(msg({ sender: "ska", body: "primo" }), NET, CHAN);
+    addQuoteToCompose(msg({ id: 2, sender: "Gazzurbo", body: "<THREADelli> secondo" }), NET, CHAN);
+    expect(getDraft(KEY)).toBe("!addquote <ska> primo <THREADelli> secondo");
+  });
+});

--- a/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
+++ b/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
@@ -161,8 +161,10 @@ const MIRRORS: readonly Mirror[] = [
   },
 
   // The scroll-edge pair (#1646 slice 2). `SCROLL_BOTTOM_THRESHOLD_PX` is the
-  // most-copied constant in the tree by a wide margin — 20 declarations, one
-  // per spec that has to decide "is this pane at its tail".
+  // most-copied constant in the tree by a wide margin — one declaration per
+  // spec that has to decide "is this pane at its tail". The count is the list
+  // below and is deliberately not restated in prose: it grows with every such
+  // spec, and a number here would be wrong by the next one.
   ...[
     "e2e/fixtures/scrollGesture.test.ts",
     "e2e/tests/bug7-ios-own-msg-visible.spec.ts",
@@ -172,6 +174,7 @@ const MIRRORS: readonly Mirror[] = [
     "e2e/tests/issue1121-overlay-close-tail-reader.spec.ts",
     "e2e/tests/issue168-scroll-authority.spec.ts",
     "e2e/tests/issue196-preview-scroll-live-arrival.spec.ts",
+    "e2e/tests/issue2031-send-with-marker-row-clipped.spec.ts",
     "e2e/tests/issue243-tap-active-scroll-bottom.spec.ts",
     "e2e/tests/issue253-kbd-resize-scroll-preserve.spec.ts",
     "e2e/tests/issue280-button-coexist.spec.ts",

--- a/cicchetto/src/__tests__/replyQuote.test.ts
+++ b/cicchetto/src/__tests__/replyQuote.test.ts
@@ -494,3 +494,108 @@ describe("replyToMessage", () => {
     expect(getDraft(KEY)).toBe("<a> primo << ciao<b> secondo << ");
   });
 });
+
+// issue 2033 — a BRIDGE relays somebody else's words under its own IRC nick and
+// wraps the real author into the body:
+//
+//   <Gazzurbo> <THREADelli> ne parlavamo in un talk...
+//
+// `msg.sender` is then the RELAY, not the speaker. Quoting it names a bot and
+// buries the person being answered, and the far side receives three
+// attributions deep (`<vjt> <Gazzurbo> <THREADelli> …`).
+//
+// vjt's rulings (2026-09-10, relayed in the issue): detection is the head shape
+// ALONE — no configured relay list — and reply re-emits the recovered author as
+// `@nick`, a real mention on the far side, because this bridge relays the
+// Telegram USERNAME and not the display name.
+describe("replyQuote — a bridged message quotes its AUTHOR, not the relay (issue 2033)", () => {
+  it("drops the relay's nick and mentions the wrapped author", () => {
+    expect(
+      replyQuote(msg({ sender: "Gazzurbo", body: "<THREADelli> ne parlavamo in un talk" })),
+    ).toBe("@THREADelli ne parlavamo in un talk << ");
+  });
+
+  // The `@` is what makes the far side notify the person. Asserted apart from
+  // the shape above: an implementation that recovered the author but left it
+  // wrapped would pass a `toContain("THREADelli")` and still notify nobody.
+  it("leaves the relay's nick nowhere in the quote", () => {
+    const quote = replyQuote(msg({ sender: "Gazzurbo", body: "<THREADelli> ciao" })) ?? "";
+    expect(quote).toBe("@THREADelli ciao << ");
+    expect(quote).not.toContain("Gazzurbo");
+    expect(quote).not.toContain("<THREADelli>");
+  });
+
+  // The ACCEPTED LIMITATION, pinned as an assertion rather than left to be
+  // rediscovered as a bug report (vjt's ruling 1). Detection is structural, so
+  // a human writing `<foo> bar` IS read as a relay — and the cost is not a
+  // stray `@`: `alice`, the actual speaker, is DROPPED. Priced in knowingly.
+  it("misreads a human who writes `<foo> bar` — and drops her, knowingly", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "<foo> bar" }))).toBe("@foo bar << ");
+  });
+
+  // The other half of the same ruling: what is NOT nick-shaped is not a relay.
+  // These are the shapes that keep ordinary prose out of the heuristic.
+  it("refuses a head that is not nick-shaped", () => {
+    expect(replyQuote(msg({ body: "<3 you" }))).toBe("<vjt> <3 you << ");
+    expect(replyQuote(msg({ body: "<two words> a" }))).toBe("<vjt> <two words> a << ");
+    expect(replyQuote(msg({ body: "<nospace>x" }))).toBe("<vjt> <nospace>x << ");
+  });
+
+  // The head must be at position 0, exactly as #1123 requires of a previous
+  // quote: mid-string, the leading text is the sender's own words.
+  it("refuses a wrapping that is not at the head of the body", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "guarda <bob> ciao" }))).toBe(
+      "<alice> guarda <bob> ciao << ",
+    );
+  });
+
+  // A relay line with nothing past the wrapping is nobody saying anything.
+  it("refuses a body that is only the wrapping", () => {
+    expect(replyQuote(msg({ sender: "Gazzurbo", body: "<THREADelli> " }))).toBeNull();
+  });
+
+  // vjt's ruling 5: the cap is measured on the body AFTER the relay head comes
+  // off — the head is not what overflows, the same reading #1235 already made
+  // for the nick. Discriminating by construction: `<THREADelli> ` is 13 chars
+  // and the body is 95, so the pre-cure string is 108 (capped, ellipsis) and
+  // the cured one is 95 (whole).
+  it("measures the 100-char cap on the body left AFTER the relay head", () => {
+    const words = "x".repeat(95);
+    const quote = replyQuote(msg({ sender: "Gazzurbo", body: `<THREADelli> ${words}` })) ?? "";
+    expect(quote).toBe(`@THREADelli ${words} << `);
+    expect(quote).not.toContain(REPLY_QUOTE_ELLIPSIS);
+  });
+
+  it("still caps a bridged body that overflows on its own", () => {
+    const words = "y".repeat(REPLY_QUOTE_BODY_LIMIT + 5);
+    const quote = replyQuote(msg({ sender: "Gazzurbo", body: `<THREADelli> ${words}` })) ?? "";
+    expect(quote).toBe(
+      `@THREADelli ${"y".repeat(REPLY_QUOTE_BODY_LIMIT)}${REPLY_QUOTE_ELLIPSIS}${REPLY_QUOTE_TAIL}`,
+    );
+  });
+
+  // NOT ruled, and decided here rather than left ambiguous: an ACTION row is
+  // never read as bridged. #1126 forbids rendering an action as speech, and
+  // `!addquote` — which shares this detection — would emit exactly that
+  // (`<THREADelli> waves` for something nobody said). No transcript of an
+  // action-shaped relay exists, so this falls back to today's behaviour, the
+  // same bounded silence rulings 1 and 3 already accept.
+  it("never reads an ACTION as bridged — #1126 outranks the heuristic", () => {
+    expect(
+      replyQuote(
+        msg({ kind: "action", sender: "Gazzurbo", body: "\x01ACTION <THREADelli> waves\x01" }),
+      ),
+    ).toBe("* Gazzurbo <THREADelli> waves << ");
+  });
+
+  // The ORDER of the two peels is forced, not free. #1123's cut runs FIRST: a
+  // plain reply body (`<bob> original<< answer`) opens with a nick wrapping
+  // too, so peeling the relay first would recover `bob` — who is being QUOTED,
+  // not speaking — and strand `original<< answer` past a cut that no longer
+  // matches. This is the test that fails if the two are swapped.
+  it("peels a previous quote BEFORE looking for a relay head", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "<bob> original<< answer" }))).toBe(
+      "<alice> answer << ",
+    );
+  });
+});

--- a/cicchetto/src/lib/addQuote.ts
+++ b/cicchetto/src/lib/addQuote.ts
@@ -31,9 +31,15 @@ export const ADDQUOTE_COMMAND = "!addquote ";
 // that is the predictable shape, not the exception to it: each is the line the
 // scrollback showed. `attributionHead` is shared with `replyQuote` so the two
 // doors cannot drift.
+//
+// issue 2033 — `"wrapped"` is where this door parts from Reply's, and only
+// here: a bridged row is archived under the author the relay wrapped, spelled
+// as the scrollback spelled them. It takes NO `@` (vjt's ruling 4) because an
+// archive addresses nobody — a mention notifies a person, and there is no
+// person reading a quote database.
 export function addQuoteCommand(msg: ScrollbackMessage): string | null {
   const body = quotableBody(msg);
-  return body === null ? null : `${ADDQUOTE_COMMAND}${attributionHead(msg)} ${body}`;
+  return body === null ? null : `${ADDQUOTE_COMMAND}${attributionHead(msg, "wrapped")} ${body}`;
 }
 
 // #1356 — ONE verb, N payloads. What a long-press adds to THIS draft: the whole
@@ -59,7 +65,7 @@ export function addQuoteCommand(msg: ScrollbackMessage): string | null {
 export function addQuoteAppendText(draft: string, msg: ScrollbackMessage): string | null {
   const body = quotableBody(msg);
   if (body === null) return null;
-  const payload = `${attributionHead(msg)} ${body}`;
+  const payload = `${attributionHead(msg, "wrapped")} ${body}`;
   if (!draft.includes(ADDQUOTE_COMMAND)) return `${ADDQUOTE_COMMAND}${payload}`;
   return draft.endsWith(" ") ? payload : ` ${payload}`;
 }

--- a/cicchetto/src/lib/quotableBody.ts
+++ b/cicchetto/src/lib/quotableBody.ts
@@ -15,6 +15,11 @@ import { mircPlainText } from "./mircFormat";
 // around this, `addQuoteCommand` puts `!addquote ` in front of it. The
 // ATTRIBUTION is not: since #1264 both doors head the quote the same way, so
 // `attributionHead` lives here with the body it heads.
+//
+// issue 2033 added the one axis on which the two heads DIFFER — a bridge relay
+// is mentioned by Reply and left wrapped by the archive — as a parameter and
+// not a fork, because WHO spoke is the same question at both doors and only
+// how to spell them changes.
 
 // #1123 — the nick charset, mirrored from the server's
 // `Grappa.IRC.Identifier` `@nick_regex` (RFC 2812 §2.3.1: first char is
@@ -40,6 +45,59 @@ function withoutPreviousQuote(body: string): string {
   return body.replace(PREVIOUS_QUOTE, "").trim();
 }
 
+// issue 2033 — a BRIDGE relays somebody else's words under its own IRC nick and
+// wraps the real author into the body: `<Gazzurbo> <THREADelli> ne parlavamo…`.
+// `msg.sender` is then the RELAY. Quoting it names a bot, buries the person
+// being answered, and reaches the far side three attributions deep.
+//
+// Detection is the head shape ALONE — vjt's ruling (2026-09-10): no configured
+// relay list, no gating on anything else. `(?: |$)` rather than a bare space
+// because the body arrives `.trim()`ed, so a relay line whose author said
+// nothing (`<THREADelli> `) has already lost the space that would anchor it;
+// the same idiom `PREVIOUS_QUOTE` uses for its own tail.
+const BRIDGE_RELAY_HEAD = new RegExp(`^<(${NICK})>(?: |$)`);
+
+// How a RECOVERED author is spelled. The two doors diverge here and nowhere
+// else (vjt's ruling 4): a reply MENTIONS them, because `@nick` is what makes
+// the far side notify a person; an archive addresses nobody and so keeps them
+// WRAPPED, exactly as the scrollback rendered them.
+export type RelayedAuthorStyle = "mention" | "wrapped";
+
+// Who spoke, and what is left of what they said. One pass, because the head
+// the caller emits and the head the body sheds are the same finding — asking
+// the question twice is how the two doors would come to disagree about what a
+// relay looks like.
+//
+// THE ORDER OF THE TWO PEELS IS FORCED, not a preference. #1123's cut runs
+// FIRST: a plain reply body (`<bob> original<< answer`) opens with a nick
+// wrapping too, so looking for a relay first would recover `bob` — who is being
+// QUOTED, not speaking — and strand the rest past a cut that no longer matches.
+//
+// An ACTION is never read as bridged, and that is a decision the rulings did
+// not cover: #1126 forbids rendering an action as speech, and `!addquote`
+// shares this detection, so it would archive `<THREADelli> waves` as something
+// nobody said. No transcript of an action-shaped relay exists; this falls back
+// to today's behaviour, the same bounded silence rulings 1 and 3 accept.
+function attributed(msg: ScrollbackMessage): { author: string | null; body: string } {
+  // #1126 — an action's stored body is the raw `\x01ACTION …\x01` wire form.
+  // Unwrap it FIRST, with the same helper the render layer uses, so the quote
+  // holds the text the operator actually saw. `mircPlainText` deliberately
+  // leaves \x01 alone (its call sites need the envelope to round-trip), so
+  // stripping there would have been the wrong door.
+  const raw = msg.kind === "action" ? stripCtcpAction(msg.body) : (msg.body ?? "");
+  // The wire body can carry mIRC control bytes (\x02 bold, \x03 colour…). The
+  // operator is quoting what they SEE, and a control byte round-tripped through
+  // compose would be re-sent as formatting they never chose.
+  // #1123 — the body being quoted may itself be a reply, carrying its own
+  // quote plus the `<< ` tail. Left in, every hop drags the whole history
+  // forward and the line actually being answered ends up buried mid-string.
+  const body = withoutPreviousQuote(mircPlainText(raw).trim());
+  if (msg.kind === "action") return { author: null, body };
+  const relay = BRIDGE_RELAY_HEAD.exec(body);
+  if (relay === null) return { author: null, body };
+  return { author: relay[1] ?? null, body: body.slice(relay[0].length).trim() };
+}
+
 // #1688 — the same question asked of a COMPOSE DRAFT rather than of a wire
 // body: does this string already open with a quote WE emitted?
 //
@@ -59,21 +117,11 @@ export function startsWithReplyQuote(text: string): boolean {
 export function quotableBody(msg: ScrollbackMessage): string | null {
   if (!isContentKind(msg.kind)) return null;
   if (msg.sender === "") return null;
-  // #1126 — an action's stored body is the raw `\x01ACTION …\x01` wire form.
-  // Unwrap it FIRST, with the same helper the render layer uses, so the quote
-  // holds the text the operator actually saw. `mircPlainText` deliberately
-  // leaves \x01 alone (its call sites need the envelope to round-trip), so
-  // stripping there would have been the wrong door.
-  const raw = msg.kind === "action" ? stripCtcpAction(msg.body) : (msg.body ?? "");
-  // The wire body can carry mIRC control bytes (\x02 bold, \x03 colour…). The
-  // operator is quoting what they SEE, and a control byte round-tripped through
-  // compose would be re-sent as formatting they never chose.
-  // #1123 — the body being quoted may itself be a reply, carrying its own
-  // quote plus the `<< ` tail. Left in, every hop drags the whole history
-  // forward and the line actually being answered ends up buried mid-string.
-  // Dropping it can empty the body: a sender whose message was nothing but a
-  // quote said nothing to quote back.
-  const body = withoutPreviousQuote(mircPlainText(raw).trim());
+  // Dropping the previous quote — or the relay head (issue 2033) — can empty
+  // the body: a sender whose message was nothing but a quote said nothing to
+  // quote back, and a relay line with nothing past the wrapping is nobody
+  // saying anything.
+  const { body } = attributed(msg);
   return body === "" ? null : body;
 }
 
@@ -86,6 +134,13 @@ export function quotableBody(msg: ScrollbackMessage): string | null {
 // what the operator READ. Shared rather than written twice because the two
 // doors are now one rule, and a copy would let the next kind be added to one of
 // them only.
-export function attributionHead(msg: ScrollbackMessage): string {
+//
+// issue 2033 — when the row turns out to be a BRIDGE relay, the head names the
+// author the relay wrapped instead of the relay itself, spelled per `style`.
+// This stayed one function on purpose: the two doors differ by that parameter
+// and by nothing else, so neither can drift on WHAT a relay is.
+export function attributionHead(msg: ScrollbackMessage, style: RelayedAuthorStyle): string {
+  const { author } = attributed(msg);
+  if (author !== null) return style === "mention" ? `@${author}` : `<${author}>`;
   return msg.kind === "action" ? `* ${msg.sender}` : `<${msg.sender}>`;
 }

--- a/cicchetto/src/lib/replyQuote.ts
+++ b/cicchetto/src/lib/replyQuote.ts
@@ -49,7 +49,14 @@ export function replyQuote(msg: ScrollbackMessage): string | null {
   const body = quotableBody(msg);
   if (body === null) return null;
   // #1126's heads, shared with `!addquote` since #1264 — see `attributionHead`.
-  return `${attributionHead(msg)} ${capQuotedBody(body)}${REPLY_QUOTE_TAIL}`;
+  //
+  // issue 2033 — `"mention"`: when the row is a bridge relay, the recovered
+  // author is emitted as `@nick`, which is what makes the far side notify them
+  // (vjt measured that his bridge relays the USERNAME, not the display name).
+  // The cap then falls on a body that has already shed the relay head, because
+  // `quotableBody` took it off — ruling 5, and the same reading #1235 made for
+  // the nick: the head is not what overflows.
+  return `${attributionHead(msg, "mention")} ${capQuotedBody(body)}${REPLY_QUOTE_TAIL}`;
 }
 
 // The marker and its trailing space — the part of the tail a second reply takes

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3204,10 +3204,23 @@ html.resize-dragging * {
    the #74 inline-strip <input>); editing happens here, inside the modal, in a
    roomy multi-line <textarea>. IRC topics are one wire line — newlines are
    flattened on submit (TopicBar.submitEdit); the textarea is a display-only
-   affordance. */
+   affordance.
+
+   issue 2035 — the height is `rows={8}` on the element now (TopicBar.tsx),
+   NOT a min-height here, and that is the whole cure rather than a bigger
+   number. The `min-height: 4.5em` this replaces was read as 4.5 / 1.25 = 3.6
+   text lines, and it never was: `* { box-sizing: border-box }` makes that
+   figure include the 0.6rem vertical padding and the 2px border, so at the
+   14px root it left 52.6px of content over a 17.5px line box — 3.0 lines,
+   which is exactly the "solo tre righe" the issue was filed about. Carrying
+   the same mistake forward, the 10em quoted for "8 lines" would have rendered
+   7.4. `rows` is the platform's own line count: it tracks font-size and
+   line-height by itself and cannot drift from them, so there is no arithmetic
+   left to get wrong. `resize: vertical` STAYS — an operator who wants more
+   drags. Below, the global form-control `min-height: var(--tap-min)` is the
+   only floor a drag meets, which is the tap-target one and correct. */
 .topic-modal-editor {
   width: 100%;
-  min-height: 4.5em;
   box-sizing: border-box;
   resize: vertical;
   background: var(--bg);

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50402,3 +50402,88 @@ issue specifies. Both are small, localised changes if the answers differ.
 _Not asserted: that the pref reaches every surface has been measured through
 the chokepoint (one parse caller, zero palette consumers elsewhere), not by
 exercising all twelve in a browser. The e2e covers one channel-pane line._
+<!-- entry #2032 -->
+
+---
+
+## 2026-09-10 — issue 2032: a visibility-return is a resume, and #535's divider half is reversed
+
+Reported: tapping a link that leaves the app and coming back moves the reader
+off the position they were reading at. Desktop and mobile, long-standing.
+Modals are unaffected — they never hide the document, so the pane holds
+position through `overlay-freeze`, a different writer.
+
+**Two writers moved the reader, not one, and the second is the one that makes
+the obvious fix wrong.**
+
+1. **The divider JUMP.** `scrollToActivation` read the `unread-marker` node for
+   `"marker-or-preserve"` — the scrolled-up arm of visibility-return — in the
+   SAME query as the deliberate-switch mode, and `scrollIntoView`d it. So the
+   mode preserved only when NO divider rendered. With one present it moved the
+   reader, which is the opposite of its name.
+2. **The divider RE-LATCH.** The visibility arm re-pointed `markerCursorId` at
+   the live read cursor. When that MOVES the cursor it recomputes `rows()`, and
+   every row is a fresh object literal under a `<For>` keyed by reference, so
+   the whole DOM list is recreated and **scrollTop collapses to 0**.
+
+Writer 2 is masked by writer 1: the jump lands somewhere immediately after the
+reset, so nobody sees the zero. **Remove the jump alone and the reader is
+dropped at the TOP of the buffer — strictly worse than the reported bug.** The
+cure removes both. `"marker-or-preserve"` is renamed `"preserve-only"`, which
+is now the truth rather than an aspiration.
+
+**This REVERSES the second half of #535 (2026-07-30), deliberately.** That entry
+recorded vjt's ruling verbatim — *"non dobbiamo sminchiare lo scroll, come regola
+generale. l'unico caso in cui scrolliamo to bottom è quando si scrive un
+messaggio nella finestra attiva"* — and then glossed it as "everything else
+preserves the reader's position **or lands on the unread divider**". vjt's words
+constrain scroll-to-BOTTOM only; the divider clause was the entry's own
+extension, and it is what authorised putting a resume mode into the divider
+query. #535's reasoning for why that was harmless: the hide-edge cursor write
+parks the cursor at the reader's own row, so the re-latched divider IS their
+position. **That holds only while the write lands.** `setCursorIfAdvances` is
+forward-only (#233), so a reader parked ABOVE the live cursor leaves it
+untouched and the divider sits somewhere else entirely. The invariant that
+survives is #168's (2026-07-03): only a DELIBERATE window change lands on the
+divider.
+
+**The freeze contract loses "option (b)".** `markerCursorId` no longer
+re-latches on visibility-return. It still re-latches on a deliberate switch, on
+cold-mount and on an own send — all genuine focus acquisitions. A resume is not
+one, and the divider a reader was reading against must not move under them.
+
+**The comment at the divider query asserted the opposite of the code** — *"the
+channel-SWITCH trigger jumps to the RENDERED frozen unread divider when one
+exists; every other trigger (cold-mount, visibility-return, resize) lands at the
+tail"*. Both clauses were false: cold-mount became a marker activation in #168's
+own 2026-07-03b completion, and visibility-return's scrolled-up arm was in the
+query. Fixed in the same commit as the cure, per the standing rule.
+
+**`"preserve-only"` still declares the `marker-activation` intent kind**, and
+that is deliberate. The kind is a PRECEDENCE CLASS, not a description of the
+write: it must outrank `tail-follow` (rank 4) or a concurrent tail-follow snaps
+the resuming reader to the tail, which is the #535 defect returning.
+`prepend-preserve`, the only other preserve-shaped kind, sits BELOW `tail-follow`
+and would reinstate it. Minting a new kind means widening the union and the
+PRECEDENCE array shared by the whole applier — a separate change with its own
+blast radius.
+
+**Tests that pinned the old behaviour were rewritten, not deleted.**
+`issue535-visibility-return-preserve-scroll.spec.ts`'s second case asserted
+"return lands ON the divider" — it pinned this defect, and was green by
+construction over the entire divider-present half of the space. Three unit cases
+in `ScrollbackPane.test.tsx` pinned the re-latch, one of them named "(option
+b)". The #168 display-only case kept its property and swapped its trigger from a
+visibility-return to an own send, since a resume can no longer remove a divider.
+New coverage: `issue2032-visibility-return-preserve-position.spec.ts`, whose
+discriminating case has the reader read DOWNWARD past the frozen divider so the
+input-gated scroll-settle advances the live cursor — giving the re-latch
+somewhere new to point, which is what separates writer 2 from writer 1.
+
+_Client-only. No wire change, no protocol bump, no migration._
+
+_Not asserted: the reported direction. The report says "backwards"; every path
+this analysis can construct from the code yanks the reader FORWARD by roughly a
+viewport, or to scrollTop 0 when the divider is absent on return. The backward
+variant was not reproduced, and the cure does not depend on it — the contract
+asserted is preservation, which is direction-agnostic and covers all three._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50402,3 +50402,66 @@ issue specifies. Both are small, localised changes if the answers differ.
 _Not asserted: that the pref reaches every surface has been measured through
 the chokepoint (one parse caller, zero palette consumers elsewhere), not by
 exercising all twelve in a browser. The e2e covers one channel-pane line._
+<!-- entry #2033 -->
+
+---
+
+## 2026-09-10 — #2033: quoting the author a bridge relayed, not the bridge
+
+A bridge bot relays somebody else's words under its OWN IRC nick and wraps the
+real author into the body — `<Gazzurbo> <THREADelli> ne parlavamo…`. `msg.sender`
+is therefore the RELAY, so both quote doors credited a bot: Reply put
+`<Gazzurbo> <THREADelli> body << ` on the wire, arriving three attributions deep
+and addressing the author as plain text (notifying nobody), and `!addquote`
+archived that misattribution permanently, into a database where the channel
+context that would explain it no longer exists.
+
+### What vjt ruled (2026-09-10, relayed into the issue — not observed on IRC)
+
+Detection is the head shape ALONE: no configured relay list, no second gate. The
+false positive is priced in. `@name` does produce a real mention because this
+bridge relays the Telegram USERNAME, not the display name — which also settles
+the charset worry the issue raised, since a username is `[A-Za-z0-9_]` and the
+existing RFC 2812 `NICK` admits that in full. `!addquote` is in scope but takes
+STRIP ONLY, no `@`: an archive addresses nobody. The cap is measured on the body
+after the head comes off.
+
+### The limitation is a dropped speaker, not a stray `@`
+
+Worth restating because the cheap reading understates it. A human writing
+`<foo> bar` is read as a relay, and the cure then drops `alice` — the actual
+speaker — and answers `@foo`, who does not exist. Accepted knowingly, and pinned
+as an assertion in `replyQuote.test.ts` so it is a recorded decision rather than
+a bug report somebody files in six months.
+
+### Two decisions the rulings did not cover
+
+**An ACTION is never read as bridged.** #1126 forbids rendering an action as
+speech, and detection is SHARED with `!addquote`, which would otherwise archive
+`<THREADelli> waves` as something nobody said. No transcript of an action-shaped
+relay exists, so this falls back to today's behaviour — the same bounded,
+deliberate silence the accepted limitations already carry. The cost is that a
+genuinely action-shaped bridge stays unfixed; the alternative was inventing a
+shape for a case with no evidence behind it.
+
+**The order of the two peels is FORCED, not a preference.** #1123's
+previous-quote cut must run FIRST. A plain reply body (`<bob> original<< answer`)
+opens with a nick wrapping too, so looking for a relay first recovers `bob` — who
+is being QUOTED, not speaking — and strands the remainder past a cut that no
+longer matches. Measured, not argued: swapping the two kills 14 tests, 13 of them
+pre-existing #1123 guards. The consequence is a real gap, stated rather than
+hidden — a bridge relaying a line that was ITSELF a reply loses its author,
+because #1123's greedy cut consumes the relay head on its way to the tail.
+
+### Shape
+
+`attributionHead/1` became `attributionHead/2`, gaining a `RelayedAuthorStyle`
+(`"mention" | "wrapped"`). One shared site, one predicate, one parameter — a
+fork would let the two doors disagree about what a relay IS, which is the
+failure `quotableBody`'s own header warns about. The 100-char cap needed no edit
+to satisfy ruling 5: it has always been measured on what `quotableBody` returns,
+and that is now the body with the head already gone.
+
+_Not asserted: that `<nick> ` is the only bridged shape in the wild. One
+transcript exists, from one bridge, and no survey was made. Verified on chromium
+via vitest only — no real bridge, no Telegram, no device._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50402,3 +50402,103 @@ issue specifies. Both are small, localised changes if the answers differ.
 _Not asserted: that the pref reaches every surface has been measured through
 the chokepoint (one parse caller, zero palette consumers elsewhere), not by
 exercising all twelve in a browser. The e2e covers one channel-pane line._
+<!-- entry #2035 -->
+
+---
+
+## 2026-09-10 — #2035: eight lines the box actually has, and an Enter that sets
+
+Two asks from dogfood, and they turned out to be different kinds of thing: one
+is a reversed decision, the other is an arithmetic bug that had been sitting in
+a comment-free stylesheet since #263.
+
+### Enter sets the topic — a reversal, on a ruling
+
+`TopicBar.tsx` used to carry this, in as many words: *"Enter in the textarea
+must stay a newline (save is the ✅ button only), the flatten collapses it on
+submit."* That is now false, and the reason it is false is that the product
+owner ruled the asserted behaviour wrong. Recording the reason matters more
+than recording the change: the decision was not flaky, not awkward to test, and
+not inconvenient — it was a product call, and it was reversed by the only
+person who can reverse one.
+
+It is worth adding that the premise it rested on was weak. An IRC topic is ONE
+wire line; the server rejects a body carrying `\r`/`\n` outright
+(`Identifier.safe_line_token?` → `:invalid_line`), and `flattenTopicNewlines`
+collapses every newline run to a single space BEFORE the send door. So the line
+break Enter bought was worth exactly one space and could never reach the wire
+as a break. The decision was defending a cosmetic that the next function call
+spent.
+
+**Shift+Enter was NOT ruled**, and the issue says so. It is answered here by
+#974 rather than by invention: vjt's 2026-08-07 ruling on `ComposeBox` — the
+sibling surface, same operator, same one-wire-line domain — reversed his own
+day-old split with the measurement that *a Shift+Enter that refuses also EATS
+the keystroke*, and that on his device the modifier arms itself on presses he
+never meant as Shift+Enter, so the send silently does not happen. Growing a
+second semantics for the same chord on a second surface is exactly the
+"whatever pattern is closest gets propagated" failure CLAUDE.md warns about, so
+the topic editor answers the chord the way the composer does: every Enter
+sends, modifier or not.
+
+Two guardrails, both held. The new element-level `keydown` handles `Enter` and
+returns on everything else — it is **not** a second ESC authority, which #232
+made the shared overlay stack's alone, and whose edit-aware branch already has
+real-browser coverage in `issue263-topic-modal-edit.spec.ts`. And **the flatten
+stays**: Enter no longer types a newline, but a PASTE still carries them in,
+which is now the route it exists for.
+
+### Three lines were not a preference — they were `box-sizing`
+
+The issue asked for eight lines and derived `min-height: 10em` from
+`4.5em / 1.25 = 3.6 lines`. Both halves of that arithmetic are wrong in the
+same way, and the wrongness is measurable rather than arguable.
+
+`* { box-sizing: border-box }` is global in `default.css`, and `html` sets
+`font-size: var(--font-size)`, so at the 14px root a `min-height` is a BORDER
+box: it swallows the editor's `0.3rem` vertical padding on each side and its
+1px borders before the text sees a pixel. The old `4.5em` = 63px therefore left
+`63 − 8.4 − 2 = 52.6px` of content over a `1.25 × 14 = 17.5px` line box —
+**3.0 lines, not 3.6**. Which is precisely the *"mo è solo tre righe"* that was
+reported: the operator counted correctly and the stylesheet's arithmetic did
+not. Carried forward unchanged, the `10em` quoted for "8 lines" would have
+rendered **7.4**.
+
+The cure is not a bigger number. `rows={8}` on the element is the platform's
+own line count: it tracks `font-size` and `line-height` by itself, cannot
+disagree with them, and leaves no coupled arithmetic for the next reader to get
+wrong — the `min-height` is deleted rather than corrected. `resize: vertical`
+stays, so an operator who wants more drags; the only floor a drag now meets is
+the global form-control `min-height: var(--tap-min)`, which is the tap-target
+one and correct.
+
+### Where each half is proven, and one test that lied
+
+The split is forced by the tooling. jsdom has no layout engine, so vitest pins
+the `rows` ATTRIBUTE, the `preventDefault`, the Shift+Enter pairing and the
+Esc-guardrail; `e2e/tests/issue2035-topic-editor-height.spec.ts` measures the
+rendered box (content height ÷ computed line-height, drift-proof against both
+properties moving) and witnesses the real `TOPIC #chan :<flattened>` from an
+in-channel peer after a keyboard `Enter`.
+
+🔴 **A Solid element handler cannot be probed with a non-bubbling event.** The
+first version of the Esc guardrail dispatched `keydown` with `bubbles: false`,
+reasoning that this isolated the element handler from the shared stack. It
+passed — and it also passed with an `Escape` branch deliberately smuggled into
+the handler, which is how it was caught: Solid DELEGATES `onKeyDown` to the
+document root, so a non-bubbling dispatch reaches no handler at all and the
+test asserted nothing. The isolation that does work is structural: `keybindings`
+(the one global keydown listener) is never installed in that test file, so a
+normally-bubbling Escape can only reach the element handler. The mutant dies
+now. The general rule is worth more than the fix — **a "the handler ignores X"
+test must be shown to fail when the handler stops ignoring X**, because the
+event never arriving looks exactly like the event being ignored.
+
+_Not asserted. The phone measurement is against the LAYOUT viewport (iPhone 15
+and Pixel 7 descriptors): Playwright raises no soft keyboard, and focusing the
+editor on a real phone roughly halves the visual viewport, so "the modal fits
+above the fold" is strictly weaker than "the ✅ is reachable while typing".
+Neither is the IME case covered: like `ComposeBox` before it, this handler has
+no `isComposing` guard, so an Enter that confirms a candidate mid-composition
+submits. That is a shared gap of the two surfaces and wants one issue over both,
+not a divergence introduced on one of them here._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50402,3 +50402,202 @@ issue specifies. Both are small, localised changes if the answers differ.
 _Not asserted: that the pref reaches every surface has been measured through
 the chokepoint (one parse caller, zero palette consumers elsewhere), not by
 exercising all twelve in a browser. The e2e covers one channel-pane line._
+<!-- entry #2031 -->
+
+---
+
+## 2026-09-10 — #2031: a send stops one padding short of the tail, and the obvious cure was a regression
+
+Reported from an iPhone: send while the `── N unread messages ──` divider is on
+screen and the just-sent line comes out clipped at the bottom of the scrollback.
+The issue's own guess named the `SCROLL_BOTTOM_THRESHOLD_PX` slack — 50px of
+declared "close enough to the tail", which is wider than a message row, so a
+pane every assertion in the codebase calls "at the tail" can hold a whole row
+below the fold.
+
+That guess is right about the mechanism it enables and wrong about the distance.
+Measured over nine runs on the untouched tree, the terminal state has exactly
+two values: `distanceFromBottom = 7` with the row overflowing the pane's bottom
+edge by +0.203px (`webkit-iphone-15`, 3/3 — deterministic on the reported
+platform) or +0.359px (chromium, 2/3), against `distanceFromBottom = 0` and
+−6.640px on the one healthy chromium run. The pane does not stop somewhere
+inside 50px of slack. It stops SEVEN pixels short, and seven is the scroller's
+own `padding-bottom` (`.scrollback { padding: 0.5rem 1rem }`).
+
+`scrollIntoView({ block: "end" })` aligns the tail ROW's bottom box with the
+scrollport's bottom EDGE. The scroller's padding sits below that row inside the
+scrollable extent, so it is simply never scrolled: the row lands flush against
+the edge with no breathing room and a fraction of a pixel cut. Nothing repairs
+it afterwards, because 7 ≤ 50 makes every "am I at the tail" reader answer yes —
+the #625 fail-safe included, which then skips its write for exactly the reason
+#625 taught it to.
+
+So the divider is not what leaves the pane short. Its collapse is the follow-on
+rows change that produces the poll whose correction gets suppressed; the
+shortfall itself is the padding blind spot, and it is there on every send. The
+divider is what makes it visible.
+
+### Two cures were refused, and a third refusal is the entry
+
+Lowering `SCROLL_BOTTOM_THRESHOLD_PX` is not available: that number is the
+definition of "at the tail" for the whole product — the scroll-to-bottom button,
+the `followMode` re-arm, the read-cursor advance, the badge suppression in
+`readingAtTail.ts`. Four unrelated behaviours moved to repair one scroll write.
+
+Changing the #625 fail-safe's PREDICATE — comparing against the tail row's box
+instead of the fixed slack — treats the symptom. The fail-safe did not misjudge
+anything; it was asked to patch a write that should have been correct.
+
+The third is the one worth recording, because it was the obvious move and it
+would have been a REGRESSION. The write's two branches read as interchangeable:
+
+```
+if (tail?.scrollIntoView) { tail.scrollIntoView({ block: "end" }); }
+else { listRef.scrollTop = listRef.scrollHeight; }
+```
+
+and the `else` branch reaches the real tail, so swapping them is a one-line fix
+that measures correct on this issue. The branches are not alternatives. UX-8(a3)
+chose the native walk over the `scrollHeight` math from a measured incident: the
+browser scrolls the container from the element's real box, which stays
+layout-aware while `scrollHeight` bookkeeping is mid-update — the channel-back
+path, where a cached window's store reload races the key-effect even after
+rAF×2. The setter has no such property, and it does not walk scrollable
+ANCESTORS either. The `else` branch is the fallback for having no element (and,
+incidentally, the jsdom path, where `Element.prototype.scrollIntoView` does not
+exist).
+
+Trading the walk for the setter therefore trades a measured 7px clip for the
+re-opening of a measured page-scale defect, on a path this issue's spec does not
+cover. So the write is COMPLETED rather than replaced:
+
+```
+const tail = list.lastElementChild as HTMLElement | null;
+tail?.scrollIntoView?.({ block: "end" });
+const max = list.scrollHeight - list.clientHeight;
+if (max > list.scrollTop) list.scrollTop = max;
+```
+
+The maximum is spelled `scrollHeight - clientHeight` rather than left to the
+browser clamping `scrollTop = scrollHeight` — the same call #1121 made two
+screens down for `restoreTo`, for the reason written there: *a number that has
+to be clamped before it is true cannot be measured against*. The shape of this
+cure was already reasoned out elsewhere in the same file; the pre-existing
+`else` branch is the part that leans on clamping.
+
+The top-up only ever scrolls DOWN, and that guard is the walk's insurance rather
+than defensive habit. A stale `scrollHeight` is the precise condition step 1
+exists to survive, so writing a stale maximum over a good walk would undo it;
+`max <= scrollTop` means the read cannot be trusted (or the pane is already
+there) and the walk stands. Down-only also keeps `followMode` out of it — the
+pane leaves the tail only when `scrollTop` DECREASES (#168).
+
+### Three sites, and "verbatim" was measured rather than eyeballed
+
+The same five lines appear three times: `scrollToActivation`'s no-marker branch,
+`tailFollowWhenSettled`, and `dispatchScrollWrite`'s operator-tail. All three
+target `lastElementChild` of the same `.scrollback` node with the same padding
+and all three mean "put the pane at the tail". Only the middle one was measured
+defective; the other two are cured BY CONSTRUCTION, and that phrase is worth
+something only if "verbatim" is a measurement.
+
+It is: stripping leading indentation and nothing else, the three write cores
+share one md5 and the three `const tail` bindings share another. Controls in
+both directions — an independent block from the same file (the marker write,
+`block: "start"`) differs; a one-byte mutant (`"end"` → `"enD"`) differs; and
+the normaliser is shown not to have gutted the content (five lines, tokens
+intact), because three empty files would also share an md5. The raw blocks are
+NOT identical — two sit at ten spaces of indentation and one at eight — so the
+identity is post-normalisation and is stated that way.
+
+The set is CLOSED, which is what "all three" actually rests on: `block: "end"`
+occurs exactly three times in non-test `cicchetto/src`, and
+`scrollTop = …scrollHeight` at those three `else` branches plus two comments.
+There is no fourth site left behind.
+
+### The spec that photographed the defect and called it green
+
+The first draft of `issue2031-send-with-marker-row-clipped.spec.ts` carried a
+1px "sub-pixel" tolerance and passed. That thread swallowed the defect whole:
+the clipped state overflows by +0.203px, so the spec measured exactly what it
+was written to catch and reported ok. The tolerance is ZERO, and zero is safe
+here precisely because it is not a knife edge — the two states are ~7px apart
+(−6.64 against +0.20) with no sub-pixel path between them.
+
+Two hypotheses were falsified on the way, recorded so the dead ends are not
+walked twice. The soft keyboard is not involved: a third case with
+`visualViewport` shrunk to 300px the way issue253 stubs it produced numbers
+identical to its keyboard-less twin to the third decimal. The CSS layout
+mechanism `themes/default.css` records for iOS WebKit ("last messages hide
+behind BottomBar", UX-6 bucket D v2) is excluded: `composeTop` equals
+`paneBottom` exactly on both engines, so nothing is painted under the compose.
+The case and the fixture that served only the dead hypothesis were REMOVED
+rather than left green and meaningless; `rowClearance` still reports the field
+so the next reader can tell the two failure shapes apart.
+
+### What the runs actually said
+
+RED on the untouched tree, both projects, and the artefact was read rather than
+the reason deduced: `Expected: <= 0 / Received: 0.203125` on
+`webkit-iphone-15`, `0.359375` on chromium, both at `distanceFromBottom = 7`.
+GREEN after the cure: `−6.640625 / d=0` (chromium) and `−6.796875 / d=0`
+(webkit) — the terminal state the untouched tree had produced once by itself on
+its healthy chromium run. The write probe shows the predicted shape: two writes
+in the SAME tick (`scrollIntoView`, then `scrollTop=1415` from `before:1408`),
+which is why #625's gap-based `delayedWrites` is unmoved by a second door
+opening.
+
+#625 is green on both its cases after the cure — the control that the
+double-scroll it killed has not come back, not a bonus. `scroll-on-window-switch`
+is green on all four, and its first test is the guard on the UX-8(a3)
+channel-back path this cure deliberately does not re-open. That guard's
+granularity is worth naming: it asserts `scrollHeight - scrollTop - clientHeight
+<= 50` — the very slack this issue accuses — so it can see a page-scale
+regression and cannot see seven pixels. Right instrument for that job, blind to
+this one. Both it and #625 run on `chromium` only (neither carries `@webkit` or
+`@touch`), which is why this issue's spec adds a `@webkit` case rather than
+trusting the desktop projection.
+
+The mutant flipped the guard (`max > scrollTop` → `max <`), which disables the
+top-up and inverts its direction at once. It killed the two new jsdom guards and
+NOTHING else (expected 120 to be 700; expected 700 to be 900 — the second is the
+guard dragging a reader 200px back up), and it killed the e2e on both projects
+with numbers bit-identical to the pre-cure red. Restore was proven rather than
+assumed: mutate → dirty → `git checkout --` → porcelain empty → the eight
+scoped e2e green again.
+
+### The jsdom suite is blind to this write, which is why two guards ride in
+
+Under jsdom `scrollHeight` and `clientHeight` both default to 0, so `max` is 0
+and the top-up never fires unless a test defines geometry BEFORE the tail write.
+The 6922-test suite therefore says nothing about the two new lines — measured,
+not assumed: a prediction that the W6 loadMore-preserve block would break was
+WRONG, and the reason is exactly this. That block defines its geometry after
+`render`, so at mount `max` is 0 and there is nothing to top up; what protects
+it is the zero geometry, not the `scrollIntoView` stub its comment credits.
+
+So two guards were added where the coverage was: one pins the top-up (700 from
+a 1000/300 pane), one pins the down-only branch (a stale maximum of 700 must
+leave a pane at 900 alone). The e2e cannot construct the second one's input —
+a stale `scrollHeight` read is a `defineProperty` in jsdom and not reachable
+from a real layout — so the guard would otherwise be an untested branch.
+
+_Not asserted: that what the reporter saw has been reproduced. They describe a
+line substantially hidden; the measurement here is 0.203px of clip — the same
+mechanism at its minimum amplitude, not the same amplitude. What makes those
+seven pixels into many more on that device is not known and is not guessed at._
+
+_Not asserted: that the report's second face — "after a moment it shifts by a
+few pixels on its own" — is cured, or absent. It did NOT reproduce: all nine
+runs recorded exactly one scroll write. The spec asserts it anyway, as the
+invariant #625 bought, stated on webkit for the first time; a green there is a
+guard, not a reproduction._
+
+_Not asserted: that UX-8(a3) is still true today. It is a measured incident
+written into the file by someone else, and it is PRESERVED rather than
+re-tested — preserving it does not require re-measuring it, removing it would
+have._
+
+_Not asserted: that the two other call sites were measured. They were not. They
+are cured by construction from the md5 identity above and carry no e2e of their
+own. Only scoped e2e was run here; the full-suite ship gate is CI's._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50430,16 +50430,20 @@ break Enter bought was worth exactly one space and could never reach the wire
 as a break. The decision was defending a cosmetic that the next function call
 spent.
 
-**Shift+Enter was NOT ruled**, and the issue says so. It is answered here by
-#974 rather than by invention: vjt's 2026-08-07 ruling on `ComposeBox` — the
-sibling surface, same operator, same one-wire-line domain — reversed his own
-day-old split with the measurement that *a Shift+Enter that refuses also EATS
-the keystroke*, and that on his device the modifier arms itself on presses he
-never meant as Shift+Enter, so the send silently does not happen. Growing a
-second semantics for the same chord on a second surface is exactly the
-"whatever pattern is closest gets propagated" failure CLAUDE.md warns about, so
-the topic editor answers the chord the way the composer does: every Enter
-sends, modifier or not.
+**Shift+Enter was left unruled by the issue, and is RULED now**: *"anche
+shift-invio setta il topic"* — vjt, 2026-09-10, his words on #grappa relayed in
+session rather than read off IRC by the implementer, which is worth stating
+because it is the provenance of the whole slice.
+
+The code predates the ruling and did not have to guess, because #974 already
+answered the same question one surface over: vjt's 2026-08-07 ruling on
+`ComposeBox` — same operator, same device, same one-wire-line domain — reversed
+his own day-old split with the measurement that *a Shift+Enter that refuses
+also EATS the keystroke*, and that on his device the modifier arms itself on
+presses he never meant as Shift+Enter, so the send silently does not happen.
+Growing a second semantics for the same chord on a second surface is exactly
+the "whatever pattern is closest gets propagated" failure CLAUDE.md warns
+about. One chord, one semantics: every Enter sends, modifier or not, on both.
 
 Two guardrails, both held. The new element-level `keydown` handles `Enter` and
 returns on everything else — it is **not** a second ESC authority, which #232

--- a/test/grappa_web/controllers/messages_limit_mirror_test.exs
+++ b/test/grappa_web/controllers/messages_limit_mirror_test.exs
@@ -4,8 +4,8 @@ defmodule GrappaWeb.MessagesLimitMirrorTest do
   limits, and until this file nothing compared a copy with its original.
 
   `@default_limit` (the unconfigured-client page size) is re-declared as
-  `REST_PAGE_SIZE` in 15 specs; `@max_http_limit` (the boundary ceiling)
-  as `MAX_HTTP_LIMIT` in 5. Twenty numbers kept in lockstep by hand,
+  `REST_PAGE_SIZE` in 16 specs; `@max_http_limit` (the boundary ceiling)
+  as `MAX_HTTP_LIMIT` in 5. Twenty-one numbers kept in lockstep by hand,
   with no witness: change the attribute and every spec keeps asserting
   the old page size, silently, because a Playwright spec seeds its own
   fixture and never asks the server what its default is.
@@ -59,7 +59,7 @@ defmodule GrappaWeb.MessagesLimitMirrorTest do
   # to the state #1646 measured. Landing either means changing the number
   # here, which is the moment someone reads this.
   @mirrors [
-    {"REST_PAGE_SIZE", "default_limit", 15},
+    {"REST_PAGE_SIZE", "default_limit", 16},
     {"MAX_HTTP_LIMIT", "max_http_limit", 5}
   ]
 

--- a/test/grappa_web/controllers/messages_limit_mirror_test.exs
+++ b/test/grappa_web/controllers/messages_limit_mirror_test.exs
@@ -4,8 +4,8 @@ defmodule GrappaWeb.MessagesLimitMirrorTest do
   limits, and until this file nothing compared a copy with its original.
 
   `@default_limit` (the unconfigured-client page size) is re-declared as
-  `REST_PAGE_SIZE` in 14 specs; `@max_http_limit` (the boundary ceiling)
-  as `MAX_HTTP_LIMIT` in 5. Nineteen numbers kept in lockstep by hand,
+  `REST_PAGE_SIZE` in 15 specs; `@max_http_limit` (the boundary ceiling)
+  as `MAX_HTTP_LIMIT` in 5. Twenty numbers kept in lockstep by hand,
   with no witness: change the attribute and every spec keeps asserting
   the old page size, silently, because a Playwright spec seeds its own
   fixture and never asks the server what its default is.
@@ -59,7 +59,7 @@ defmodule GrappaWeb.MessagesLimitMirrorTest do
   # to the state #1646 measured. Landing either means changing the number
   # here, which is the moment someone reads this.
   @mirrors [
-    {"REST_PAGE_SIZE", "default_limit", 14},
+    {"REST_PAGE_SIZE", "default_limit", 15},
     {"MAX_HTTP_LIMIT", "max_http_limit", 5}
   ]
 


### PR DESCRIPTION
Carries FOUR reviewed branches as one merge: PR #2036 (issue 2032), PR #2038
(issue 2031), PR #2039 (issue 2033) and PR #2040 (issue 2035). Built by `git
merge`, not cherry-pick, so all four heads stay ancestors of this branch and
keep their authorship — verified for each.

> **The branch name says three and the union is four.** `w1/union-2036-2038-2039`
> was cut before PR #2040 joined; renaming it now would close and reopen this PR
> and throw away the CI already spent, so the name stays stale on purpose. The
> list above is the authority, not the branch name.

## Why one union rather than three merges

All four append to `docs/DESIGN_NOTES.md`, and two of them — #2036 and #2038 —
**both rewrite `cicchetto/src/ScrollbackPane.tsx` and its unit test**. Each was
gated against the same base, never against the others, so no per-PR green ever
observed their intersection. Merging them one at a time would also cost N-1
serialized rebase + full-CI rounds, because GitHub does not apply the
`merge=union` driver on a merge ref. PR #2040 was folded in for exactly that
reason: it appends to the same log, so landing the other three first would have
turned it CONFLICTING and cost it a rebase plus a full integration run of its
own.

That is the argument. Here is the measurement, and it is the reason this is a
union rather than a convenience:

**1. The `#1646` mirror count is 16, and no per-PR run can see it.** That gate
pins how many e2e specs declare `REST_PAGE_SIZE`. Each of the two branches adds
one new spec and each bumped the pin by one against a tree holding only its own:

```
origin/main 14 · #2036 15 · #2038 15 · UNION 16
```

Union arithmetic is `14 + 2`, not `max()`. #2036 is green at 15, #2038 is green
at 15, and their merge is red at 16 — a defect that exists only in the
intersection. Not a drift: all sixteen copies read `50`, against
`@default_limit 50`, measured with the test's own `declaration_values/2`
predicate. `MAX_HTTP_LIMIT` is untouched at five copies of `200`.

**2. An e2e red that belongs to no single branch either.** `#2038`'s cure parks
the pane at the scroller's true maximum, and `cursor-forward-only.spec.ts`
assumed the ~7px of leftover run that the old tail write left unscrolled.
Measured on one machine, five runs per side:

| tree | scrollTop | max | remaining | wheel-down moves | spec |
|---|---|---|---|---|---|
| clean base | 4029 | 4036 | 7 | 7 | 5/5 green |
| this union | 4036 | 4036 | 0 | 0 | 5/5 red |

Same `scrollHeight` (4248) and `clientHeight` (212); only those 7px differ. A
probe resolves the fixture's own ambiguous message: the pane is CLAMPED, not
unreached — from the same position a wheel UP still moves it (4036 → 3736) in
the same run. **That spec was passing because of the defect.**

## The spec adjustment, and its scope

Ruling: adjust the spec, leave the cure alone. Provenance, stated plainly —
**vjt's words on #grappa, relayed to this session; not read first-hand.**

`scrollToBottom` now asserts the STATE it is named for (be at the bottom)
instead of a SIDE EFFECT (something moved). This is not a widened tolerance: no
timeout grew, no threshold moved, no assertion was deleted, and
`scrollByGesture` is untouched — its rejection is a real guard for all of its
callers. Whenever run remains, the gesture still goes through that same
rejecting door, so an undelivered wheel is still a named failure.

Scope is measured rather than assumed, because a gate is a sample and not a
list. A scan of every e2e call site reaching the move-demanding fixture — 23
sites, with positive and negative controls inside the tool, which refuses to
print counts if a control fails — finds three downward ones, all in this file,
and exactly one issued from a position that can already be the tail. The other
two are preceded by a 300px and a 150px scroll up.

## Verification

Composition, not just absence of conflict. `merge=union` covers only
`DESIGN_NOTES.md`, where a clean `rc=0` proves nothing, so each file class got
its own check:

- **DESIGN_NOTES arithmetic, predicted BEFORE each merge**: `2948534 + 5193 +
  11504 + 3490 = 2968721` bytes / `50751` lines for the first three, then
  `2968721 + 6149 = 2974870` bytes / `50855` lines once #2040 joined — both
  matched to the byte. The tail is an exact partition: `tail == block2036 +
  block2038 + block2039`, and #2040's block lands verbatim and exactly once
  after it, with negative controls on a different order, on a swapped line pair
  and on one character less. Four distinct entry markers, none already on
  `origin/main`.
- **Prefix identity**: the first 50404 lines are byte-identical to main's, with
  a same-length negative control (one byte flipped mid-prefix), since a
  differing-length control only trips on EOF.
- **Compositionality on the two doubly-rewritten files**: `delta(2036 → union)
  == delta(main → 2038)` and `delta(2038 → union) == delta(main → 2036)`,
  identical in both directions, removals included — 88 removed lines that a
  line-presence check cannot see.
- **For #2040 that check is VACUOUS, and is declared rather than run for
  habit's sake.** Its only file in common with the rest of the union is
  `docs/DESIGN_NOTES.md`; `TopicBar.tsx`, its unit test, `themes/default.css`
  and its new spec are touched by nobody else. Measured as a set intersection,
  with a positive control (the log appears in both lists) and a negative one
  (`ScrollbackPane.tsx` must not).

Gates on the four-way merged tree: `bun run check` green (5 stages) and `bun run
test` green (342 files, 6946 tests). On the three-way tree, before #2040 joined,
the whole `cursor-forward-only` spec was green (7 of 7, including the one that
was 5/5 red); #2040 shares no source file with it.

The `#1646` pin was RE-MEASURED after #2040 rather than assumed to still hold:
still 16 declarations, all `50`, and `MAX_HTTP_LIMIT` still 5 of `200`. #2040
adds one spec that declares no mirrored constant, and does not touch the vitest
mirror table.

Mutation testing of the adjusted spec, with the mutation channel proven first:

| mutant | tree | expected | result |
|---|---|---|---|
| row testid renamed (channel control) | union | red | 6/6 red — channel proven |
| settle stops writing the cursor | union | ? | 6/6 green |
| same, ORIGINAL spec on the clean base | base | ? | 6/6 green |
| `#2031` top-up removed | union | green | 6/6 green, probe confirms remaining 7 |

The adjusted spec is idempotent with respect to the cure — it passes with and
without it — and it was NOT switched off: the third row shows the original spec
on the pre-cure product is equally blind to that writer, so the insensitivity
predates this branch. Recorded as a separate finding, not treated here.

Restoration proven: both trees back to their pinned HEAD and md5 after every
mutant.
