### PR TITLE
cic(#2034): dismiss a conversation's notifications when it comes into view

### DIFF
--- a/cicchetto/src/__tests__/notificationDismiss.test.ts
+++ b/cicchetto/src/__tests__/notificationDismiss.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  dismissNotificationsForActiveWindow,
+  installNotificationDismiss,
+} from "../lib/notificationDismiss";
+
+// #2034 — a notification is dismissed when its conversation comes back
+// into view, not only when it is tapped.
+//
+// Boundary: the selection store and the network / query stores are mocked
+// (pushTarget.test.ts precedent) so the assertions are about the
+// composition this module owns — enumerate the open notifications, resolve
+// each one's `data.url` to a WINDOW IDENTITY, close the ones naming the
+// focused window — rather than about the fold rules those stores already
+// prove. The DM case below is why the identity step exists at all: the
+// notification carries the RAW wire nick `Alice` while the focused window
+// is `alice`, so a byte compare would leave it sitting in the shade.
+
+// The fixture's whole mutable world: which window is focused, and whether
+// the document is visible. Hoisted because the `vi.mock` factories close
+// over it, and reset in `beforeEach` — an implementation swapped in by one
+// test is exactly the leak that made the pageshow arm below pass for the
+// wrong reason while it was being written.
+const fixture = vi.hoisted(() => ({
+  visible: true,
+  active: { networkSlug: "libera", channelName: "#sniffo", kind: "channel" } as {
+    networkSlug: string;
+    channelName: string;
+    kind: string;
+  } | null,
+}));
+
+const FOCUSED_CHANNEL = { networkSlug: "libera", channelName: "#sniffo", kind: "channel" };
+
+vi.mock("../lib/selection", () => ({
+  // Stands in for the real exact-tuple compare (#243 `isActiveSelection`,
+  // which folds the channel KEY on the way in). Byte-equal here: the fold
+  // is selection.ts's contract and is proven there.
+  isActiveSelection: vi.fn(
+    (sel: { networkSlug: string; channelName: string; kind: string } | null) => {
+      const active = fixture.active;
+      return (
+        sel !== null &&
+        active !== null &&
+        sel.networkSlug === active.networkSlug &&
+        sel.channelName === active.channelName &&
+        sel.kind === active.kind
+      );
+    },
+  ),
+  selectedChannel: vi.fn(() => fixture.active),
+  setSelectedChannel: vi.fn(),
+}));
+
+vi.mock("../lib/documentVisibility", () => ({
+  isDocumentVisible: vi.fn(() => fixture.visible),
+}));
+
+vi.mock("../lib/networks", () => ({
+  networkBySlug: vi.fn((slug: string) =>
+    slug === "libera" ? { id: 1, slug: "libera", kind: "user" } : undefined,
+  ),
+  channelsBySlug: vi.fn(() => ({})),
+  networks: vi.fn(() => []),
+  networkIdBySlug: () => undefined,
+}));
+
+// The open query window spells the peer `alice`; the wire spells it
+// `Alice`. `canonicalQueryNick` is the store verb that resolves one to the
+// other — it returns the OPEN window's stored `targetNick` on a
+// casemapping-aware match, so the lowercasing stub here stands in for a
+// window that was first opened as `alice`.
+vi.mock("../lib/queryWindows", () => ({
+  openQueryWindowState: vi.fn(),
+  canonicalQueryNick: vi.fn((_networkId: number, nick: string) => nick.toLowerCase()),
+}));
+
+type FakeNotification = { data: unknown; close: ReturnType<typeof vi.fn> };
+
+const notification = (url: string | undefined): FakeNotification => ({
+  data: url === undefined ? null : { url },
+  close: vi.fn(),
+});
+
+const originalSW = (navigator as Navigator & { serviceWorker?: unknown }).serviceWorker;
+
+function installFakeServiceWorker(notifications: FakeNotification[]): {
+  getNotifications: ReturnType<typeof vi.fn>;
+} {
+  const getNotifications = vi.fn().mockResolvedValue(notifications);
+  Object.defineProperty(navigator, "serviceWorker", {
+    configurable: true,
+    value: {
+      getRegistration: vi.fn().mockResolvedValue({ getNotifications }),
+      addEventListener: vi.fn(),
+    },
+  });
+  return { getNotifications };
+}
+
+function restoreServiceWorker(): void {
+  if (originalSW === undefined) {
+    // biome-ignore lint/performance/noDelete: test cleanup
+    delete (navigator as unknown as { serviceWorker?: unknown }).serviceWorker;
+    return;
+  }
+  Object.defineProperty(navigator, "serviceWorker", {
+    configurable: true,
+    value: originalSW,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fixture.visible = true;
+  fixture.active = { ...FOCUSED_CHANNEL };
+});
+
+afterEach(restoreServiceWorker);
+
+describe("dismissNotificationsForActiveWindow", () => {
+  it("closes the notifications naming the focused channel and leaves the others", async () => {
+    const mine = notification("/?network=libera&channel=%23sniffo");
+    const elsewhere = notification("/?network=libera&channel=%23other");
+    const otherNetwork = notification("/?network=azzurra&channel=%23sniffo");
+    installFakeServiceWorker([mine, elsewhere, otherNetwork]);
+
+    const closed = await dismissNotificationsForActiveWindow();
+
+    expect(mine.close).toHaveBeenCalledTimes(1);
+    expect(elsewhere.close).not.toHaveBeenCalled();
+    expect(otherNetwork.close).not.toHaveBeenCalled();
+    expect(closed).toBe(1);
+  });
+
+  it("resolves the RAW wire nick of a DM to the window spelling before comparing", async () => {
+    // The focused window is the query `alice`; the payload spells the peer
+    // `Alice`, because the server keeps `sender` raw for display.
+    fixture.active = { networkSlug: "libera", channelName: "alice", kind: "query" };
+    const dm = notification("/?network=libera&channel=Alice");
+    installFakeServiceWorker([dm]);
+
+    await dismissNotificationsForActiveWindow();
+
+    expect(dm.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a notification whose data carries no usable URL", async () => {
+    const dataless = notification(undefined);
+    const malformed = notification("/?network=libera");
+    installFakeServiceWorker([dataless, malformed]);
+
+    const closed = await dismissNotificationsForActiveWindow();
+
+    expect(dataless.close).not.toHaveBeenCalled();
+    expect(malformed.close).not.toHaveBeenCalled();
+    expect(closed).toBe(0);
+  });
+
+  it("does nothing while the document is not visible", async () => {
+    fixture.visible = false;
+    const mine = notification("/?network=libera&channel=%23sniffo");
+    const { getNotifications } = installFakeServiceWorker([mine]);
+
+    const closed = await dismissNotificationsForActiveWindow();
+
+    // Not merely "closes nothing": the shade is never enumerated, so a
+    // backgrounded tab costs no service-worker round-trip on unrelated
+    // churn — and a hidden tab is exactly where the notification is still
+    // doing its job.
+    expect(getNotifications).not.toHaveBeenCalled();
+    expect(mine.close).not.toHaveBeenCalled();
+    expect(closed).toBe(0);
+  });
+
+  it("is a no-op without a service worker registration", async () => {
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: { getRegistration: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    await expect(dismissNotificationsForActiveWindow()).resolves.toBe(0);
+  });
+
+  it("is a no-op when the service worker API is absent altogether", async () => {
+    // biome-ignore lint/performance/noDelete: test setup
+    delete (navigator as unknown as { serviceWorker?: unknown }).serviceWorker;
+
+    await expect(dismissNotificationsForActiveWindow()).resolves.toBe(0);
+  });
+});
+
+describe("installNotificationDismiss", () => {
+  it("sweeps on pageshow — the resume that reports no visibility change", async () => {
+    const mine = notification("/?network=libera&channel=%23sniffo");
+    const { getNotifications } = installFakeServiceWorker([mine]);
+
+    installNotificationDismiss();
+    // The install sweeps once on its own (the window is visible and a
+    // conversation is focused the moment the effect runs). Let that settle
+    // before asking whether `pageshow` sweeps AGAIN, or the assertion
+    // passes on the wrong call.
+    await vi.waitFor(() => expect(mine.close).toHaveBeenCalledTimes(1));
+    getNotifications.mockClear();
+    mine.close.mockClear();
+
+    window.dispatchEvent(new Event("pageshow"));
+    // Wait on the CLOSE rather than the enumeration: the sweep awaits the
+    // registration and then the notification list before it closes
+    // anything, so a wait that stops at `getNotifications` stops two
+    // microtask turns early.
+    await vi.waitFor(() => expect(mine.close).toHaveBeenCalledTimes(1));
+
+    expect(getNotifications).toHaveBeenCalledTimes(1);
+  });
+});

--- a/cicchetto/src/__tests__/notificationDismiss.test.ts
+++ b/cicchetto/src/__tests__/notificationDismiss.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   dismissNotificationsForActiveWindow,
   installNotificationDismiss,
@@ -15,30 +15,45 @@ import {
 // prove. The DM case below is why the identity step exists at all: the
 // notification carries the RAW wire nick `Alice` while the focused window
 // is `alice`, so a byte compare would leave it sitting in the shade.
+//
+// The two store stubs are REAL Solid signals, not `vi.fn` returning a
+// fixture field, and that is load-bearing rather than tidy (review,
+// 2026-09-10). `installNotificationDismiss` is a `createEffect` over
+// `selectedChannel()` and `isDocumentVisible()`; a plain function stub
+// notifies nothing, so the effect can never re-run and the window-switch
+// trigger — the PRIMARY user story in the issue — is untestable. With
+// signals, the mutant `untrack(selectedChannel)` in the effect kills the
+// window-switch arm below. Without them it passes everything.
 
-// The fixture's whole mutable world: which window is focused, and whether
-// the document is visible. Hoisted because the `vi.mock` factories close
-// over it, and reset in `beforeEach` — an implementation swapped in by one
-// test is exactly the leak that made the pageshow arm below pass for the
-// wrong reason while it was being written.
+type Sel = { networkSlug: string; channelName: string; kind: string } | null;
+
+const FOCUSED_CHANNEL: Sel = { networkSlug: "libera", channelName: "#sniffo", kind: "channel" };
+
+// The factories below write the real accessors/setters back into this
+// object, so the tests drive the stores the way production code does.
 const fixture = vi.hoisted(() => ({
-  visible: true,
-  active: { networkSlug: "libera", channelName: "#sniffo", kind: "channel" } as {
-    networkSlug: string;
-    channelName: string;
-    kind: string;
-  } | null,
+  selection: (() => null as Sel) as () => Sel,
+  setSelection: ((_next: Sel) => undefined) as (next: Sel) => void,
+  visible: (() => true) as () => boolean,
+  setVisible: ((_next: boolean) => undefined) as (next: boolean) => void,
 }));
 
-const FOCUSED_CHANNEL = { networkSlug: "libera", channelName: "#sniffo", kind: "channel" };
-
-vi.mock("../lib/selection", () => ({
-  // Stands in for the real exact-tuple compare (#243 `isActiveSelection`,
-  // which folds the channel KEY on the way in). Byte-equal here: the fold
-  // is selection.ts's contract and is proven there.
-  isActiveSelection: vi.fn(
-    (sel: { networkSlug: string; channelName: string; kind: string } | null) => {
-      const active = fixture.active;
+vi.mock("../lib/selection", async () => {
+  const { createSignal, untrack } = await import("solid-js");
+  const [selection, setSelection] = createSignal<Sel>({
+    networkSlug: "libera",
+    channelName: "#sniffo",
+    kind: "channel",
+  });
+  fixture.selection = selection;
+  fixture.setSelection = (next) => setSelection(() => next);
+  return {
+    // Stands in for the real exact-tuple compare (#243 `isActiveSelection`),
+    // including its `untrack` — the production comparator must not subscribe
+    // its caller to the selection. Byte-equal here: the channel fold it
+    // applies is selection.ts's contract and is proven there.
+    isActiveSelection: vi.fn((sel: Sel) => {
+      const active = untrack(selection);
       return (
         sel !== null &&
         active !== null &&
@@ -46,15 +61,19 @@ vi.mock("../lib/selection", () => ({
         sel.channelName === active.channelName &&
         sel.kind === active.kind
       );
-    },
-  ),
-  selectedChannel: vi.fn(() => fixture.active),
-  setSelectedChannel: vi.fn(),
-}));
+    }),
+    selectedChannel: selection,
+    setSelectedChannel: vi.fn(),
+  };
+});
 
-vi.mock("../lib/documentVisibility", () => ({
-  isDocumentVisible: vi.fn(() => fixture.visible),
-}));
+vi.mock("../lib/documentVisibility", async () => {
+  const { createSignal } = await import("solid-js");
+  const [visible, setVisible] = createSignal(true);
+  fixture.visible = visible;
+  fixture.setVisible = (next) => setVisible(() => next);
+  return { isDocumentVisible: visible };
+});
 
 vi.mock("../lib/networks", () => ({
   networkBySlug: vi.fn((slug: string) =>
@@ -84,10 +103,14 @@ const notification = (url: string | undefined): FakeNotification => ({
 
 const originalSW = (navigator as Navigator & { serviceWorker?: unknown }).serviceWorker;
 
-function installFakeServiceWorker(notifications: FakeNotification[]): {
-  getNotifications: ReturnType<typeof vi.fn>;
-} {
-  const getNotifications = vi.fn().mockResolvedValue(notifications);
+function installFakeServiceWorker(
+  notifications: FakeNotification[],
+  onEnumerate?: () => void,
+): { getNotifications: ReturnType<typeof vi.fn> } {
+  const getNotifications = vi.fn(() => {
+    onEnumerate?.();
+    return Promise.resolve(notifications);
+  });
   Object.defineProperty(navigator, "serviceWorker", {
     configurable: true,
     value: {
@@ -112,8 +135,8 @@ function restoreServiceWorker(): void {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  fixture.visible = true;
-  fixture.active = { ...FOCUSED_CHANNEL };
+  fixture.setVisible(true);
+  fixture.setSelection({ ...FOCUSED_CHANNEL } as Sel);
 });
 
 afterEach(restoreServiceWorker);
@@ -136,7 +159,7 @@ describe("dismissNotificationsForActiveWindow", () => {
   it("resolves the RAW wire nick of a DM to the window spelling before comparing", async () => {
     // The focused window is the query `alice`; the payload spells the peer
     // `Alice`, because the server keeps `sender` raw for display.
-    fixture.active = { networkSlug: "libera", channelName: "alice", kind: "query" };
+    fixture.setSelection({ networkSlug: "libera", channelName: "alice", kind: "query" });
     const dm = notification("/?network=libera&channel=Alice");
     installFakeServiceWorker([dm]);
 
@@ -158,7 +181,7 @@ describe("dismissNotificationsForActiveWindow", () => {
   });
 
   it("does nothing while the document is not visible", async () => {
-    fixture.visible = false;
+    fixture.setVisible(false);
     const mine = notification("/?network=libera&channel=%23sniffo");
     const { getNotifications } = installFakeServiceWorker([mine]);
 
@@ -170,6 +193,21 @@ describe("dismissNotificationsForActiveWindow", () => {
     // doing its job.
     expect(getNotifications).not.toHaveBeenCalled();
     expect(mine.close).not.toHaveBeenCalled();
+    expect(closed).toBe(0);
+  });
+
+  it("closes nothing when the document goes away between the gate and the act", async () => {
+    // The race the second review found: `getRegistration()` and
+    // `getNotifications()` are IPC round-trips, so the document can be gone
+    // by the time the list comes back — and anything shown inside that
+    // window is unread by construction. The stub hides the document during
+    // the enumeration, exactly where a real push would land.
+    const arrived = notification("/?network=libera&channel=%23sniffo");
+    installFakeServiceWorker([arrived], () => fixture.setVisible(false));
+
+    const closed = await dismissNotificationsForActiveWindow();
+
+    expect(arrived.close).not.toHaveBeenCalled();
     expect(closed).toBe(0);
   });
 
@@ -191,18 +229,44 @@ describe("dismissNotificationsForActiveWindow", () => {
 });
 
 describe("installNotificationDismiss", () => {
+  // Installed ONCE for the whole block: the effect and the `pageshow`
+  // listener are never disposed, so a per-test install would stack sweeps
+  // and make the call counts meaningless. Each test brings its own fake
+  // registration, which is what the sweep reads at call time.
+  beforeAll(() => {
+    installNotificationDismiss();
+  });
+
+  it("sweeps when the reader switches to the conversation while visible", async () => {
+    // THE user story: the reader is already looking at the app and moves to
+    // the window a banner belongs to. The banner names `#other` and the
+    // focused window is `#sniffo`, so no stray sweep can close it before the
+    // switch — only the switch itself can.
+    const other = notification("/?network=libera&channel=%23other");
+    installFakeServiceWorker([other]);
+
+    fixture.setSelection({ networkSlug: "libera", channelName: "#other", kind: "channel" });
+
+    await vi.waitFor(() => expect(other.close).toHaveBeenCalled());
+  });
+
+  it("sweeps when the tab comes back into view", async () => {
+    fixture.setVisible(false);
+    const mine = notification("/?network=libera&channel=%23sniffo");
+    installFakeServiceWorker([mine]);
+
+    fixture.setVisible(true);
+
+    await vi.waitFor(() => expect(mine.close).toHaveBeenCalled());
+  });
+
   it("sweeps on pageshow — the resume that reports no visibility change", async () => {
     const mine = notification("/?network=libera&channel=%23sniffo");
     const { getNotifications } = installFakeServiceWorker([mine]);
-
-    installNotificationDismiss();
-    // The install sweeps once on its own (the window is visible and a
-    // conversation is focused the moment the effect runs). Let that settle
-    // before asking whether `pageshow` sweeps AGAIN, or the assertion
-    // passes on the wrong call.
-    await vi.waitFor(() => expect(mine.close).toHaveBeenCalledTimes(1));
-    getNotifications.mockClear();
-    mine.close.mockClear();
+    // Nothing else can sweep from here: the registration is installed AFTER
+    // the `beforeEach` selection reset, and no signal changes below. So the
+    // enumeration that follows is `pageshow`'s and only `pageshow`'s.
+    expect(getNotifications).not.toHaveBeenCalled();
 
     window.dispatchEvent(new Event("pageshow"));
     // Wait on the CLOSE rather than the enumeration: the sweep awaits the

--- a/cicchetto/src/lib/notificationDismiss.ts
+++ b/cicchetto/src/lib/notificationDismiss.ts
@@ -1,0 +1,132 @@
+// #2034 — the other half of the notification lifecycle: a notification
+// leaves the shade when its conversation comes back into view, not only
+// when it is tapped.
+//
+// The tap half has always been there (`notificationclick` calls
+// `event.notification.close()` in `service-worker.ts`). Nothing ever took
+// a notification BACK, so reading a conversation in the app left its
+// banners sitting in the shade, and a later tap yanked the reader to a
+// window they had caught up with minutes ago.
+//
+// The whole mechanism is a sweep: enumerate what the registration is
+// currently showing, resolve each notification to the WINDOW it names,
+// close the ones naming the focused window. No new state, no new server
+// field, no bookkeeping to drift — the notification's own `data.url` is
+// the identity, and the selection store is the "what is the reader
+// looking at" oracle both this module and `pushTarget.ts` already read.
+//
+// Deliberately NOT keyed on the payload `tag`. `getNotifications({ tag })`
+// needs the tag SPELLED client-side, which means a second copy of
+// `Grappa.Push.Payload`'s format — and it would be a WRONG copy for DMs,
+// where the server tags with the raw wire nick (`libera:Alice`) while the
+// selection store holds the canonical window nick (`alice`). Filtering by
+// an exact-match tag we cannot construct correctly closes nothing. The URL
+// is already parsed by `parsePushTargetUrl` for the tap path, so reusing
+// it costs one function call and keeps ONE spelling of push identity.
+//
+// Presence banners (`<slug>:presence:<nick>`, #378) deep-link to the same
+// `?network=&channel=` shape, so opening a peer's query also clears their
+// online/offline banner. That falls out of matching on the window rather
+// than the tag, and it is the same rule stated for messages: close what
+// the reader is looking at.
+
+import { createEffect } from "solid-js";
+import { isDocumentVisible } from "./documentVisibility";
+import { moduleRoot } from "./moduleRoot";
+import { parsePushTargetUrl } from "./pushPayload";
+import { pushTargetSelection } from "./pushTarget";
+import { isActiveSelection, selectedChannel } from "./selection";
+
+/**
+ * Closes every open notification that names the window currently in view.
+ * Returns how many were closed (0 on every no-op path) — the count is what
+ * the spec asserts against, and it keeps the function honest about doing
+ * nothing.
+ *
+ * No-ops when the document is not visible, WITHOUT enumerating: a
+ * backgrounded tab must not be walking the shade on unrelated churn, and
+ * "not visible" is exactly the state in which the notification is still
+ * doing its job.
+ *
+ * `getRegistration()` rather than `serviceWorker.ready` (which `push.ts`
+ * uses): `ready` NEVER settles when no service worker is registered, and
+ * this runs on every focus flip and every window switch, so a browser with
+ * SW disabled would accumulate one dangling promise per sweep for the life
+ * of the session. `getRegistration()` resolves to `undefined` and the
+ * sweep ends.
+ */
+export async function dismissNotificationsForActiveWindow(): Promise<number> {
+  if (!isDocumentVisible()) return 0;
+  if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return 0;
+
+  const registration = await navigator.serviceWorker.getRegistration();
+  if (registration === undefined) return 0;
+
+  const open = await registration.getNotifications();
+  let closed = 0;
+  for (const notification of open) {
+    if (!namesActiveWindow(notification)) continue;
+    notification.close();
+    closed += 1;
+  }
+  return closed;
+}
+
+/**
+ * True iff `notification` deep-links to the window already in view.
+ *
+ * A notification with no usable `data.url` — a shape from a future server,
+ * or one shown by something other than the push handler — is left alone.
+ * Unrecognised is never fatal, and leaving a banner up is the harmless
+ * direction of that error: the reader can still dismiss it by hand,
+ * whereas closing on a guess destroys a notification nobody read.
+ */
+function namesActiveWindow(notification: Notification): boolean {
+  const data = notification.data as { url?: unknown } | null | undefined;
+  const url = data?.url;
+  if (typeof url !== "string") return false;
+
+  const target = parsePushTargetUrl(url);
+  if (target === null) return false;
+
+  // Through the SAME identity mapping the tap path uses, so "the window
+  // this notification opens" and "the window this notification is dismissed
+  // by" cannot drift apart.
+  return isActiveSelection(pushTargetSelection(target));
+}
+
+/**
+ * Wires the sweep to the moments a conversation can come into view.
+ * Mounted at boot from `main.tsx`, alongside `installPushTargetListener`.
+ *
+ * Two triggers, because one signal does not cover the PWA:
+ *
+ *   * the reactive arm — `isDocumentVisible()` (visibilitychange + window
+ *     focus/blur) crossed with `selectedChannel()`. This is both halves of
+ *     "the conversation is in view": the tab came back, or the reader
+ *     switched windows while it was already in front of them.
+ *   * `pageshow` — an iOS PWA frequently thaws from a frozen document
+ *     without reporting a visibility transition, so the reactive arm never
+ *     re-runs (`resumeProbe.ts` / `DiagFloat.tsx` arm on the same pair for
+ *     the same reason). The sweep is idempotent, so the overlap between
+ *     the two triggers costs nothing.
+ *
+ * Fire-and-forget: a rejected sweep must not take down the caller's
+ * effect, and there is nothing to recover — the next visibility flip
+ * sweeps again.
+ */
+export function installNotificationDismiss(): void {
+  moduleRoot(() => {
+    createEffect(() => {
+      const selection = selectedChannel();
+      if (!isDocumentVisible()) return;
+      if (selection === null) return;
+      void dismissNotificationsForActiveWindow().catch(() => undefined);
+    });
+  });
+
+  if (typeof window === "undefined") return;
+  window.addEventListener("pageshow", () => {
+    void dismissNotificationsForActiveWindow().catch(() => undefined);
+  });
+}

--- a/cicchetto/src/lib/notificationDismiss.ts
+++ b/cicchetto/src/lib/notificationDismiss.ts
@@ -48,6 +48,19 @@ import { isActiveSelection, selectedChannel } from "./selection";
  * "not visible" is exactly the state in which the notification is still
  * doing its job.
  *
+ * Visibility is checked TWICE, and the second check is the load-bearing one
+ * (review, 2026-09-10). `getRegistration()` and `getNotifications()` are IPC
+ * round-trips to the service worker, not microtasks, so the window between
+ * asking and acting is real: a reader who switches to `#sniffo` and then
+ * locks the phone can have a push for `#sniffo` land and be SHOWN inside
+ * that window — the suppression gate is leaky in exactly this direction
+ * (`shouldSuppressPush`'s own note on iOS `clients.matchAll`, plus the
+ * deliver-leaning server default of #182). The list then comes back holding
+ * a brand-new banner, the selection has not changed, and a single-check
+ * sweep closes a notification the reader never saw. That inverts this
+ * module's whole posture, so the precondition is re-established immediately
+ * before it is acted on rather than only when it was first asked.
+ *
  * `getRegistration()` rather than `serviceWorker.ready` (which `push.ts`
  * uses): `ready` NEVER settles when no service worker is registered, and
  * this runs on every focus flip and every window switch, so a browser with
@@ -63,6 +76,10 @@ export async function dismissNotificationsForActiveWindow(): Promise<number> {
   if (registration === undefined) return 0;
 
   const open = await registration.getNotifications();
+  // See the moduledoc above: the document may have gone away across the two
+  // awaits, and anything shown in that window is unread by construction.
+  if (!isDocumentVisible()) return 0;
+
   let closed = 0;
   for (const notification of open) {
     if (!namesActiveWindow(notification)) continue;

--- a/cicchetto/src/lib/pushTarget.ts
+++ b/cicchetto/src/lib/pushTarget.ts
@@ -86,8 +86,18 @@ function routePushTarget(target: PushTarget): void {
  * CANONICAL nick — whatever spelling the open query window already uses.
  * `Alice` on the wire is the window `alice`, and a byte compare of the two
  * answers "different window" for the very notification the reader is
- * looking at. Channels need no step here: `setSelectedChannel` folds the
- * channel KEY itself (`foldChannelKey`, #1396), so both sides arrive folded.
+ * looking at.
+ *
+ * Channels need no step here, and the reason is worth stating precisely,
+ * because the obvious one is wrong for half the callers (review,
+ * 2026-09-10). It is NOT that `setSelectedChannel` folds the channel KEY on
+ * the way in — it does (`foldChannelKey`, #1396), but only the FORWARD path
+ * reaches the setter; the backward path never calls it. What covers BOTH
+ * directions is `isActiveSelection`, which runs its own argument through the
+ * same `foldChannelKey` before comparing. So the fold that makes this
+ * function safe to skip for channels lives in `selection.ts`'s comparator,
+ * not in its setter — removing it there would silently break the dismissal
+ * while every forward-path test stayed green.
  *
  * Total: an unresolvable network yields the raw name rather than null, so
  * a stale deep-link degrades to a best-effort match instead of a crash.

--- a/cicchetto/src/lib/pushTarget.ts
+++ b/cicchetto/src/lib/pushTarget.ts
@@ -29,7 +29,7 @@ import { moduleRoot } from "./moduleRoot";
 import { channelsBySlug, networkBySlug, networks } from "./networks";
 import { type PushTarget, parsePushTargetUrl } from "./pushPayload";
 import { canonicalQueryNick, openQueryWindowState } from "./queryWindows";
-import { setSelectedChannel } from "./selection";
+import { type SelectedChannel, setSelectedChannel } from "./selection";
 
 /**
  * Routes a parsed push target into the selection store.
@@ -54,28 +54,60 @@ import { setSelectedChannel } from "./selection";
  * between them.
  */
 function routePushTarget(target: PushTarget): void {
+  const selection = pushTargetSelection(target);
+  if (selection.kind === "query") {
+    const net = networkBySlug(target.networkSlug);
+    // Network not resolvable (stale deep-link to an unbound network): no
+    // query window to open, and `pushTargetSelection` has already fallen
+    // back to the raw nick. The select below is still best-effort — the
+    // selection store's bucket-E picker only fires on a was-live→not-live
+    // transition, so a fresh not-live selection is not clobbered.
+    if (net !== undefined) {
+      openQueryWindowState(net.id, selection.channelName, new Date().toISOString());
+    }
+  }
+  setSelectedChannel(selection);
+}
+
+/**
+ * THE push-target → window-identity mapping, shared by the two directions
+ * a notification travels (#2034).
+ *
+ * `routePushTarget` walks it forwards (a tapped notification names the
+ * window to focus); `notificationDismiss.ts` walks it backwards (an OPEN
+ * notification is asked whether it names the window already focused). Both
+ * must agree on what "the same window" means, so the canonicalisation lives
+ * here once rather than being spelled twice.
+ *
+ * The mapping is not the identity function, and that is the whole reason
+ * this is extracted rather than inlined. A DM payload carries the peer nick
+ * RAW as the server saw it on the wire (`Push.Payload.build/3` uses
+ * `sender`, per the key/display split), while the selection store holds the
+ * CANONICAL nick — whatever spelling the open query window already uses.
+ * `Alice` on the wire is the window `alice`, and a byte compare of the two
+ * answers "different window" for the very notification the reader is
+ * looking at. Channels need no step here: `setSelectedChannel` folds the
+ * channel KEY itself (`foldChannelKey`, #1396), so both sides arrive folded.
+ *
+ * Total: an unresolvable network yields the raw name rather than null, so
+ * a stale deep-link degrades to a best-effort match instead of a crash.
+ */
+export function pushTargetSelection(target: PushTarget): NonNullable<SelectedChannel> {
   if (target.kind === "query") {
     const net = networkBySlug(target.networkSlug);
     if (net !== undefined) {
-      const canonical = canonicalQueryNick(net.id, target.channelName);
-      openQueryWindowState(net.id, canonical, new Date().toISOString());
-      setSelectedChannel({
+      return {
         networkSlug: target.networkSlug,
-        channelName: canonical,
+        channelName: canonicalQueryNick(net.id, target.channelName),
         kind: "query",
-      });
-      return;
+      };
     }
-    // Network not resolvable (stale deep-link to an unbound network):
-    // fall through to a best-effort plain select. The selection store's
-    // bucket-E picker only fires on a was-live→not-live transition, so a
-    // fresh not-live selection is not clobbered.
   }
-  setSelectedChannel({
+  return {
     networkSlug: target.networkSlug,
     channelName: target.channelName,
     kind: target.kind,
-  });
+  };
 }
 
 /**

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -29,6 +29,7 @@ import { installGlobalPaste } from "./lib/globalPaste";
 import { HIDDEN_TICK_MS, installHiddenProbe } from "./lib/hiddenProbe";
 import { installKeyboardPreserve } from "./lib/keepKeyboard";
 import { refetchChannels, refetchNetworks } from "./lib/networks";
+import { installNotificationDismiss } from "./lib/notificationDismiss";
 import { applyIosClass, isStandalonePwa } from "./lib/platform";
 import { installPushResubscribe } from "./lib/pushResubscribe";
 import { applyDeepLinkFromUrl, installPushTargetListener } from "./lib/pushTarget";
@@ -203,6 +204,15 @@ bootstrapAuth();
 // is what lets an invite survive the login round-trip.
 installPushTargetListener();
 applyDeepLinkFromUrl();
+
+// #2034 — the OTHER half of the notification lifecycle, mounted next to the
+// tap path it completes. A tap has always closed its notification; nothing
+// ever closed one because the reader caught up in the app, so the shade kept
+// banners for conversations that were read minutes ago and a later tap
+// yanked the reader back to them. `installNotificationDismiss` sweeps the
+// open notifications whenever a conversation comes into view and closes the
+// ones naming it. See `lib/notificationDismiss.ts`.
+installNotificationDismiss();
 
 // #1103 — the THIRD boot-time shape, and the only one that is not a link: the
 // OS share sheet POSTs files at the service worker, which stashes them and

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52102,3 +52102,99 @@ produces that source and the ambient sweepers are its scheduled caller, but
 their cadence is 24h under `config/test.exs`, so naming one would be a guess.
 The fix does not depend on the answer: the window is closed to every emitter
 that is not this test, whoever it was.
+<!-- entry #2034 -->
+
+---
+
+## 2026-09-10 — #2034: a notification is dismissed by READING the conversation, not only by tapping it
+
+The tap half shipped with the deep-link work: `notificationclick` calls
+`event.notification.close()`. The other half never existed —
+`getNotifications()` had zero occurrences in the whole cicchetto tree, so once
+a banner was on screen nothing ever took it back. Reading a conversation in
+the app left its banners in the shade, and a later tap yanked the reader to a
+window they had caught up with minutes ago.
+
+`lib/notificationDismiss.ts` is the missing half: on every moment a
+conversation can come into view, enumerate what the registration is showing
+and close the notifications naming the focused window. No new state, no new
+server field, no bookkeeping to drift.
+
+### Matching on the URL, not on the `tag` — and it is a correctness argument
+
+The obvious shape is the one the issue proposed: `getNotifications({ tag })`
+for the active conversation's tag. It does not work, and the reason is the
+key/display split rather than taste.
+
+`getNotifications({ tag })` filters by EXACT string, so the client has to
+SPELL the tag — a second copy of `Grappa.Push.Payload`'s
+`"<slug>:<channel_or_dm_peer>"` format living in cic. For channels the copy
+would be right by luck (both sides fold). For a DM it is wrong by
+construction: the server tags with `sender` RAW (`libera:Alice`), because a
+nick's case is presentation and the payload keeps it, while the selection
+store holds the CANONICAL window nick (`alice`). A filter built from the
+selection asks for `libera:alice`, matches nothing, and closes nothing —
+silently, in exactly the case DMs make most common.
+
+So the match runs the other way: each open notification is resolved through
+its own `data.url` — the deep link it would follow if tapped — by the
+`parsePushTargetUrl` that the tap path already uses. That makes the identity
+question one question with one answer, asked in two directions.
+
+`pushTargetSelection/1` is the extraction that makes "one answer" literal.
+`routePushTarget` walks the mapping forwards (a tapped notification names the
+window to focus); the sweep walks it backwards (an open notification is asked
+whether it names the window already focused). Both go through the same
+`canonicalQueryNick` step, so the tap and the dismissal cannot disagree about
+which window a notification belongs to. Channels need no step there —
+`setSelectedChannel` folds the channel KEY itself (#1396) — which is precisely
+why the DM arm is the one carrying a test.
+
+**Presence banners fall out for free, and that is the intended reading.**
+`build_presence/3` deep-links to the same `?network=&channel=` shape, so
+opening a peer's query also clears their online/offline banner. A tag filter
+would have had to be taught this; matching on the window means the rule is
+stated once — close what the reader is looking at — and both banner kinds obey
+it.
+
+### Two triggers, and one API choice
+
+The reactive arm is `isDocumentVisible()` crossed with `selectedChannel()`:
+that pair IS "the conversation is in view", covering both the tab coming back
+and the reader switching windows while it is already in front of them.
+`pageshow` is the second trigger for the reason `resumeProbe.ts` and
+`DiagFloat.tsx` already carry it — an iOS PWA frequently thaws without
+reporting a visibility transition, so the reactive arm never re-runs. The
+sweep is idempotent, so the overlap costs nothing.
+
+`getRegistration()`, not `serviceWorker.ready` (which `push.ts` uses).
+`ready` NEVER settles when no service worker is registered, and this runs on
+every focus flip and every window switch rather than once at opt-in — a
+browser with SW disabled would accumulate one dangling promise per sweep for
+the life of the session. `getRegistration()` resolves to `undefined` and the
+sweep ends.
+
+The sweep does not enumerate at all while the document is hidden. Not an
+optimisation: a hidden tab is exactly where a notification is still doing its
+job, so "visible" is a precondition of the whole operation rather than a
+filter applied to its results.
+
+**No e2e, and the ceiling is the harness rather than the effort.**
+`self.registration.showNotification(...)` rejects under headless Playwright
+with "No notification permission has been granted for this origin" even after
+`context.grantPermissions(["notifications"])` — the finding `e2e/fixtures/
+pushTap.ts` already documents for the TAP path, which is why that path is
+driven through the cold deep-link and a replayed `navigate` message instead of
+a real `NotificationEvent`. A dismissal test needs a notification that EXISTS,
+so it hits the same wall one step earlier: with nothing shown,
+`getNotifications()` returns an empty list and the sweep would pass while
+closing nothing. vitest is therefore the ceiling here, and the spec pays for it
+by asserting the DM canonicalisation directly.
+
+_Not covered: a notification that arrives WHILE its conversation is open and
+visible. `shouldSuppressPush()` already gates that toast at the service
+worker, so the case is handled one layer up; wiring the sweep into the push
+handler as well would add a trigger for a state that should not occur. A
+notification with no usable `data.url` is left alone rather than closed on a
+guess — unrecognised is never fatal, and leaving a banner up is the harmless
+direction of that error._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52146,9 +52146,15 @@ question one question with one answer, asked in two directions.
 window to focus); the sweep walks it backwards (an open notification is asked
 whether it names the window already focused). Both go through the same
 `canonicalQueryNick` step, so the tap and the dismissal cannot disagree about
-which window a notification belongs to. Channels need no step there —
-`setSelectedChannel` folds the channel KEY itself (#1396) — which is precisely
-why the DM arm is the one carrying a test.
+which window a notification belongs to. Channels need no step there, and the
+reason matters more than the fact (review, 2026-09-10): it is NOT that
+`setSelectedChannel` folds the channel KEY on the way in. It does (#1396), but
+only the FORWARD path reaches the setter — the sweep never calls it. What
+covers BOTH directions is `isActiveSelection`, which runs its own argument
+through the same `foldChannelKey` before comparing. The distinction is not
+pedantry: a later reader who drops the fold from the comparator, believing the
+setter covers it, breaks the dismissal while every forward-path test stays
+green. That asymmetry is also why the DM arm is the one carrying a test.
 
 **Presence banners fall out for free, and that is the intended reading.**
 `build_presence/3` deep-links to the same `?network=&channel=` shape, so
@@ -52191,10 +52197,70 @@ so it hits the same wall one step earlier: with nothing shown,
 closing nothing. vitest is therefore the ceiling here, and the spec pays for it
 by asserting the DM canonicalisation directly.
 
-_Not covered: a notification that arrives WHILE its conversation is open and
-visible. `shouldSuppressPush()` already gates that toast at the service
-worker, so the case is handled one layer up; wiring the sweep into the push
-handler as well would add a trigger for a state that should not occur. A
-notification with no usable `data.url` is left alone rather than closed on a
+### The residual: a notification arriving while its conversation is in view
+
+All three triggers are TRANSITIONS — a visibility flip, a selection change, a
+`pageshow`. None of them fires when the reader is already looking at the window
+and the banner appears underneath it. That case is not handled here, and the
+first draft of this entry claimed it was "handled one layer up" by
+`shouldSuppressPush()` and called it "a state that should not occur". **Both
+halves of that were wrong, and this tree says so in writing.**
+`service-worker.ts` records that `clients.matchAll` visibility is UNRELIABLE on
+iOS PWAs — an empty or non-"visible" client list while foregrounded — and #182
+leaves the server-side gate deliver-leaning in the just-connected window on
+every platform. So the residual lands precisely on the device this feature
+exists for. Two independent blind reviews found it from those same two pieces
+of evidence without reading each other, which is the strongest signal available
+here that it is real rather than theoretical.
+
+The mechanism is deferred, not denied: one `postMessage` from the push handler
+to the visible client, or a sweep at the tail of `handlePush`, closes it. What
+is NOT known — and would move the severity in either direction — is whether an
+iOS banner over a foregrounded PWA produces a blur/focus pair at all. If it
+does, `isDocumentVisible()` flips and the reactive arm already self-heals the
+whole case on that platform. The tree carries no note either way and no device
+was measured.
+
+### The race between asking and acting
+
+`getRegistration()` and `getNotifications()` are IPC round-trips to the service
+worker, not microtasks, so the gap between reading `isDocumentVisible()` and
+closing anything is real wall-clock time. A reader who switches to `#sniffo`
+and then locks the phone can have a push for `#sniffo` land and be SHOWN inside
+that gap — the suppression gate being leaky in exactly that direction, per
+above. The list then comes back holding a brand-new banner, the selection has
+not changed, and a single-check sweep closes a notification the reader never
+saw.
+
+That is the one failure mode here that DESTROYS information rather than
+withholding it, and it inverts the module's own posture ("a hidden tab is
+exactly where a notification is still doing its job"). The cure is to
+re-establish the precondition immediately before acting on it rather than only
+when it was first asked. Structural, not observed: no instrumentation says this
+has fired in the field.
+
+### Two known approximations, stated so they are not rediscovered as bugs
+
+`parsePushTargetUrl` decides channel-vs-query from four hardcoded RFC-2812
+sigils (`# & ! +`) and ignores the network's advertised CHANTYPES, though
+`lib/chantypes.ts` exists. On a network advertising an exotic chantype a
+channel notification is classified as a query, gets `canonicalQueryNick`
+applied, is compared against a channel selection, and is never dismissed. That
+is pre-existing tap-path behaviour; what changed here is that the same
+approximate parse became load-bearing in a SECOND direction.
+
+A notification with no usable `data.url` is left alone rather than closed on a
 guess — unrecognised is never fatal, and leaving a banner up is the harmless
-direction of that error._
+direction of that error, whereas closing on a guess destroys a notification
+nobody read.
+
+### What was checked and cleared
+
+"The shade empties but the badge does not" is the obvious fear and it does not
+land: `lib/badge.ts` re-pulls the authoritative `/me` count on every visible
+event and force-applies it, bypassing the signal-equality skip, so the badge
+axis is server-authoritative and independently reconciled. Verified for the OS
+icon badge and the `document.title` mirror; the in-app sidebar counters were
+not audited. `installNotificationDismiss` being non-idempotent is fine — the
+sibling `installPushTargetListener` is equally so, `main.tsx` calls each once,
+and the sweep is idempotent regardless.


### PR DESCRIPTION
## Summary

**The proposed `getNotifications({ tag })` does not work for DMs, so this matches on the notification's own deep-link URL instead.** An exact-match tag filter forces cic to *spell* the server's tag — a second copy of `Grappa.Push.Payload`'s format — and that copy is wrong by construction for a query: the server tags with the peer nick RAW (`libera:Alice`, per the key/display split), while the selection store holds the canonical window spelling (`alice`). The filter asks for `libera:alice`, matches nothing, and closes nothing — silently, in the case DMs make most common. Each open notification is instead resolved through its own `data.url` by the `parsePushTargetUrl` the tap path already uses, so there is one spelling of push identity rather than two.

Everything else follows the issue: no new state, no new server field, no new permission.

## What changed

- **`lib/notificationDismiss.ts`** — the sweep. Whenever a conversation comes into view, enumerate what the registration is showing and close the notifications naming the focused window.
- **`lib/pushTarget.ts`** — `pushTargetSelection` extracted from `routePushTarget`. The tap path walks the push-target → window mapping forwards ("this notification names the window to focus"); the sweep walks it backwards ("does this notification name the window already focused"). One mapping, so a tap and a dismissal cannot disagree about which window a notification belongs to. No behaviour change; `pushTarget.test.ts` passes untouched.
- **`main.tsx`** — `installNotificationDismiss()`, mounted next to the tap path it completes.

## Notes for review

**Presence banners fall out for free.** `build_presence/3` (#378) deep-links to the same `?network=&channel=` shape, so opening a peer's query also clears their online/offline banner. A tag filter would have had to be taught this; matching on the window states the rule once — close what the reader is looking at.

**Two triggers.** The reactive arm is `isDocumentVisible()` crossed with `selectedChannel()` — both halves of "in view": the tab came back, or the reader switched windows while it was already in front of them. `pageshow` is the second, for the reason `resumeProbe.ts` already carries it (an iOS PWA thaws without reporting a visibility transition). The sweep is idempotent, so the overlap costs nothing.

**`getRegistration()`, not `serviceWorker.ready`** (which `push.ts` uses). `ready` never settles when no service worker is registered, and this runs on every focus flip rather than once at opt-in, so a browser with SW disabled would accumulate one dangling promise per sweep. A hidden document is not enumerated at all — that is where a notification is still doing its job.

## Since review (2 reviews, 4 commits)

- **`d11baff9`** — re-establish `isDocumentVisible()` AFTER the two awaits, before the close loop. The one finding that could destroy an unread notification: `getNotifications()` is an IPC round-trip, and a push shown inside that gap was being closed unseen.
- **`094048f9`** — the store stubs are real Solid signals now, so the effect can actually re-run, and the **primary user story** (switch window while visible) has a test. The named mutant `untrack(selectedChannel)` killed that trigger with all seven old tests green; it is red now. Both new tests were run against their mutants — each kills exactly its own.
- **`023eee0d`** — the docstring credited `setSelectedChannel`'s fold; the sweep never calls the setter. Corrected to `isActiveSelection`'s `foldChannelKey`.
- **`e68505e1`** — DESIGN_NOTES retracts "handled one layer up" / "a state that should not occur" for the already-in-view residual; the tree says the opposite. Also records the race, the CHANTYPES approximation, the badge acquittal, and the one unmeasured fact (whether an iOS banner over a foregrounded PWA produces a blur/focus pair).

**Deferred, not fixed:** the already-in-view sweep mechanism (a `postMessage` from the push handler). Both reviews called it a follow-up. Not filed as an issue — enqueue is vjt's.

## Testing

`src/__tests__/notificationDismiss.test.ts` — 10 tests: the DM arm that fails on a byte compare, the window-switch trigger, the visibility-flip trigger, `pageshow`, and the mid-sweep race. Mutation-checked — two named mutants, each killed by exactly one test.

**No e2e, and the ceiling is the harness.** `self.registration.showNotification(...)` rejects under headless Playwright with *"No notification permission has been granted for this origin"* even after `context.grantPermissions(["notifications"])` — the finding `e2e/fixtures/pushTap.ts` already documents for the tap path. A dismissal test needs a notification that EXISTS, so it hits the same wall one step earlier: with nothing shown, `getNotifications()` returns an empty list and the test would pass while closing nothing.

Local gates: `bun run check` green (5 stages, 0 failed). Full vitest suite 6946 passed / 7 failed — `mentions`, `selection`, `subscribe`, `userTopic`, all timeout-shaped, all in the known Windows-host flake family; re-run in isolation they are 362/362 green. Not manually dogfooded (the reviewer was unavailable to test this round).

Addresses #2034. (Closing keyword deliberately dropped — enqueue and closure are vjt's in this repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
