### PR TITLE
union: gate #2047 + #2049 together on current main

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -1349,3 +1349,46 @@ export async function setUploadConfirmEnabled(token: string, enabled: boolean): 
     );
   }
 }
+
+/**
+ * #2037 B — force the `show_event_badge` display pref for a subject, out of
+ * band.
+ *
+ * The pref ships OFF and it is SERVER-BACKED (#449/#1766), which is why this
+ * helper exists rather than a click: a spec that turns it on through the
+ * drawer and then dies mid-way leaves the whole account with the sidebar's
+ * events pill suppressed, and every other badge spec that runs after it in
+ * the same worker inherits that. Restoring through the API is the only
+ * restore that survives a failed test body, so it belongs in an
+ * `afterEach`/`finally` and not in the gesture under test.
+ *
+ * `PUT /me/settings/display-prefs` is a FULL-MAP replace with no PATCH form
+ * (`UserSettingsController.update_display_prefs/2`), so this reads the
+ * current map first and overrides one key. Sending only the one key would
+ * silently reset the other five to the server's defaults — the same trap
+ * `displayPrefs.ts` documents for `buildWireMap`.
+ */
+export async function setShowEventBadge(token: string, on: boolean): Promise<void> {
+  const url = `${GRAPPA_BASE_URL}/me/settings/display-prefs`;
+  const headers = { "content-type": "application/json", authorization: `Bearer ${token}` };
+
+  const current = await fetch(url, { headers });
+  if (!current.ok) {
+    throw new Error(
+      `setShowEventBadge(${on}): GET display-prefs → ${current.status} ${await current.text()}`,
+    );
+  }
+  const body = (await current.json()) as { display_prefs?: Record<string, unknown> };
+  const prefs = { ...(body.display_prefs ?? {}), show_event_badge: on };
+
+  const written = await fetch(url, {
+    method: "PUT",
+    headers,
+    body: JSON.stringify({ display_prefs: prefs }),
+  });
+  if (!written.ok) {
+    throw new Error(
+      `setShowEventBadge(${on}): PUT display-prefs → ${written.status} ${await written.text()}`,
+    );
+  }
+}

--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -1351,16 +1351,26 @@ export async function setUploadConfirmEnabled(token: string, enabled: boolean): 
 }
 
 /**
- * #2037 B — force the `show_event_badge` display pref for a subject, out of
+ * #2037 B — set the `show_event_badge` display pref for a subject, out of
  * band.
  *
- * The pref ships OFF and it is SERVER-BACKED (#449/#1766), which is why this
- * helper exists rather than a click: a spec that turns it on through the
- * drawer and then dies mid-way leaves the whole account with the sidebar's
- * events pill suppressed, and every other badge spec that runs after it in
- * the same worker inherits that. Restoring through the API is the only
- * restore that survives a failed test body, so it belongs in an
- * `afterEach`/`finally` and not in the gesture under test.
+ * The pref ships OFF, so every spec whose SUBJECT is the sidebar's events
+ * pill has to opt in first, and four of them predate this pref: #265 (the
+ * event-only window bumps the events badge), #239 and r6 (the badge does NOT
+ * appear) and #532 (no event badge on an archived row). The last three are
+ * the reason this is not optional — a `toHaveCount(0)` under a pref that
+ * suppresses the element is VACUOUSLY true, so leaving them alone would have
+ * kept three specs green while they tested nothing.
+ *
+ * Called BEFORE `loginAs`, deliberately: `displayPrefs.ts` applies the
+ * server's map on the post-login refresh, so a pref written after the boot
+ * fetch would need a reload to take.
+ *
+ * No restore is needed and none is offered. Each test runs on its own
+ * throwaway subject (`provisionSpecSubject`, named off the title path and
+ * DELETEd at teardown), so the pref dies with the user and cannot reach
+ * another spec. A spec that wants it off again inside one body should say so
+ * with a second call.
  *
  * `PUT /me/settings/display-prefs` is a FULL-MAP replace with no PATCH form
  * (`UserSettingsController.update_display_prefs/2`), so this reads the

--- a/cicchetto/e2e/tests/issue1229-unread-retention-bound.spec.ts
+++ b/cicchetto/e2e/tests/issue1229-unread-retention-bound.spec.ts
@@ -94,7 +94,15 @@
 // PRIVMSG bites it again — and `scrollback.ts`'s accumulation on the second
 // bite (`current.missed + unreadDropped`, deliberate: after the first bite the
 // store only ever holds one page, so a recount would report the bound forever
-// while the operator is thousands behind) reports `UNREAD_BOUND + 1`.
+// while the operator is thousands behind) reports `UNREAD_BOUND + 1` RAW ROWS.
+//
+// #2037 A changed what the banner DISPLAYS of that: the number is the MESSAGES
+// bucket now, so the JOINs past the cursor come out of it and this fixture
+// reads 199 rather than 201. The ARMING is untouched and still raw — what arms
+// far-behind is "a row at/after the cursor left the store", which a JOIN does
+// as surely as a message. Only the displayed quantity narrowed, and the
+// assertion below derives the expected value rather than carrying a second
+// magic number.
 //
 // That number is an artefact of the setup, not the behaviour under test. The
 // peer therefore joins BEFORE anything is measured, so its row is part of the
@@ -215,6 +223,28 @@ test.describe("#1229 — the unread retention bound", () => {
       // not, this count would be one too high.
       expect(rows.filter((r) => r.id > cursorRow.id).length).toBe(UNREAD_BEFORE);
 
+      // #2037 A — the banner's number is the MESSAGES bucket now, not the raw
+      // row count, so the expectation below is derived from the fixture rather
+      // than being `UNREAD_BOUND + 1`. See the comment at that assertion.
+      //
+      // The two kinds are NAMED rather than the content predicate mirrored:
+      // this fixture puts exactly PRIVMSGs and JOINs past the cursor (the
+      // peer's JOIN, and vjt's own autojoin self-JOIN — which lands AFTER the
+      // seeded block, because the reset purges and seeds BEFORE it respawns
+      // the session). The `every` below is what keeps that exact: a third kind
+      // appearing fails here instead of quietly skewing the count.
+      //
+      // `capScrollbackRing`'s content twin filters `isContentKind` with NO
+      // own-nick arm, so on this path the self-JOIN drops out as a KIND and
+      // not as an own row — which is why counting joins is the whole of it.
+      const past = rows.filter((r) => r.id > cursorRow.id);
+      expect(
+        past.every((r) => r.kind === "privmsg" || r.kind === "join"),
+        "#1229 fixture grew a third row kind — the derivation below is no longer exact",
+      ).toBe(true);
+      const presencePast = past.filter((r) => r.kind === "join").length;
+      expect(presencePast, "no presence rows past the cursor — see the comment").toBeGreaterThan(0);
+
       await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
 
       await loginAs(page, vjt);
@@ -265,7 +295,17 @@ test.describe("#1229 — the unread retention bound", () => {
       await expect(bar).toBeVisible({ timeout: OUTCOME_TIMEOUT_MS });
       // The count is how far behind the operator actually is, taken BEFORE the
       // bite and so including the row that crossed — not the page still held.
-      await expect(bar).toContainText(String(UNREAD_BOUND + 1));
+      //
+      // #2037 A moved the UNIT of that number, not its meaning: the banner now
+      // reports the MESSAGES bucket, the same partition the sidebar's bold
+      // pill carries, because a bar counting raw rows against a split badge is
+      // what #2037 was reported for. So the JOINs past the cursor come out
+      // (`presencePast`), the crossing PRIVMSG stays in, and this fixture's
+      // 201 raw rows read as 199. Derived rather than re-hardcoded: the
+      // contrast this assertion exists for is still "the accumulated distance,
+      // NOT the page still held", and the derivation keeps it anchored to
+      // `UNREAD_BOUND + 1` instead of quietly becoming a new magic number.
+      await expect(bar).toContainText(String(UNREAD_BOUND + 1 - presencePast));
       await expect(marker).toHaveCount(0);
 
       // (4) a PREFIX drop: both the oldest unread AND the read context above

--- a/cicchetto/e2e/tests/issue1738-send-at-tail-rest-position.spec.ts
+++ b/cicchetto/e2e/tests/issue1738-send-at-tail-rest-position.spec.ts
@@ -1,0 +1,230 @@
+// Issue 1738 — after a send the scrollback comes to rest SHORT of its own
+// tail: the sent line is flush against the chrome below it and the pane can
+// still be hand-scrolled further down.
+//
+// ## What this spec is FOR, and it is not a cure
+//
+// It is the measurement issue 1738 was never given. The report is visual, from
+// an iPhone, and its falsifiable content is one number — the residual
+// `scrollHeight - scrollTop - clientHeight` the pane rests at once a send has
+// settled. "It can still be scrolled further by hand" IS that number being
+// positive; nothing else in the report distinguishes the defect from a taste
+// call about spacing.
+//
+// ## Why it is not `issue2031-send-with-marker-row-clipped.spec.ts`
+//
+// That spec measures the SAME write on the SAME platform and is the reason the
+// mechanism is known. It differs in its precondition and in what it asserts:
+//
+//   * its send happens with the reader PARKED IN HISTORY and the unread marker
+//     on screen — a scenario built to make the marker collapse a suspect. This
+//     report has no marker and no parking: the reader is at the tail and sends.
+//     The tail write is reached through `tailFollowWhenSettled` in both, but a
+//     spec that only ever exercises the parked entry cannot say the plain one
+//     rests correctly;
+//   * it asserts the ROW's box against the PANE's box (`overflowBelowPx`) and
+//     only LOGS `distanceFromBottomPx`. The row-clipping face and the
+//     rest-position face are not the same claim: a row can sit entirely inside
+//     the pane while the pane is still short of its tail by less than one row.
+//     This report is about the pane's rest position, so that is the assertion.
+//
+// ## The configuration the report was taken in
+//
+// vjt's screenshots have the docked radio player under the scrollback ("no
+// breathing room between the last line and whatever chrome sits below — the
+// docked player, or the compose box when no player is up"). `.audio-mini-player`
+// is an in-flow flex sibling with no positioning trick, so it can only reach
+// the tail write through `clientHeight`; the case is here because it is the
+// REPORTED configuration, not because a mechanism is suspected in it.
+//
+// ## Platform split, and it is deliberate rather than uniform
+//
+// The no-player case runs on `webkit-iphone-15` — the platform the report came
+// from, and the one where issue 2031 measured the pre-cure shortfall
+// DETERMINISTICALLY (3/3, distanceFromBottom = 7).
+//
+// The player case runs on desktop chromium. Docking the bar is a rail gesture,
+// and on mobile the rail lives inside the members drawer, whose overlay lock
+// FREEZES the pane — so a mobile player case would have to open and close a
+// drawer, and would be testing the drawer's freeze/restore (which is #1701's
+// subject) rather than the rest position. Stated rather than quietly skipped:
+// "iPhone WITH the player docked" is not covered by this file.
+//
+// NO THIRD-PARTY NETWORK (#682 posture): the stream is served from local bytes
+// by `page.route`, scoped to the station's real URL so a change that stops
+// requesting it still fails.
+
+import type { Page } from "@playwright/test";
+import { silentMp3 } from "../fixtures/bytes";
+import {
+  composeSend,
+  loginAs,
+  openRailMenu,
+  rowClearance,
+  scrollbackDistanceFromBottom,
+  scrollbackLines,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Literals rather than an import from `src/lib/radioStations`, matching the
+// #682 / #1701 posture: a table edit that drops or renames this station must
+// fail HERE instead of being followed silently.
+const STATION_ID = "groovesalad";
+const STATION_STREAM = "https://ice.somafm.com/groovesalad-128-mp3";
+
+// The band for "the pane is at its own tail".
+//
+// 🔴 NOT `SCROLL_BOTTOM_THRESHOLD_PX`, which is 50 and is the tolerance under
+// accusation: the whole reported defect (7px of unscrolled `padding-bottom`)
+// fits inside it, so an assertion written in those terms is green against the
+// thing it is named after.
+//
+// 2px is a sub-pixel band and not a knife edge. `scrollHeight` and
+// `clientHeight` are integer-rounded while `scrollTop` is fractional, so a
+// correct rest lands in [0, 1). Issue 2031 measured the two states seven pixels
+// apart on both engines (correct 0, defective 7), so nothing can round across
+// this line — only a shortfall can cross it.
+const TAIL_RESIDUAL_TOLERANCE_PX = 2;
+
+// Mirror of issue 2031's own tolerance for the row-vs-pane reading, and its
+// reason carries over verbatim: the clipped state overflows the pane's bottom
+// edge by +0.203px (webkit) / +0.359px (chromium), so a defensive 1px slack
+// would swallow the defect whole.
+const SUBPIXEL_TOLERANCE_PX = 0;
+
+// Must outlast every #608 deferred writer before the terminal geometry is
+// read: SETTLE_MAX_FRAMES (30) ≈ 0.5s, SCROLL_SETTLE_DEBOUNCE_MS = 500,
+// PRESENCE_CURSOR_SETTLE_MS = 500. Same window issue 2031 and issue 625 sample
+// over, for the same reason.
+const SETTLE_WINDOW_MS = 2500;
+
+// Bring the pane to the state the report is taken in: at the TRUE tail, with no
+// unread marker, following for an honest reason.
+//
+// The pin is the RAW setter and not the app's own write, deliberately: the
+// browser clamps `scrollTop = scrollHeight` to the real maximum INCLUDING the
+// scroller's bottom padding, so the precondition is established by something
+// other than the code under test. It also cannot mask a defect in what follows
+// — the measured send happens after it, and a write that stops short lands
+// short from wherever it started.
+async function parkAtTrueTail(page: Page, tag: string): Promise<void> {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+
+  // A send of our own first. It collapses whatever unread marker the seeded
+  // buffer opened with (so the measured send below cannot be routed to a
+  // marker-activation instead of tail-follow) and it arms the follow intent
+  // through the app's own edge rather than leaving the mount default
+  // undisturbed.
+  await composeSend(page, `i1738 ${tag} warmup ${Date.now()}`);
+  await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(0, { timeout: 10_000 });
+
+  await page.getByTestId("scrollback").evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+  });
+  // Let `onScroll` observe the pin — without it the pane never learns it is at
+  // the tail and the state the report describes cannot exist.
+  await page.waitForTimeout(300);
+  await expect
+    .poll(() => scrollbackDistanceFromBottom(page), { timeout: 5_000 })
+    .toBeLessThanOrEqual(TAIL_RESIDUAL_TOLERANCE_PX);
+}
+
+// The body of both cases. One function because they differ only in the chrome
+// below the pane, and a copy would let the two drift into asserting different
+// things — which is the one comparison the pair exists to make.
+async function sendAtTailAndAssertRestedAtTail(page: Page, tag: string): Promise<void> {
+  await parkAtTrueTail(page, tag);
+
+  const body = `i1738 ${tag} ${Date.now()}`;
+  await composeSend(page, body);
+
+  const sentLine = scrollbackLines(page).filter({ hasText: body });
+  await expect(sentLine).toHaveCount(1, { timeout: 10_000 });
+
+  // Let every deferred writer land before the terminal geometry is read.
+  await page.waitForTimeout(SETTLE_WINDOW_MS);
+
+  const clearance = await rowClearance(sentLine);
+  console.log(`[#1738 ${tag}] clearance=${JSON.stringify(clearance)}`);
+
+  // ── the reported tell: the pane rests where hand-scrolling would take it ──
+  expect(
+    clearance.distanceFromBottomPx,
+    `the pane rests short of its own tail after a send, so it can still be ` +
+      `hand-scrolled further down. distanceFromBottom=` +
+      `${clearance.distanceFromBottomPx.toFixed(3)}px, ` +
+      `overflowBelow=${clearance.overflowBelowPx.toFixed(3)}px. ` +
+      `A residual near the scroller's 8px bottom padding is issue 2031's ` +
+      `mechanism (the tail write not consuming it); a materially larger one is ` +
+      `something else and the number is the lead.`,
+  ).toBeLessThanOrEqual(TAIL_RESIDUAL_TOLERANCE_PX);
+
+  // ── and the sent row is not clipped by the pane that holds it ──
+  // The row-vs-pane face of the same rest. Kept alongside because the two can
+  // separate: a pane one pixel short clips nothing, and a pane at its tail can
+  // still hold a row past its edge if the write landed on the wrong element.
+  expect(
+    clearance.overflowBelowPx,
+    `the sent row is clipped at the pane's bottom edge. ` +
+      `overflowBelow=${clearance.overflowBelowPx.toFixed(3)}px, ` +
+      `distanceFromBottom=${clearance.distanceFromBottomPx.toFixed(3)}px, ` +
+      `hiddenBehindCompose=${clearance.hiddenBehindComposePx?.toFixed(3) ?? "n/a"}px.`,
+  ).toBeLessThanOrEqual(SUBPIXEL_TOLERANCE_PX);
+}
+
+test.describe("issue 1738 — a send while already at the tail (iPhone, no player)", () => {
+  // No `test.use({ viewport })`: the `webkit-iphone-15` project's device
+  // descriptor owns the viewport, and overriding it would throw away the
+  // fidelity that makes this the reported platform's case.
+  test("@webkit the pane rests at its own tail, not one padding short", async ({ page }) => {
+    await loginAs(page, specUser());
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+    await sendAtTailAndAssertRestedAtTail(page, "iphone");
+  });
+});
+
+test.describe("issue 1738 — a send while already at the tail (desktop, player docked)", () => {
+  // Tiny viewport so the seeded buffer overflows and the geometry is real —
+  // the same 800×300 issue 580 / 625 / 2031 use.
+  test.use({ viewport: { width: 800, height: 300 } });
+  test.setTimeout(90_000);
+
+  test("the docked player does not leave the pane short of its tail", async ({ page }) => {
+    test.slow();
+    await page.route("https://ice.somafm.com/**", async (route) => {
+      await route.fulfill({ status: 200, contentType: "audio/mpeg", body: silentMp3(8) });
+    });
+    await loginAs(page, specUser());
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+    // Dock the bar, then CLOSE the picker. The picker holds a
+    // `createOverlayLock` refcount (#1701), and overlay-freeze outranks
+    // tail-follow — a send underneath it would measure the freeze, not the rest
+    // position.
+    await openRailMenu(page);
+    await page.getByTestId("rail-action-radio").click();
+    const picker = page.getByTestId("rail-radio-picker");
+    await expect(picker).toBeVisible();
+    await page.getByTestId(`rail-radio-station-${STATION_ID}`).click();
+    await expect(page.getByTestId("audio-mini-player-el")).toHaveJSProperty("src", STATION_STREAM);
+    await expect(page.getByTestId("audio-mini-player")).toBeVisible({ timeout: 15_000 });
+    await page.getByTestId("rail-radio-picker-close").click();
+    await expect(picker).toBeHidden();
+
+    // VACUITY GUARD. The case is "the reported chrome is under the pane"; if the
+    // bar took no space out of the scroller, everything below is a re-run of the
+    // no-player case wearing its name.
+    const shrink = await page.getByTestId("scrollback").evaluate((el) => {
+      const bar = document.querySelector(".audio-mini-player") as HTMLElement | null;
+      if (!bar) throw new Error("the docked player is not mounted");
+      return bar.getBoundingClientRect().height;
+    });
+    expect(shrink, "the docked player occupies no height").toBeGreaterThan(20);
+
+    await sendAtTailAndAssertRestedAtTail(page, "desktop-player");
+  });
+});

--- a/cicchetto/e2e/tests/issue1738-send-at-tail-rest-position.spec.ts
+++ b/cicchetto/e2e/tests/issue1738-send-at-tail-rest-position.spec.ts
@@ -28,6 +28,39 @@
 //     the pane while the pane is still short of its tail by less than one row.
 //     This report is about the pane's rest position, so that is the assertion.
 //
+// 🔴 That second bullet is MEASURED, not reasoned. On the mutant bench below —
+// the pre-cure code, this gesture — the numbers separate exactly as the bullet
+// predicts: `overflowBelow = -0.172` (webkit) / `-0.422` (chromium), i.e. the
+// row sits FULLY INSIDE the pane and 2031's assertion is GREEN, while
+// `distanceFromBottom` reads 7 and 6 and the pane really is short. So the 2031
+// spec, re-run on the untouched tree, would have reported this report's gesture
+// as fine. The distance assertion is the one that catches it, and that is the
+// whole reason this file exists.
+//
+// ## What this measured  (2026-09-10, on e7677913b)
+//
+// CURED TREE, `--repeat-each 3`, and byte-identical across all three repeats of
+// every case — 12/12 green:
+//
+//   webkit-iphone-15  #1738 iphone          distance 0   overflowBelow -6.813
+//   webkit-iphone-15  #2031 iphone          distance 0   overflowBelow -7.438
+//   chromium          #1738 desktop-player  distance 0   overflowBelow -6.422
+//   chromium          #2031 desktop         distance 0   overflowBelow -6.641
+//
+// MUTANT BENCH, because a spec born green has not been shown to be able to
+// fail. `scrollToTail`'s top-up (the two lines `fffcc344c` added) was removed,
+// restoring the pre-cure shape, and all four entries went RED:
+//
+//   webkit-iphone-15  #1738 iphone          distance 7   overflowBelow -0.172
+//   webkit-iphone-15  #2031 iphone          distance 7   overflowBelow +0.203
+//   chromium          #1738 desktop-player  distance 6   overflowBelow -0.422
+//   chromium          #2031 desktop         distance 7   overflowBelow +0.359
+//
+// The bench is verified to BE the pre-cure state rather than merely broken: the
+// two 2031 rows reproduce the numbers its own header recorded over nine runs
+// before any cure existed (+0.203 webkit, +0.359 chromium) to the third
+// decimal. So a red here is the reported mechanism and not some other damage.
+//
 // ## The configuration the report was taken in
 //
 // vjt's screenshots have the docked radio player under the scrollback ("no

--- a/cicchetto/e2e/tests/issue2037-unread-bar-and-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue2037-unread-bar-and-badge.spec.ts
@@ -238,7 +238,15 @@ test.describe("issue 2037 — the far-behind bar and the sidebar badges", () => 
 
       await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
 
-      // Back into the window: this is the open that takes the probe.
+      // A RELOAD, and it is load-bearing rather than tidiness. `probeGap`
+      // fires from `loadInitialScrollback`, which sits behind a load-once gate
+      // (`loadedChannels`, `scrollback.ts`): this window was already hydrated
+      // by the visit above, so simply selecting it again re-renders the store
+      // and takes no probe. Measured — the first version of this spec switched
+      // away and back, and the bar never appeared while the pane happily
+      // rendered the already-loaded rows. The gate is cleared on identity
+      // transition and by a fresh document; the document is the cheap one.
+      await page.reload();
       await selectChannel(page, NETWORK_SLUG, CHANNEL, { awaitWsReady: false });
       await expect(page.getByTestId("far-behind-bar")).toBeVisible({
         timeout: OUTCOME_TIMEOUT_MS,

--- a/cicchetto/e2e/tests/issue2037-unread-bar-and-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue2037-unread-bar-and-badge.spec.ts
@@ -80,7 +80,6 @@ import {
   resetSubject,
   restoreReadCursorToTail,
   setReadCursorToId,
-  setShowEventBadge,
 } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
@@ -138,22 +137,13 @@ const badgeNumber = async (locator: import("@playwright/test").Locator): Promise
   Number((await locator.innerText()).trim());
 
 test.describe("issue 2037 — the far-behind bar and the sidebar badges", () => {
-  // `show_event_badge` is SERVER-backed and OFF by default. A spec body that
-  // turns it on and then dies would leave the whole account with the events
-  // pill suppressed and poison every badge spec that follows in this worker,
-  // so the restore is out-of-band and unconditional rather than a click at the
-  // end of a happy path.
-  test.afterEach(async () => {
-    try {
-      await setShowEventBadge(specUser().token, false);
-    } catch {
-      // A failed restore must not mask the test's own verdict, but it must
-      // not be silent either: the next badge spec in this worker is the one
-      // that pays for it.
-      process.stderr.write("__I2037__\tshow_event_badge restore FAILED\n");
-    }
-  });
-
+  // No `afterEach` restoring `show_event_badge`. There was one, and its
+  // stated reason — that leaving the pref on would poison the badge specs
+  // that follow in this worker — is FALSE: every test runs on its own
+  // throwaway subject (`provisionSpecSubject`, named off the title path and
+  // DELETEd at teardown), so the pref dies with the user. Both tests below
+  // read the OFF default as a fresh fact, and the second one proves it: it
+  // asserts the default while running after a test that turned the pref on.
   test("the far-behind bar and the bold pill are ONE number, it is strictly below the raw gap, and bar + events + own accounts for every row", async ({
     page,
   }) => {

--- a/cicchetto/e2e/tests/issue2037-unread-bar-and-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue2037-unread-bar-and-badge.spec.ts
@@ -1,0 +1,384 @@
+// issue 2037 — three unread numbers on one screen for what the reporter read
+// as one quantity: a far-behind bar saying 1807, a bold sidebar pill saying
+// 187 and a faint one saying 216.
+//
+// The measurement that framed the fix is in DESIGN_NOTES #2037a and is NOT
+// re-run here: the bar's anchor term is bounded above by zero, so re-anchoring
+// the probe moves the bar DOWN by at most one page and leaves the residual
+// exactly where it is. Two things were built on top of that ruling, and this
+// is the only place either of them is checked against a real server:
+//
+//   A. `far().missed` IS the messages bucket — the same partition the bold
+//      pill carries. Not a second value that agrees with it; the SAME
+//      variable, read twice.
+//   B. the faint `!messaggi` pill is behind `show_event_badge`, OFF by
+//      default, and the bucket it hides is wider than join/part.
+//
+// ── WHY AN e2e AND NOT THE UNIT TESTS THAT ALREADY EXIST ─────────────────
+//
+// Both sides are covered and neither side can see the seam. The cic specs
+// drive `probeGap` / `perChannelUnread` / `WindowBadges` against a stubbed
+// API, so they pin the wiring and the defaults but never the server's actual
+// numbers. The server specs pin the response shape and the posture sharing
+// but never the render. #2037's defect lived exactly between them: the server
+// was answering two different questions correctly and the client was drawing
+// both answers as one quantity.
+//
+// ── WHY THE TWO NUMBERS ARE NOT MERELY COMPARED TO EACH OTHER ────────────
+//
+// A spec that asserts "bar === pill" and stops passes if both are wrong the
+// same way — which, under A, they now would be, since they are one variable.
+// So the bar is also pinned BELOW the raw gap, and then pinned exactly, by a
+// decomposition the spec can state without re-implementing the server's kind
+// predicate:
+//
+//     bar + faint pill + own-authored rows === raw rows past the cursor
+//
+// `bar` and `faint pill` come from the UI. `raw rows past the cursor` is a
+// count of the server's own ordered list. `own-authored rows` is an IDENTITY
+// count over that same list (rows whose sender is the operator), not a kind
+// classification. Every row past the cursor is exactly one of the three by
+// construction — own, non-own message, non-own event — so the identity holds
+// for any correct implementation and fails for a bucket that double-counts,
+// loses a kind, or forgets the own-authored exclusion. That is the assertion
+// `count_after_split/6`'s own ExUnit probe makes on constructed rows; this is
+// it on rows a real bahamut produced.
+//
+// ── WHY THE FAR-BEHIND WINDOW STAYS BADGED WHILE IT IS FOCUSED ───────────
+//
+// Reading the bar requires the window to be selected, and #981 zeroes the
+// badge on the window the pane reports it is reading at the tail. A
+// far-behind window is deliberately excluded from that suppression
+// (`selection.ts`: its cursor is frozen, the arm cannot advance it, and the
+// rows the operator is at the bottom of are not the unread region). If that
+// exclusion is ever dropped, the bold-pill assertion below is what notices.
+//
+// ── NOT COVERED HERE, DELIBERATELY ───────────────────────────────────────
+//
+// The THRESHOLD. `count_after/6` keeps its predicate and its caller
+// (`probeGap` → `isFarBehind`); vjt's 09:00 ruling put it out of scope and
+// the reason is a correctness one, not a scheduling one — a messages-only
+// threshold would have a channel with 3000 hidden JOINs and 40 messages
+// report a 40-row gap and take a contiguous-paging path it cannot serve.
+//
+// And the 1404-row residual. A+B unify the quantity; they do not explain the
+// report, they are not claimed to, and no assertion here should be read as
+// evidence about it.
+
+import {
+  closeSettings,
+  composeSend,
+  loginAs,
+  openSettingsSection,
+  selectChannel,
+  sidebarEventsBadge,
+  sidebarMessageBadge,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
+import {
+  fetchAllMessagesAsc,
+  resetSubject,
+  restoreReadCursorToTail,
+  setReadCursorToId,
+  setShowEventBadge,
+} from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Enough history that the cursor can be planted well behind the tail with a
+// read context above it.
+const SEED_COUNT = 400;
+const SEED_SENDER = "seed-bot";
+
+// How far behind the planted cursor sits, in RAW rows. It must exceed the
+// far-behind threshold, and it is NOT mirrored from the production constant
+// on purpose: if the threshold ever rises past this, the far-behind bar
+// simply does not appear and the spec fails LOUDLY on its first assertion,
+// which is the honest failure. A mirrored copy would instead have to be kept
+// in step by hand.
+const UNREAD_GAP = 250;
+
+// Own-authored content, sent through the real compose box. Its only job is to
+// make the own-exclusion term of the decomposition non-zero — a fixture where
+// the operator never spoke would satisfy the identity trivially.
+const OWN_LINES = [
+  "issue2037: a line the operator typed, one",
+  "issue2037: a line the operator typed, two",
+  "issue2037: a line the operator typed, three",
+];
+
+const PEER_LINES = [
+  "issue2037: peer content after the operator's own",
+  "issue2037: peer content, second",
+];
+
+const OUTCOME_TIMEOUT_MS = 15_000;
+
+// The operator's own rows, counted by IDENTITY rather than by kind. Lowercased
+// on both sides because this is a setup guard over wire rows and not a
+// production fold-MATCH site — `sender` is stored raw for display and bahamut
+// echoes back what we sent, so a case difference here would be a harness
+// artefact rather than the thing under test.
+const authoredBy = (rows: { sender: string }[], nick: string): number =>
+  rows.filter((r) => r.sender.toLowerCase() === nick.toLowerCase()).length;
+
+// "1807 unread — jump back" → 1807. Reading the rendered string rather than a
+// signal is the point: this is the number the operator saw.
+const barNumber = async (page: import("@playwright/test").Page): Promise<number> => {
+  const text = (await page.getByTestId("far-behind-jump").innerText()).trim();
+  const match = /^(\d+)\s+unread/.exec(text);
+  if (match === null) throw new Error(`#2037 spec: far-behind bar text unparseable: ${text}`);
+  return Number(match[1]);
+};
+
+const badgeNumber = async (locator: import("@playwright/test").Locator): Promise<number> =>
+  Number((await locator.innerText()).trim());
+
+test.describe("issue 2037 — the far-behind bar and the sidebar badges", () => {
+  // `show_event_badge` is SERVER-backed and OFF by default. A spec body that
+  // turns it on and then dies would leave the whole account with the events
+  // pill suppressed and poison every badge spec that follows in this worker,
+  // so the restore is out-of-band and unconditional rather than a click at the
+  // end of a happy path.
+  test.afterEach(async () => {
+    try {
+      await setShowEventBadge(specUser().token, false);
+    } catch {
+      // A failed restore must not mask the test's own verdict, but it must
+      // not be silent either: the next badge spec in this worker is the one
+      // that pays for it.
+      process.stderr.write("__I2037__\tshow_event_badge restore FAILED\n");
+    }
+  });
+
+  test("the far-behind bar and the bold pill are ONE number, it is strictly below the raw gap, and bar + events + own accounts for every row", async ({
+    page,
+  }) => {
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+    const vjt = specUser();
+    const admin = getSeededAdmin();
+    const ownNick = specNick();
+    const peerNick = `i2037a-${Date.now().toString(36)}`;
+
+    await resetSubject(
+      admin.token,
+      vjt.name,
+      { [NETWORK_SLUG]: AUTOJOIN_CHANNELS },
+      { [NETWORK_SLUG]: [{ name: CHANNEL, seedCount: SEED_COUNT, seedSender: SEED_SENDER }] },
+    );
+
+    const peer = await IrcPeer.connect({ nick: peerNick });
+    try {
+      // The peer's JOIN is a scrollback row like any other, and it is one of
+      // the non-message kinds the decomposition needs on the far side of the
+      // cursor. Waited for by its persisted row, not by the peer's own echo:
+      // the echo says bahamut saw it, not that grappa stored it, and the
+      // cursor is planted by id off the stored list.
+      await peer.join(CHANNEL);
+      await expect
+        .poll(
+          async () => {
+            const seen = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
+            return seen.some((r) => r.kind === "join" && r.sender === peerNick);
+          },
+          { timeout: OUTCOME_TIMEOUT_MS },
+        )
+        .toBe(true);
+
+      await loginAs(page, vjt);
+      await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick });
+
+      for (const line of OWN_LINES) await composeSend(page, line);
+      for (const line of PEER_LINES) peer.privmsg(CHANNEL, line);
+
+      // The peer's PART closes the fixture: once its row is stored, every row
+      // this spec plants is in the table and the id list is stable.
+      await peer.part(CHANNEL, "issue2037 fixture complete");
+      await expect
+        .poll(
+          async () => {
+            const seen = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
+            const own = seen.filter((r) => r.body === OWN_LINES[OWN_LINES.length - 1]).length;
+            const peerSaid = seen.filter(
+              (r) => r.body === PEER_LINES[PEER_LINES.length - 1],
+            ).length;
+            const parted = seen.some((r) => r.kind === "part" && r.sender === peerNick);
+            return own === 1 && peerSaid === 1 && parted;
+          },
+          { timeout: OUTCOME_TIMEOUT_MS },
+        )
+        .toBe(true);
+
+      // Leave the window BEFORE forcing the cursor backward. With the pane
+      // still on it, the settle writer would race the force and put the
+      // cursor back at the tail.
+      await selectChannel(page, NETWORK_SLUG, "$server", { awaitWsReady: false });
+
+      const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
+      expect(rows.length).toBeGreaterThan(UNREAD_GAP + 20);
+      const cursorRow = rows[rows.length - 1 - UNREAD_GAP];
+      if (!cursorRow) throw new Error("#2037 spec: cursor row index missing");
+
+      const past = rows.filter((r) => r.id > cursorRow.id);
+      // Preconditions, guarded rather than assumed. A region with no
+      // own-authored rows or no event rows would satisfy "strictly below the
+      // raw gap" and the decomposition for the wrong reason.
+      expect(past.length).toBe(UNREAD_GAP);
+      const ownPast = authoredBy(past, ownNick);
+      expect(ownPast, "no own-authored rows past the cursor — fixture degenerate").toBeGreaterThan(
+        0,
+      );
+      expect(
+        past.some((r) => r.kind === "join") && past.some((r) => r.kind === "part"),
+        "no peer presence rows past the cursor — fixture degenerate",
+      ).toBe(true);
+
+      await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
+
+      // Back into the window: this is the open that takes the probe.
+      await selectChannel(page, NETWORK_SLUG, CHANNEL, { awaitWsReady: false });
+      await expect(page.getByTestId("far-behind-bar")).toBeVisible({
+        timeout: OUTCOME_TIMEOUT_MS,
+      });
+
+      const bar = await barNumber(page);
+      const boldPill = sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL);
+
+      // (A) the acceptance criterion — one number, two surfaces.
+      await expect(boldPill).toHaveText(String(bar), { timeout: OUTCOME_TIMEOUT_MS });
+
+      // (A) and it is not the raw gap. `toBeGreaterThan(0)` is not decoration:
+      // a bar and a pill that both read 0 would satisfy the equality above.
+      expect(bar).toBeGreaterThan(0);
+      expect(bar, "the bar is still counting raw rows").toBeLessThan(UNREAD_GAP);
+
+      // (B) OFF by default: the faint pill is absent, and so is its accessible
+      // name. Both, because zeroing the count is what this change does and an
+      // element hidden with its `aria-label` intact would be the wrong half.
+      await expect(sidebarEventsBadge(page, NETWORK_SLUG, CHANNEL)).toHaveCount(0);
+      await expect(
+        sidebarWindow(page, NETWORK_SLUG, CHANNEL).getByRole("img", { name: /event/i }),
+      ).toHaveCount(0);
+
+      // (B) the toggle brings it back with no reload — the pref is read as a
+      // signal at render time, not once at boot.
+      const display = await openSettingsSection(page, "display");
+      await display.getByTestId("show-event-badge-toggle").check();
+      await closeSettings(page);
+
+      const faintPill = sidebarEventsBadge(page, NETWORK_SLUG, CHANNEL);
+      await expect(faintPill).toBeVisible({ timeout: OUTCOME_TIMEOUT_MS });
+      const events = await badgeNumber(faintPill);
+      expect(events).toBeGreaterThan(0);
+
+      // The decomposition. Every row past the cursor is own, or a non-own
+      // message, or a non-own event — so these three must account for all of
+      // them, exactly.
+      expect(
+        bar + events + ownPast,
+        `bar ${bar} + events ${events} + own ${ownPast} != raw gap ${UNREAD_GAP}`,
+      ).toBe(UNREAD_GAP);
+    } finally {
+      await peer.disconnect("issue2037 done").catch(() => {});
+      // BUGHUNT-3 cascade rule — the planted cursor is backward and would
+      // change what every later spec on this channel sees.
+      await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL).catch(() => {});
+    }
+  });
+
+  test("a KICK earns no badge while the events pref is off, and is NOT smuggled into the message bucket", async ({
+    page,
+  }) => {
+    // The deliberate behaviour change, given its own spec rather than a
+    // comment. `topic`, `kick` and `server_event` sit OUTSIDE
+    // `suppressed_presence_kinds/0` on purpose (#458) because the PANE still
+    // renders them on a denoised channel — but they are `kind not in
+    // @content_kinds`, so they are `!messaggi` and they follow the bucket into
+    // the opt-in. Rendering in the pane and earning a badge are different
+    // questions and this pref answers only the second.
+    //
+    // The other half is the one a "fix" would get wrong: a kick must not be
+    // promoted into the MESSAGE bucket to keep it loud. That would put a
+    // non-message back into the very number the bar now shares with the bold
+    // pill and undo A. A kick that must stay loud belongs in the
+    // mention/severity channel (#267).
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+    const vjt = specUser();
+    const ownNick = specNick();
+    const stamp = Date.now().toString(36);
+    const kickChannel = `#i2037k-${stamp}`;
+    const opNick = `i2037op-${stamp}`;
+    const victimNick = `i2037v-${stamp}`;
+
+    // The founding JOINer auto-ops on the testnet bahamut (cp15-b6), so the
+    // op joins first. The victim is a THIRD party on purpose: a kick aimed at
+    // the operator would flip the window to `:kicked` and change what is
+    // being measured from "which bucket does a kick land in" to "what does a
+    // kicked window look like", which is cp15-b6's question.
+    const op = await IrcPeer.connect({ nick: opNick });
+    const victim = await IrcPeer.connect({ nick: victimNick });
+    try {
+      await op.join(kickChannel);
+      await victim.join(kickChannel);
+
+      await loginAs(page, vjt);
+      await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick });
+      await composeSend(page, `/join ${kickChannel}`);
+      await expect(
+        page
+          .locator('[data-testid="scrollback-line"][data-kind="join"]')
+          .filter({ hasText: ownNick })
+          .filter({ hasText: kickChannel })
+          .first(),
+      ).toBeVisible({ timeout: OUTCOME_TIMEOUT_MS });
+
+      // Park elsewhere so the kick lands in a BACKGROUND window and stays
+      // unread — the focused window's cursor would advance over it.
+      await selectChannel(page, NETWORK_SLUG, CHANNEL, { awaitWsReady: false });
+      await expect(sidebarWindow(page, NETWORK_SLUG, kickChannel)).toHaveCount(1);
+
+      await op.kick(kickChannel, victimNick, "issue2037: the bucket a kick lands in");
+
+      // Server-side truth first: a red below then separates "the kick never
+      // reached grappa" from "it did and the badge is wrong".
+      await expect
+        .poll(
+          async () => {
+            const seen = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, kickChannel);
+            return seen.some((r) => r.kind === "kick");
+          },
+          { timeout: OUTCOME_TIMEOUT_MS },
+        )
+        .toBe(true);
+
+      // No faint pill, no accessible name, and no BOLD pill either: the kick
+      // must not have been counted as a message.
+      await expect(sidebarEventsBadge(page, NETWORK_SLUG, kickChannel)).toHaveCount(0);
+      await expect(
+        sidebarWindow(page, NETWORK_SLUG, kickChannel).getByRole("img", { name: /event/i }),
+      ).toHaveCount(0);
+      await expect(
+        sidebarMessageBadge(page, NETWORK_SLUG, kickChannel),
+        "a kick was counted as a message",
+      ).toHaveCount(0);
+
+      // Opting in shows it, and shows it as ONE event — the kick, and nothing
+      // the operator's own join contributed (own rows are never unread).
+      const display = await openSettingsSection(page, "display");
+      await display.getByTestId("show-event-badge-toggle").check();
+      await closeSettings(page);
+
+      await expect(sidebarEventsBadge(page, NETWORK_SLUG, kickChannel)).toHaveText("1", {
+        timeout: OUTCOME_TIMEOUT_MS,
+      });
+      await expect(sidebarMessageBadge(page, NETWORK_SLUG, kickChannel)).toHaveCount(0);
+    } finally {
+      await victim.disconnect("issue2037 done").catch(() => {});
+      await op.disconnect("issue2037 done").catch(() => {});
+      await composeSend(page, `/part ${kickChannel}`).catch(() => {});
+    }
+  });
+});

--- a/cicchetto/e2e/tests/issue239-hidden-msg-unread.spec.ts
+++ b/cicchetto/e2e/tests/issue239-hidden-msg-unread.spec.ts
@@ -41,7 +41,7 @@ import {
   sidebarEventsBadge,
   sidebarMessageBadge,
 } from "../fixtures/cicchettoPage";
-import { restoreReadCursorToTail } from "../fixtures/grappaApi";
+import { restoreReadCursorToTail, setShowEventBadge } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
@@ -62,6 +62,14 @@ test("#239 — hidden control message does NOT bump the unread badge; reading cl
   page,
 }) => {
   const vjt = specUser();
+  // #2037 B put the sidebar's events pill behind `show_event_badge`, OFF by
+  // default, so this spec opts in BEFORE login — `displayPrefs.ts` applies the
+  // server's map on the post-login refresh. Without it this spec's
+  // `toHaveCount(0)` on the events pill is VACUOUSLY true — the pref hides the
+  // element whether or not the hidden JOIN was counted, which is the whole
+  // question #239 asks.
+  await setShowEventBadge(vjt.token, true);
+
   await loginAs(page, vjt);
 
   // Focus #spec-wN first so its per-channel WS topic is subscribed (the badge

--- a/cicchetto/e2e/tests/issue265-activity-messages-only.spec.ts
+++ b/cicchetto/e2e/tests/issue265-activity-messages-only.spec.ts
@@ -30,6 +30,7 @@ import {
   sidebarWindow,
   waitForDmListenerReady,
 } from "../fixtures/cicchettoPage";
+import { setShowEventBadge } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
@@ -85,6 +86,16 @@ test("desktop: #265 next-active count includes the message (DM) window, excludes
 }) => {
   const vjt = specUser();
   const peerNick = "act265-d";
+
+  // #2037 B put the sidebar's events pill behind `show_event_badge`, OFF by
+  // default. Opted in BEFORE login — `displayPrefs.ts` applies the server's
+  // map on the post-login refresh — because the seeder below asserts the
+  // #spec-wN EVENT badge is visible, and under the default it would wait for
+  // an element the pref suppresses and time out. #265's own subject (which
+  // windows the next-active cycle counts) is unaffected by the pref; only its
+  // seeding barrier reads the pill.
+  await setShowEventBadge(vjt.token, true);
+
   await loginAs(page, vjt);
 
   const peer = await seedEventOnlyAndMessageWindows(page, peerNick);
@@ -117,6 +128,16 @@ test("@webkit @touch mobile: #265 bottom-bar next-active count excludes the even
 }) => {
   const vjt = specUser();
   const peerNick = "act265-m";
+
+  // #2037 B put the sidebar's events pill behind `show_event_badge`, OFF by
+  // default. Opted in BEFORE login — `displayPrefs.ts` applies the server's
+  // map on the post-login refresh — because the seeder below asserts the
+  // #spec-wN EVENT badge is visible, and under the default it would wait for
+  // an element the pref suppresses and time out. #265's own subject (which
+  // windows the next-active cycle counts) is unaffected by the pref; only its
+  // seeding barrier reads the pill.
+  await setShowEventBadge(vjt.token, true);
+
   await loginAs(page, vjt);
 
   const peer = await seedEventOnlyAndMessageWindows(page, peerNick);

--- a/cicchetto/e2e/tests/issue532-stale-unread-badges.spec.ts
+++ b/cicchetto/e2e/tests/issue532-stale-unread-badges.spec.ts
@@ -49,6 +49,7 @@ import {
   joinChannel,
   partChannel,
   restoreReadCursorToTail,
+  setShowEventBadge,
 } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
@@ -78,6 +79,13 @@ test("#532 A — a self-PART leaves NO stale event badge on the archived channel
   page,
 }) => {
   const vjt = specUser();
+  // #2037 B put the sidebar's events pill behind `show_event_badge`, OFF by
+  // default, so this spec opts in BEFORE login — `displayPrefs.ts` applies the
+  // server's map on the post-login refresh. Without it the "no event badge on
+  // the archived row" assertion is VACUOUSLY true — the pref hides the element
+  // whether or not the own `:part` was counted, which is what A is about.
+  await setShowEventBadge(vjt.token, true);
+
   await loginAs(page, vjt);
 
   // Put the cursor at the current tail so the ONLY row after it is the own

--- a/cicchetto/e2e/tests/r6-own-action-no-events-badge.spec.ts
+++ b/cicchetto/e2e/tests/r6-own-action-no-events-badge.spec.ts
@@ -52,7 +52,12 @@ import {
   sidebarEventsBadge,
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
-import { joinChannel, partChannel, restoreReadCursorToTail } from "../fixtures/grappaApi";
+import {
+  joinChannel,
+  partChannel,
+  restoreReadCursorToTail,
+  setShowEventBadge,
+} from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -82,6 +87,13 @@ test("CP29 R-6 — operator's own /part → /join cycle does NOT raise an unread
   page,
 }) => {
   const vjt = specUser();
+  // #2037 B put the sidebar's events pill behind `show_event_badge`, OFF by
+  // default, so this spec opts in BEFORE login — `displayPrefs.ts` applies the
+  // server's map on the post-login refresh. Without it the closing
+  // `toHaveCount(0)` is VACUOUSLY true: the pref suppresses the element whether
+  // or not the bump-gate let the own ACTION through, which is the question.
+  await setShowEventBadge(vjt.token, true);
+
   await loginAs(page, vjt);
 
   // 1. Focus #spec-wN — initial cold load. The seeded autojoin already

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -29,10 +29,12 @@ import { CREDITS_LABEL, openCreditsModal } from "./lib/creditsModal";
 import {
   syncedSetColoredNicklist,
   syncedSetShowBottomBar,
+  syncedSetShowEventBadge,
   syncedSetStripFormatting,
   syncedSetTimeFormat,
 } from "./lib/displayPrefs";
 import { formatDuration } from "./lib/duration";
+import { getShowEventBadge } from "./lib/eventBadge";
 import { type FontSizeKey, getFontSize, setFontSize } from "./lib/fontSize";
 import { errorMessage, friendlyApiError } from "./lib/friendlyApiError";
 import { getHideNextActive, setHideNextActive } from "./lib/hideNextActive";
@@ -279,6 +281,13 @@ const SettingsDrawer: Component<Props> = (props) => {
   // coordinator (the single PUT authority for the #449 synced prefs).
   const onStripFormattingChange = (e: Event) => {
     syncedSetStripFormatting((e.currentTarget as HTMLInputElement).checked);
+  };
+
+  // #2037 B — same shape again. The one difference worth knowing is the
+  // DEFAULT: this is the first synced display pref that ships OFF and thereby
+  // removes something an operator already sees.
+  const onShowEventBadgeChange = (e: Event) => {
+    syncedSetShowEventBadge((e.currentTarget as HTMLInputElement).checked);
   };
 
   // #986 — the `onDetach` / `onQuit` handlers moved to RailActions with
@@ -2270,6 +2279,30 @@ const SettingsDrawer: Component<Props> = (props) => {
                     data-testid="strip-formatting-toggle"
                   />
                   strip colours and formatting from messages
+                </label>
+
+                {/* #2037 B — the events badge, OFF by default. vjt's ruling:
+                  "i !messaggi non sono interessanti e devono solo finire
+                  nell'opt-in badge". The sidebar's faint pill counted
+                  everything that is not a message, next to a bold pill that
+                  counted messages and a far-behind bar that counted raw rows —
+                  three numbers for what a reader takes to be one quantity
+                  (#2037). The bar and the bold pill are now the same number by
+                  construction; this takes the third out of the default view.
+                  ⚠️ Wider than join/part: the bucket is every non-content kind,
+                  so `topic`, `kick` and `server_event` follow it — they sit
+                  outside the suppressed-presence set on purpose (#458) because
+                  the PANE still renders them, which is a different question
+                  from whether they earn a badge. A kick that must stay loud
+                  belongs in the mention channel (#267). */}
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={getShowEventBadge()}
+                    onChange={onShowEventBadgeChange}
+                    data-testid="show-event-badge-toggle"
+                  />
+                  count joins, parts and other events in the sidebar badge
                 </label>
 
                 {/* #1766 — the mobile window bar (BottomBar), ON by default:

--- a/cicchetto/src/WindowBadges.tsx
+++ b/cicchetto/src/WindowBadges.tsx
@@ -1,6 +1,7 @@
 import { type Component, Show } from "solid-js";
 import type { ChannelKey } from "./lib/channelKey";
 import { isConversationMuted } from "./lib/conversationMute";
+import { getShowEventBadge } from "./lib/eventBadge";
 import { mentionCounts } from "./lib/mentions";
 import { notificationPrefs } from "./lib/notificationPrefs";
 import { farBehindByChannel } from "./lib/scrollback";
@@ -76,7 +77,14 @@ const WindowBadges: Component<Props> = (props) => {
   // clear the record and the modifier must clear with it (#888 acceptance).
   const farBehind = () => farBehindByChannel()[props.channelKey] !== undefined;
   const messages = () => messagesUnread()[props.channelKey] ?? 0;
-  const events = () => eventsUnread()[props.channelKey] ?? 0;
+  // #2037 B — `!messaggi` render only when opted in. Gated on the SIGNAL, not
+  // a snapshot, so flipping the checkbox clears the pills without a reload.
+  //
+  // Zeroed rather than hidden at the `<Show>`: the count feeds `title` and
+  // `aria-label` too, and a hidden element whose accessible name still claims
+  // "216 unread events" is the wrong half of the change. Zero fails the
+  // `> 0` guard once, for every consumer in this component.
+  const events = () => (getShowEventBadge() ? (eventsUnread()[props.channelKey] ?? 0) : 0);
   const mentions = () => mentionCounts()[props.channelKey] ?? 0;
   // #1077 — the SAME predicate the cycle-skip consults (`activeWindows`
   // .orderUnreadWindows, #1018), so the badge cannot drift from the mute it

--- a/cicchetto/src/__tests__/BottomBar.test.tsx
+++ b/cicchetto/src/__tests__/BottomBar.test.tsx
@@ -104,11 +104,14 @@ vi.mock("../lib/archive", () => ({
 }));
 
 import BottomBar from "../BottomBar";
+import { setShowEventBadge } from "../lib/eventBadge";
 import * as scrollCmd from "../lib/scrollToBottomCommand";
 import * as selMod from "../lib/selection";
 import * as windowCloseMod from "../lib/windowClose";
 
 beforeEach(() => {
+  // #2037 B — the events pill is opt-in now; this spec asserts it renders.
+  setShowEventBadge(true);
   vi.clearAllMocks();
   // #243 — default "not the active window" so existing click tests never
   // trip the scroll-to-bottom branch.

--- a/cicchetto/src/__tests__/Sidebar.test.tsx
+++ b/cicchetto/src/__tests__/Sidebar.test.tsx
@@ -208,6 +208,7 @@ import * as apiMod from "../lib/api";
 // `await import` would resolve a second instance under vitest's mocked graph
 // and never reflect the requestConfirm write).
 import { acceptConfirm, confirmRequest, dismissConfirm } from "../lib/confirmDialog";
+import { setShowEventBadge } from "../lib/eventBadge";
 // Capture mocked module references at import time, before any resetModules
 import * as qwMod from "../lib/queryWindows";
 import * as scrollCmd from "../lib/scrollToBottomCommand";
@@ -222,6 +223,8 @@ import {
 import Sidebar from "../Sidebar";
 
 beforeEach(() => {
+  // #2037 B — the events pill is opt-in now; this spec asserts it renders.
+  setShowEventBadge(true);
   vi.clearAllMocks();
   // #96 — `clearAllMocks` clears CALL HISTORY but keeps a spy's
   // implementation, so the two `vi.spyOn(selMod, "selectedChannel")

--- a/cicchetto/src/__tests__/WindowBadges.test.tsx
+++ b/cicchetto/src/__tests__/WindowBadges.test.tsx
@@ -18,7 +18,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // other's behaviour asserted nowhere. Both variants are driven here.
 
 const mockFarBehind = vi.hoisted(() => ({
-  value: {} as Record<string, { missed: number; resumeFrom: number } | undefined>,
+  value: {} as Record<string, { missed: number; events: number; resumeFrom: number } | undefined>,
 }));
 const mockMessages = vi.hoisted(() => ({ value: {} as Record<string, number> }));
 const mockEvents = vi.hoisted(() => ({ value: {} as Record<string, number> }));
@@ -51,6 +51,7 @@ vi.mock("../lib/notificationPrefs", () => ({
 
 import { channelKey } from "../lib/channelKey";
 import { conversationMuteKey } from "../lib/conversationMute";
+import { setShowEventBadge } from "../lib/eventBadge";
 import WindowBadges, { badgeLabel, FAR_BEHIND_CLASS, MUTED_CLASS } from "../WindowBadges";
 
 const BEHIND = channelKey("freenode", "#italia");
@@ -63,11 +64,16 @@ beforeEach(() => {
   mockEvents.value = { [BEHIND]: 40, [NORMAL]: 2 };
   mockMentions.value = {};
   setMutedTargets({});
+  // #2037 B — the events pill is now OPT-IN (default OFF). These specs are
+  // ABOUT that pill (its far-behind modifier, its muted modifier), so they opt
+  // in rather than lose the coverage. The default itself is pinned separately
+  // below, which is where a regression to opt-OUT would be caught.
+  setShowEventBadge(true);
 });
 
 describe("#888 far-behind badge treatment", () => {
   it("marks BOTH unread badges of a far-behind window", () => {
-    mockFarBehind.value = { [BEHIND]: { missed: 1832, resumeFrom: 10 } };
+    mockFarBehind.value = { [BEHIND]: { missed: 1832, events: 40, resumeFrom: 10 } };
     const { container } = render(() => <WindowBadges channelKey={BEHIND} variant="sidebar" />);
 
     const msg = container.querySelector(".sidebar-msg-unread");
@@ -82,7 +88,7 @@ describe("#888 far-behind badge treatment", () => {
   });
 
   it("says what the number means, on hover and to a screen reader", () => {
-    mockFarBehind.value = { [BEHIND]: { missed: 1832, resumeFrom: 10 } };
+    mockFarBehind.value = { [BEHIND]: { missed: 1832, events: 40, resumeFrom: 10 } };
     render(() => <WindowBadges channelKey={BEHIND} variant="sidebar" />);
 
     // Production's own wording, called the way production calls it — a
@@ -96,7 +102,7 @@ describe("#888 far-behind badge treatment", () => {
   });
 
   it("leaves a merely-unread window alone", () => {
-    mockFarBehind.value = { [BEHIND]: { missed: 1832, resumeFrom: 10 } };
+    mockFarBehind.value = { [BEHIND]: { missed: 1832, events: 40, resumeFrom: 10 } };
     const { container } = render(() => <WindowBadges channelKey={NORMAL} variant="sidebar" />);
 
     const msg = container.querySelector(".sidebar-msg-unread");
@@ -110,7 +116,7 @@ describe("#888 far-behind badge treatment", () => {
   });
 
   it("clears the treatment as soon as the far-behind record clears", () => {
-    mockFarBehind.value = { [BEHIND]: { missed: 1832, resumeFrom: 10 } };
+    mockFarBehind.value = { [BEHIND]: { missed: 1832, events: 40, resumeFrom: 10 } };
     const { container, unmount } = render(() => (
       <WindowBadges channelKey={BEHIND} variant="sidebar" />
     ));
@@ -129,7 +135,7 @@ describe("#888 far-behind badge treatment", () => {
   });
 
   it("applies the same treatment on the mobile bottom-bar variant", () => {
-    mockFarBehind.value = { [BEHIND]: { missed: 1832, resumeFrom: 10 } };
+    mockFarBehind.value = { [BEHIND]: { missed: 1832, events: 40, resumeFrom: 10 } };
     const { container } = render(() => <WindowBadges channelKey={BEHIND} variant="bottom-bar" />);
 
     const msg = container.querySelector(".bottom-bar-msg-unread");
@@ -142,7 +148,7 @@ describe("#888 far-behind badge treatment", () => {
   });
 
   it("does not touch the mention badge (server-authoritative, not cursor-frozen)", () => {
-    mockFarBehind.value = { [BEHIND]: { missed: 1832, resumeFrom: 10 } };
+    mockFarBehind.value = { [BEHIND]: { missed: 1832, events: 40, resumeFrom: 10 } };
     mockMentions.value = { [BEHIND]: 4 };
     const { container } = render(() => <WindowBadges channelKey={BEHIND} variant="sidebar" />);
 
@@ -227,7 +233,7 @@ describe("#1077 muted badge treatment", () => {
   });
 
   it("composes with the far-behind treatment rather than replacing it", () => {
-    mockFarBehind.value = { [BEHIND]: { missed: 1832, resumeFrom: 10 } };
+    mockFarBehind.value = { [BEHIND]: { missed: 1832, events: 40, resumeFrom: 10 } };
     setMutedTargets({ [conversationMuteKey("freenode", "#italia")]: { until: null } });
     const { container } = render(() => <WindowBadges channelKey={BEHIND} variant="sidebar" />);
     const msg = container.querySelector(".sidebar-msg-unread");

--- a/cicchetto/src/__tests__/displayPrefs.test.ts
+++ b/cicchetto/src/__tests__/displayPrefs.test.ts
@@ -13,6 +13,7 @@ import {
   syncedSetStripFormatting,
   syncedSetTimeFormat,
 } from "../lib/displayPrefs";
+import { getShowEventBadge, setShowEventBadge } from "../lib/eventBadge";
 import {
   getAllPresencePrefs,
   getChannelPresencePref,
@@ -56,6 +57,7 @@ function resetLocal(): void {
   replacePresencePrefs({});
   setShowBottomBar(true);
   setStripFormatting(false);
+  setShowEventBadge(false);
   setToken(null);
 }
 
@@ -88,12 +90,13 @@ afterEach(() => {
 });
 
 describe("buildWireMap", () => {
-  it("reads the five module getters into the wire shape", () => {
+  it("reads the six module getters into the wire shape", () => {
     setTimeFormat("hm");
     setColoredNicklist(true);
     replacePresencePrefs({ [KEY_A]: "hide" });
     setShowBottomBar(false);
     setStripFormatting(true);
+    setShowEventBadge(true);
 
     expect(buildWireMap()).toEqual({
       time_format: "hm",
@@ -101,7 +104,17 @@ describe("buildWireMap", () => {
       presence_filter: { [KEY_A]: "hide" },
       show_bottom_bar: false,
       strip_formatting: true,
+      show_event_badge: true,
     });
+  });
+
+  // #2037 B — the sixth key is the first whose default REMOVES something an
+  // operator already sees, so the default earns its own pin: a bundle that
+  // shipped it opt-OUT by accident would silently keep the third number on
+  // screen and nothing else here would notice.
+  it("defaults show_event_badge to false — the events pill is opt-in", () => {
+    expect(getShowEventBadge()).toBe(false);
+    expect(buildWireMap().show_event_badge).toBe(false);
   });
 
   it("emits an empty presence_filter when no channel is pinned", () => {
@@ -292,6 +305,7 @@ describe("mountDisplayPrefsSync — login reconcile", () => {
         presence_filter: { [KEY_A]: "hide" },
         show_bottom_bar: false,
         strip_formatting: true,
+        show_event_badge: false,
       },
     });
 
@@ -368,6 +382,7 @@ describe("syncedSet* — optimistic local + full-map PUT", () => {
         presence_filter: { [KEY_A]: "hide" },
         show_bottom_bar: true,
         strip_formatting: false,
+        show_event_badge: false,
       },
     });
   });
@@ -457,6 +472,7 @@ describe("mountDisplayPrefsSync — clear-on-logout (no cross-account bleed)", (
     presence_filter: {},
     show_bottom_bar: true,
     strip_formatting: false,
+    show_event_badge: false,
   };
 
   // Phase-mutable fetch stub: the GET body changes across A-login / B-login.

--- a/cicchetto/src/__tests__/loadInitialScrollback.test.ts
+++ b/cicchetto/src/__tests__/loadInitialScrollback.test.ts
@@ -19,7 +19,14 @@
 // skip-empty-page.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ScrollbackMessage } from "../lib/api";
+import type { GapProbe, ScrollbackMessage } from "../lib/api";
+
+// #2037 — the gap probe returns three numbers now: `gap` (raw rows, the
+// threshold's input) and the `{messages, events}` display split. These specs
+// were written about the gap, so the helper reports a window whose unread is
+// all content — the messages count then equals the gap and every assertion
+// below keeps meaning exactly what it meant.
+const probe = (gap: number, events = 0) => ({ gap, messages: gap - events, events });
 
 // Mock socket so importing scrollback's transitive graph doesn't open a
 // real WebSocket against jsdom's about:blank base URL. Mirrors
@@ -54,7 +61,7 @@ vi.mock("../lib/auth", () => ({
 // exists) returns a server-shaped ASC page.
 const listMessagesSpy = vi.fn<(...a: unknown[]) => Promise<ScrollbackMessage[]>>();
 const listMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<ScrollbackMessage[]>>();
-const countMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<number>>();
+const countMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<GapProbe>>();
 vi.mock("../lib/api", async () => {
   const actual = await vi.importActual<typeof import("../lib/api")>("../lib/api");
   return {
@@ -100,7 +107,7 @@ describe("loadInitialScrollback cursor baseline", () => {
     listMessagesAfterSpy.mockResolvedValue([]);
     countMessagesAfterSpy.mockReset();
     // Default: a small gap, i.e. the pre-#693 contiguous resume.
-    countMessagesAfterSpy.mockResolvedValue(0);
+    countMessagesAfterSpy.mockResolvedValue(probe(0));
     mockTokenValue = "test-bearer";
   });
 
@@ -177,7 +184,7 @@ describe("#693 far-behind resume", () => {
     listMessagesAfterSpy.mockReset();
     listMessagesAfterSpy.mockResolvedValue([]);
     countMessagesAfterSpy.mockReset();
-    countMessagesAfterSpy.mockResolvedValue(0);
+    countMessagesAfterSpy.mockResolvedValue(probe(0));
     mockTokenValue = "test-bearer";
   });
 
@@ -187,7 +194,7 @@ describe("#693 far-behind resume", () => {
     const { channelKey } = await import("../lib/channelKey");
     applyJoinReply("net", "#flood", 100);
     // 3000 rows accumulated while the operator was away; the tail is 3100.
-    countMessagesAfterSpy.mockResolvedValue(3000);
+    countMessagesAfterSpy.mockResolvedValue(probe(3000));
     listMessagesSpy.mockResolvedValue([row(3100), row(3099), row(3098)]);
 
     await loadInitialScrollback("net", "#flood");
@@ -205,13 +212,14 @@ describe("#693 far-behind resume", () => {
     const { applyJoinReply } = await import("../lib/readCursor");
     const { channelKey } = await import("../lib/channelKey");
     applyJoinReply("net", "#missed", 100);
-    countMessagesAfterSpy.mockResolvedValue(3000);
+    countMessagesAfterSpy.mockResolvedValue(probe(3000));
     listMessagesSpy.mockResolvedValue([row(3100)]);
 
     await loadInitialScrollback("net", "#missed");
 
     expect(farBehindByChannel()[channelKey("net", "#missed")]).toEqual({
       missed: 3000,
+      events: 0,
       resumeFrom: 100,
     });
   });
@@ -221,7 +229,7 @@ describe("#693 far-behind resume", () => {
     const { applyJoinReply } = await import("../lib/readCursor");
     const { channelKey } = await import("../lib/channelKey");
     applyJoinReply("net", "#small", 100);
-    countMessagesAfterSpy.mockResolvedValue(12);
+    countMessagesAfterSpy.mockResolvedValue(probe(12));
     listMessagesAfterSpy.mockResolvedValue([row(101), row(102)]);
     listMessagesSpy.mockResolvedValue([row(100), row(99)]);
 
@@ -259,7 +267,7 @@ describe("#693 far-behind resume", () => {
     const { channelKey } = await import("../lib/channelKey");
     const key = channelKey("net", "#jump");
     applyJoinReply("net", "#jump", 100);
-    countMessagesAfterSpy.mockResolvedValue(3000);
+    countMessagesAfterSpy.mockResolvedValue(probe(3000));
     listMessagesSpy.mockResolvedValue([row(3100), row(3099)]);
     await loadInitialScrollback("net", "#jump");
 
@@ -295,7 +303,7 @@ describe("#693 far-behind resume", () => {
     const { channelKey } = await import("../lib/channelKey");
     const key = channelKey("net", "#truncated");
     applyJoinReply("net", "#truncated", 100);
-    countMessagesAfterSpy.mockResolvedValue(3000);
+    countMessagesAfterSpy.mockResolvedValue(probe(3000));
     listMessagesSpy.mockResolvedValue([row(3100)]);
     await loadInitialScrollback("net", "#truncated");
 
@@ -318,7 +326,7 @@ describe("#693 far-behind resume", () => {
     const { channelKey } = await import("../lib/channelKey");
     const key = channelKey("net", "#drained");
     applyJoinReply("net", "#drained", 100);
-    countMessagesAfterSpy.mockResolvedValue(3000);
+    countMessagesAfterSpy.mockResolvedValue(probe(3000));
     listMessagesSpy.mockResolvedValue([row(3100)]);
     await loadInitialScrollback("net", "#drained");
 
@@ -341,7 +349,7 @@ describe("#693 far-behind resume", () => {
     const fullPage = Array.from({ length: 200 }, (_, i) => row(501 + i));
     listMessagesAfterSpy.mockResolvedValue(fullPage);
     // ...and the probe says 2000 rows still sit past the last one ingested.
-    countMessagesAfterSpy.mockResolvedValue(2000);
+    countMessagesAfterSpy.mockResolvedValue(probe(2000));
     listMessagesSpy.mockResolvedValue([row(2900), row(2899)]);
 
     await refreshScrollback("net", "#resume");
@@ -351,7 +359,7 @@ describe("#693 far-behind resume", () => {
     expect(tailOf(scrollbackByChannel()[key])).toBe(2900);
     // ...while the jump TARGET is the operator's read position (500) — see the
     // re-probe case below.
-    expect(farBehindByChannel()[key]).toEqual({ missed: 2000, resumeFrom: 500 });
+    expect(farBehindByChannel()[key]).toEqual({ missed: 2000, events: 0, resumeFrom: 500 });
   });
 
   it("reconnect: a full backfill page that drains the gap keeps its rows", async () => {
@@ -366,7 +374,7 @@ describe("#693 far-behind resume", () => {
     listMessagesAfterSpy.mockResolvedValue(fullPage);
     // Only 10 rows behind after that page — one more scroll closes it, so the
     // pane must NOT be thrown away.
-    countMessagesAfterSpy.mockResolvedValue(10);
+    countMessagesAfterSpy.mockResolvedValue(probe(10));
 
     await refreshScrollback("net", "#drained");
 
@@ -400,7 +408,7 @@ describe("#693 far-behind resume", () => {
     listMessagesAfterSpy.mockResolvedValue(Array.from({ length: 200 }, (_, i) => row(501 + i)));
     // First probe (at the anchor 700) says 2000; the re-probe at the cursor
     // says 2200 — the same region plus the 200 rows just ingested.
-    countMessagesAfterSpy.mockResolvedValueOnce(2000).mockResolvedValueOnce(2200);
+    countMessagesAfterSpy.mockResolvedValueOnce(probe(2000)).mockResolvedValueOnce(probe(2200));
     listMessagesSpy.mockResolvedValue([row(2900)]);
 
     await refreshScrollback("net", "#target");
@@ -409,6 +417,7 @@ describe("#693 far-behind resume", () => {
     expect(countMessagesAfterSpy).toHaveBeenNthCalledWith(2, "test-bearer", "net", "#target", 500);
     expect(farBehindByChannel()[channelKey("net", "#target")]).toEqual({
       missed: 2200,
+      events: 0,
       resumeFrom: 500,
     });
   });
@@ -425,7 +434,7 @@ describe("#693 far-behind resume", () => {
     const { channelKey } = await import("../lib/channelKey");
     const key = channelKey("net", "#live");
     applyJoinReply("net", "#live", 100);
-    countMessagesAfterSpy.mockResolvedValue(3000);
+    countMessagesAfterSpy.mockResolvedValue(probe(3000));
     listMessagesSpy.mockImplementation(async () => {
       // The WS delivers row 3101 while the tail page is in flight.
       appendToScrollback(key, row(3101));
@@ -450,7 +459,7 @@ describe("#693 far-behind resume", () => {
     const key = channelKey("net", "#race");
     applyJoinReply("net", "#race", 100);
     // The cold load sees a small gap and takes the anchored branch...
-    countMessagesAfterSpy.mockResolvedValue(10);
+    countMessagesAfterSpy.mockResolvedValue(probe(10));
     let releaseAnchored: (rows: ScrollbackMessage[]) => void = () => {};
     listMessagesAfterSpy.mockImplementation(
       () =>
@@ -465,7 +474,7 @@ describe("#693 far-behind resume", () => {
     const { farBehindByChannel } = await import("../lib/scrollback");
     expect(farBehindByChannel()[key]).toBeUndefined();
     listMessagesSpy.mockResolvedValue([row(3100), row(3099)]);
-    countMessagesAfterSpy.mockResolvedValue(3000);
+    countMessagesAfterSpy.mockResolvedValue(probe(3000));
     listMessagesAfterSpy.mockResolvedValueOnce(Array.from({ length: 200 }, (_, i) => row(101 + i)));
     await refreshScrollback("net", "#race");
     expect(farBehindByChannel()[key]).toBeDefined();
@@ -484,7 +493,7 @@ describe("#693 far-behind resume", () => {
     const { channelKey } = await import("../lib/channelKey");
     const key = channelKey("net", "#flaky");
     applyJoinReply("net", "#flaky", 100);
-    countMessagesAfterSpy.mockResolvedValue(3000);
+    countMessagesAfterSpy.mockResolvedValue(probe(3000));
     listMessagesSpy.mockResolvedValue([row(3100)]);
     await loadInitialScrollback("net", "#flaky");
 
@@ -504,7 +513,7 @@ describe("#693 far-behind resume", () => {
     const { applyJoinReply } = await import("../lib/readCursor");
     const { channelKey } = await import("../lib/channelKey");
     applyJoinReply("net", "oldpeer", 100);
-    countMessagesAfterSpy.mockResolvedValue(3000);
+    countMessagesAfterSpy.mockResolvedValue(probe(3000));
     listMessagesSpy.mockResolvedValue([row(3100)]);
     await loadInitialScrollback("net", "oldpeer");
 
@@ -512,6 +521,7 @@ describe("#693 far-behind resume", () => {
 
     expect(farBehindByChannel()[channelKey("net", "newpeer")]).toEqual({
       missed: 3000,
+      events: 0,
       resumeFrom: 100,
     });
     expect(farBehindByChannel()[channelKey("net", "oldpeer")]).toBeUndefined();
@@ -525,7 +535,7 @@ describe("#693 far-behind resume", () => {
     const { channelKey } = await import("../lib/channelKey");
     const key = channelKey("net", "#dismiss");
     applyJoinReply("net", "#dismiss", 100);
-    countMessagesAfterSpy.mockResolvedValue(3000);
+    countMessagesAfterSpy.mockResolvedValue(probe(3000));
     listMessagesSpy.mockResolvedValue([row(3100), row(3099)]);
     await loadInitialScrollback("net", "#dismiss");
 

--- a/cicchetto/src/__tests__/scrollbackIdentityRotation.test.ts
+++ b/cicchetto/src/__tests__/scrollbackIdentityRotation.test.ts
@@ -24,7 +24,14 @@
 
 import { createSignal } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ScrollbackMessage } from "../lib/api";
+import type { GapProbe, ScrollbackMessage } from "../lib/api";
+
+// #2037 — the gap probe returns three numbers now: `gap` (raw rows, the
+// threshold's input) and the `{messages, events}` display split. These specs
+// were written about the gap, so the helper reports a window whose unread is
+// all content — the messages count then equals the gap and every assertion
+// below keeps meaning exactly what it meant.
+const probe = (gap: number, events = 0) => ({ gap, messages: gap - events, events });
 
 // Mirrors loadInitialScrollback.test.ts: keep importing scrollback's
 // transitive graph from opening a real WebSocket against jsdom's
@@ -50,7 +57,7 @@ vi.mock("../lib/auth", () => ({
 
 const listMessagesSpy = vi.fn<(...a: unknown[]) => Promise<ScrollbackMessage[]>>();
 const listMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<ScrollbackMessage[]>>();
-const countMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<number>>();
+const countMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<GapProbe>>();
 vi.mock("../lib/api", async () => {
   const actual = await vi.importActual<typeof import("../lib/api")>("../lib/api");
   return {
@@ -127,7 +134,7 @@ describe("#788 identity rotation mid-flight", () => {
     listMessagesAfterSpy.mockReset();
     listMessagesAfterSpy.mockResolvedValue([]);
     countMessagesAfterSpy.mockReset();
-    countMessagesAfterSpy.mockResolvedValue(0);
+    countMessagesAfterSpy.mockResolvedValue(probe(0));
     setReadCursorSpy.mockClear();
     // Each test starts from a clean identity. Setting the token IS a
     // rotation, so this also fires the store purge between cases.

--- a/cicchetto/src/__tests__/scrollbackIngestCost.test.ts
+++ b/cicchetto/src/__tests__/scrollbackIngestCost.test.ts
@@ -249,7 +249,7 @@ describe("#1288 — the batched ingest keeps every per-row invariant", () => {
     vi.mocked(api.listMessagesAfter).mockResolvedValue(page);
     // A full page also triggers the #693 gap probe; answer "nothing more" so
     // the ingest is the only thing under test.
-    vi.mocked(api.countMessagesAfter).mockResolvedValue(0);
+    vi.mocked(api.countMessagesAfter).mockResolvedValue({ gap: 0, messages: 0, events: 0 });
     await scrollback.refreshScrollback(SLUG, CHAN);
 
     const rows = scrollback.scrollbackByChannel()[KEY] ?? [];
@@ -272,7 +272,7 @@ describe("#1288 — the batched ingest keeps every per-row invariant", () => {
     const page = Array.from({ length: 200 }, (_, i) => plainRow(cap + 1 + i));
     mockGetResumeCursor.mockReturnValue(cap);
     vi.mocked(api.listMessagesAfter).mockResolvedValue(page);
-    vi.mocked(api.countMessagesAfter).mockResolvedValue(0);
+    vi.mocked(api.countMessagesAfter).mockResolvedValue({ gap: 0, messages: 0, events: 0 });
     await scrollback.refreshScrollback(SLUG, CHAN);
 
     const ids = (scrollback.scrollbackByChannel()[KEY] ?? []).map((m) => m.id);
@@ -295,7 +295,7 @@ describe("#1288 — the batched ingest keeps every per-row invariant", () => {
     const page = Array.from({ length: 200 }, (_, i) => plainRow(cap + 1 + i));
     mockGetResumeCursor.mockReturnValue(cap);
     vi.mocked(api.listMessagesAfter).mockResolvedValue(page);
-    vi.mocked(api.countMessagesAfter).mockResolvedValue(0);
+    vi.mocked(api.countMessagesAfter).mockResolvedValue({ gap: 0, messages: 0, events: 0 });
     await scrollback.refreshScrollback(SLUG, CHAN);
 
     const rows = scrollback.scrollbackByChannel()[KEY] ?? [];
@@ -321,7 +321,7 @@ describe("#1288 — the batched ingest keeps every per-row invariant", () => {
     const page = Array.from({ length: 200 }, (_, i) => plainRow(cap + 1 + i));
     mockGetResumeCursor.mockReturnValue(cap);
     vi.mocked(api.listMessagesAfter).mockResolvedValue(page);
-    vi.mocked(api.countMessagesAfter).mockResolvedValue(0);
+    vi.mocked(api.countMessagesAfter).mockResolvedValue({ gap: 0, messages: 0, events: 0 });
     await scrollback.refreshScrollback(SLUG, CHAN);
     expect(scrollback.scrollbackByChannel()[KEY]?.some((m) => m.id === 1)).toBe(false);
 

--- a/cicchetto/src/__tests__/unread2037AnchorProbe.test.ts
+++ b/cicchetto/src/__tests__/unread2037AnchorProbe.test.ts
@@ -23,7 +23,7 @@
 //     and there is no anchor term at all.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ScrollbackMessage } from "../lib/api";
+import type { GapProbe, ScrollbackMessage } from "../lib/api";
 
 vi.mock("../lib/socket", () => ({
   joinUser: vi.fn(() => ({ on: vi.fn(), push: vi.fn().mockReturnValue({ receive: vi.fn() }) })),
@@ -48,7 +48,7 @@ vi.mock("../lib/auth", () => ({
 
 const listMessagesSpy = vi.fn<(...a: unknown[]) => Promise<ScrollbackMessage[]>>();
 const listMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<ScrollbackMessage[]>>();
-const countMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<number>>();
+const countMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<GapProbe>>();
 vi.mock("../lib/api", async () => {
   const actual = await vi.importActual<typeof import("../lib/api")>("../lib/api");
   return {
@@ -95,7 +95,7 @@ describe("issue 2037 — the ANCHOR term, measured with its sign", () => {
     listMessagesAfterSpy.mockReset();
     listMessagesAfterSpy.mockResolvedValue([]);
     countMessagesAfterSpy.mockReset();
-    countMessagesAfterSpy.mockResolvedValue(0);
+    countMessagesAfterSpy.mockResolvedValue({ gap: 0, messages: 0, events: 0 });
     mockTokenValue = "test-bearer";
   });
 
@@ -109,14 +109,18 @@ describe("issue 2037 — the ANCHOR term, measured with its sign", () => {
     const { channelKey } = await import("../lib/channelKey");
 
     applyJoinReply("net", "#coldprobe", 100);
-    countMessagesAfterSpy.mockResolvedValue(1807);
+    // #2037 — the probe now returns three numbers. The bar renders `messages`;
+    // `gap` is what `isFarBehind` reads. Kept distinct here on purpose, so the
+    // assertions below say WHICH one reached the bar.
+    countMessagesAfterSpy.mockResolvedValue({ gap: 1807, messages: 187, events: 216 });
     listMessagesSpy.mockResolvedValue([row(1907), row(1906)]);
 
     await loadInitialScrollback("net", "#coldprobe");
 
     expect(anchorsProbed()).toEqual([100]);
     expect(farBehindByChannel()[channelKey("net", "#coldprobe")]).toEqual({
-      missed: 1807,
+      missed: 187,
+      events: 216,
       resumeFrom: 100,
     });
   });
@@ -139,7 +143,9 @@ describe("issue 2037 — the ANCHOR term, measured with its sign", () => {
     // Monotone in the anchor: the earlier anchor (the cursor) counts MORE.
     countMessagesAfterSpy.mockImplementation(async (..._a: unknown[]) => {
       const anchor = _a[3] as number;
-      return anchor === 100 ? 1807 : 1500;
+      return anchor === 100
+        ? { gap: 1807, messages: 187, events: 216 }
+        : { gap: 1500, messages: 150, events: 180 };
     });
 
     await refreshScrollback("net", "#twoanchors");
@@ -155,7 +161,8 @@ describe("issue 2037 — the ANCHOR term, measured with its sign", () => {
     expect(probed[1] as number).toBeLessThan(probed[0] as number);
 
     expect(farBehindByChannel()[channelKey("net", "#twoanchors")]).toEqual({
-      missed: 1807,
+      missed: 187,
+      events: 216,
       resumeFrom: 100,
     });
   });
@@ -180,23 +187,28 @@ describe("issue 2037 — the ANCHOR term, measured with its sign", () => {
     countMessagesAfterSpy.mockImplementation(async (..._a: unknown[]) => {
       const anchor = _a[3] as number;
       if (anchor === 100) throw new Error("probe failed");
-      return 1500;
+      return { gap: 1500, messages: 150, events: 180 };
     });
 
     await refreshScrollback("net", "#reprobefail");
 
     const far = farBehindByChannel()[channelKey("net", "#reprobefail")];
-    expect(far).toEqual({ missed: 1500, resumeFrom: 300 });
-    // The fallback number is SMALLER than the cursor-anchored one (1807 in
-    // the case above, same fixture): the anchor term's sign is <= 0.
-    expect(far?.missed as number).toBeLessThan(1807);
+    expect(far).toEqual({ missed: 150, events: 180, resumeFrom: 300 });
+    // The fallback number is SMALLER than the cursor-anchored one (187 in the
+    // case above, same fixture): the anchor term's sign is <= 0. Measured on
+    // the DISPLAY quantity now, which is the one the operator reads.
+    expect(far?.missed as number).toBeLessThan(187);
   });
 
   // Where the SIDEBAR number comes from while the bar is up. The seed is
   // whatever the server last pushed for the key; the bar is a separate probe.
   // Two numbers, two server functions, ONE anchor — so the residual between
   // them is a PREDICATE difference, not an anchor difference.
-  it("the far-behind badge is the server seed, untouched by the bar's probe", async () => {
+  // #2037 A — after the cure this is no longer "the seed survives"; it is
+  // "the bar and the badge are the SAME VARIABLE". `perChannelUnread` reads
+  // the far-behind entry for a far-behind key, and the bar renders the same
+  // field, so they cannot disagree by construction rather than by luck.
+  it("the far-behind badge and the bar read one value (#2037)", async () => {
     const { loadInitialScrollback } = await import("../lib/scrollback");
     const { applyJoinReply } = await import("../lib/readCursor");
     const { channelKey } = await import("../lib/channelKey");
@@ -207,15 +219,21 @@ describe("issue 2037 — the ANCHOR term, measured with its sign", () => {
     // The join reply's `window_counts` — `Scrollback.count_after_split/6`,
     // anchored at the SAME cursor the bar probes at.
     setServerSeedCount(key, { messages: 187, events: 216 });
-    countMessagesAfterSpy.mockResolvedValue(1807);
+    countMessagesAfterSpy.mockResolvedValue({ gap: 1807, messages: 187, events: 216 });
     listMessagesSpy.mockResolvedValue([row(1907), row(1906)]);
 
     await loadInitialScrollback("net", "#seedwins");
 
+    const { farBehindByChannel } = await import("../lib/scrollback");
+    const far = farBehindByChannel()[key];
+    expect(far?.missed).toBe(187);
     expect(messagesUnread()[key]).toBe(187);
     expect(eventsUnread()[key]).toBe(216);
-    // ...while the bar rendered 1807 from the same anchor. Same anchor, three
-    // numbers.
+    // The bar renders `far.missed`; the pill renders `messagesUnread()[key]`.
+    // Same value, one origin. Before #2037 the bar showed 1807 here — the raw
+    // `gap`, which is still probed and still decides the threshold, and is now
+    // never rendered.
+    expect(far?.missed).toBe(messagesUnread()[key]);
     expect(anchorsProbed()).toEqual([100]);
   });
 });

--- a/cicchetto/src/__tests__/unread2037AnchorProbe.test.ts
+++ b/cicchetto/src/__tests__/unread2037AnchorProbe.test.ts
@@ -1,0 +1,221 @@
+// issue 2037 — MEASUREMENT INSTRUMENT for the ANCHOR term, not a regression
+// test.
+//
+// The issue body says own-authored rows plus the content/events split account
+// for the bar-vs-badge mismatch "in direction and in kind" but not in size
+// (1807 - 403 = 1404), and names the ANCHOR as the remaining candidate:
+//
+//   > `resolveJumpTarget` returns `missed` from `probeGap(cursor)` but falls
+//   > back to `missedAtAnchor` with `resumeFrom: anchor` when the probe fails
+//   > — two different anchors reachable on the same screen.
+//
+// The anchor lives on the CLIENT, so this is where it is measurable. What is
+// measured here is not just the size of the term but its SIGN: a residual of
+// +1404 needs a term that makes the BAR BIGGER than the badge, and the two
+// anchors this file exercises are ordered (`cursor <= high-water mark`) with
+// `countMessagesAfter` monotone non-increasing in its anchor.
+//
+// Controls, both inside the file and both asserted before the sign claim:
+//   * POSITIVE — the divergent case must actually reach the wire with TWO
+//     DIFFERENT anchors. Without that assertion a passing sign check would be
+//     compatible with a harness that only ever probed once.
+//   * NEGATIVE — when the cursor equals the anchor, exactly ONE probe is made
+//     and there is no anchor term at all.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScrollbackMessage } from "../lib/api";
+
+vi.mock("../lib/socket", () => ({
+  joinUser: vi.fn(() => ({ on: vi.fn(), push: vi.fn().mockReturnValue({ receive: vi.fn() }) })),
+  joinChannel: vi.fn(() => ({
+    join: vi.fn(() => ({ receive: vi.fn().mockReturnValue({ receive: vi.fn() }) })),
+    on: vi.fn(),
+  })),
+  pushCloseQueryWindow: vi.fn(),
+  pushOpenQueryWindow: vi.fn(),
+  notifyClientClosing: vi.fn(),
+  pushAwaySet: vi.fn(),
+  pushAwayUnset: vi.fn(),
+}));
+
+let mockTokenValue: string | null = null;
+vi.mock("../lib/auth", () => ({
+  token: () => mockTokenValue,
+  setToken: vi.fn((v: string | null) => {
+    mockTokenValue = v;
+  }),
+}));
+
+const listMessagesSpy = vi.fn<(...a: unknown[]) => Promise<ScrollbackMessage[]>>();
+const listMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<ScrollbackMessage[]>>();
+const countMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<number>>();
+vi.mock("../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../lib/api")>("../lib/api");
+  return {
+    ...actual,
+    listMessages: (...args: unknown[]) => listMessagesSpy(...args),
+    listMessagesAfter: (...args: unknown[]) => listMessagesAfterSpy(...args),
+    countMessagesAfter: (...args: unknown[]) => countMessagesAfterSpy(...args),
+  };
+});
+
+const setReadCursorSpy = vi.fn().mockResolvedValue(undefined);
+vi.mock("../lib/readCursor", async () => {
+  const actual = await vi.importActual<typeof import("../lib/readCursor")>("../lib/readCursor");
+  return {
+    ...actual,
+    setReadCursor: (...args: Parameters<typeof actual.setReadCursor>) => setReadCursorSpy(...args),
+  };
+});
+
+const PAGE_LIMIT = 200;
+
+const row = (id: number): ScrollbackMessage => ({
+  id,
+  network: "net",
+  channel: "#chan",
+  server_time: 1_700_000_000 + id,
+  kind: "privmsg",
+  sender: "peer",
+  body: `line ${id}`,
+  meta: {},
+});
+
+// The anchors the two probes carry, recovered from the spy rather than
+// assumed: `countMessagesAfter(t, slug, name, anchor)`.
+const anchorsProbed = (): number[] => countMessagesAfterSpy.mock.calls.map((c) => c[3] as number);
+
+describe("issue 2037 — the ANCHOR term, measured with its sign", () => {
+  beforeEach(async () => {
+    const { clearReadCursors } = await import("../lib/readCursor");
+    clearReadCursors();
+    setReadCursorSpy.mockClear();
+    listMessagesSpy.mockReset();
+    listMessagesSpy.mockResolvedValue([]);
+    listMessagesAfterSpy.mockReset();
+    listMessagesAfterSpy.mockResolvedValue([]);
+    countMessagesAfterSpy.mockReset();
+    countMessagesAfterSpy.mockResolvedValue(0);
+    mockTokenValue = "test-bearer";
+  });
+
+  // NEGATIVE CONTROL. The cold-open path holds ONE anchor: the read cursor,
+  // which is the same integer `ReadCursor.bulk_unread_split/3` anchors the
+  // sidebar seed at. No anchor term exists on this path — so a residual
+  // measured on a cold open cannot be blamed on the anchor.
+  it("NEG CTRL — cold open probes exactly once, at the read cursor", async () => {
+    const { loadInitialScrollback, farBehindByChannel } = await import("../lib/scrollback");
+    const { applyJoinReply } = await import("../lib/readCursor");
+    const { channelKey } = await import("../lib/channelKey");
+
+    applyJoinReply("net", "#coldprobe", 100);
+    countMessagesAfterSpy.mockResolvedValue(1807);
+    listMessagesSpy.mockResolvedValue([row(1907), row(1906)]);
+
+    await loadInitialScrollback("net", "#coldprobe");
+
+    expect(anchorsProbed()).toEqual([100]);
+    expect(farBehindByChannel()[channelKey("net", "#coldprobe")]).toEqual({
+      missed: 1807,
+      resumeFrom: 100,
+    });
+  });
+
+  // POSITIVE CONTROL + the measurement. The reconnect path holds TWO anchors:
+  // the high-water mark of the page it just ingested, and the read cursor
+  // behind it. The control is that both reach the wire; the measurement is
+  // which number the bar ends up rendering.
+  it("POS CTRL — reconnect probes TWO anchors; the bar renders the CURSOR one", async () => {
+    const { refreshScrollback, farBehindByChannel } = await import("../lib/scrollback");
+    const { applyJoinReply } = await import("../lib/readCursor");
+    const { channelKey } = await import("../lib/channelKey");
+
+    applyJoinReply("net", "#twoanchors", 100);
+    // A FULL page, so the >1-page probe arm is entered. Its last row is the
+    // high-water anchor.
+    const page = Array.from({ length: PAGE_LIMIT }, (_, i) => row(101 + i));
+    listMessagesAfterSpy.mockResolvedValue(page);
+    listMessagesSpy.mockResolvedValue([row(2000)]);
+    // Monotone in the anchor: the earlier anchor (the cursor) counts MORE.
+    countMessagesAfterSpy.mockImplementation(async (..._a: unknown[]) => {
+      const anchor = _a[3] as number;
+      return anchor === 100 ? 1807 : 1500;
+    });
+
+    await refreshScrollback("net", "#twoanchors");
+
+    const probed = anchorsProbed();
+    // POS CTRL: two DISTINCT anchors actually reached the wire, and they are
+    // ordered cursor <= high-water. Without this the sign claim below would
+    // be vacuous.
+    expect(probed).toHaveLength(2);
+    expect(new Set(probed).size).toBe(2);
+    expect(probed[0]).toBe(300);
+    expect(probed[1]).toBe(100);
+    expect(probed[1] as number).toBeLessThan(probed[0] as number);
+
+    expect(farBehindByChannel()[channelKey("net", "#twoanchors")]).toEqual({
+      missed: 1807,
+      resumeFrom: 100,
+    });
+  });
+
+  // THE SIGN. The one branch that renders the OTHER anchor's number is the
+  // re-probe failure the issue body names. Measured: it renders the SMALLER
+  // number, because the anchor it falls back to is FURTHER FORWARD than the
+  // cursor and `count_after/6` is monotone non-increasing in its anchor.
+  //
+  // Consequence for the issue: the anchor term is bounded ABOVE by zero. It
+  // can only ever make the far-behind bar UNDERCOUNT relative to a
+  // cursor-anchored badge — it cannot supply a positive 1404.
+  it("SIGN — a failed re-probe renders the HIGH-WATER number, which is SMALLER", async () => {
+    const { refreshScrollback, farBehindByChannel } = await import("../lib/scrollback");
+    const { applyJoinReply } = await import("../lib/readCursor");
+    const { channelKey } = await import("../lib/channelKey");
+
+    applyJoinReply("net", "#reprobefail", 100);
+    const page = Array.from({ length: PAGE_LIMIT }, (_, i) => row(101 + i));
+    listMessagesAfterSpy.mockResolvedValue(page);
+    listMessagesSpy.mockResolvedValue([row(2000)]);
+    countMessagesAfterSpy.mockImplementation(async (..._a: unknown[]) => {
+      const anchor = _a[3] as number;
+      if (anchor === 100) throw new Error("probe failed");
+      return 1500;
+    });
+
+    await refreshScrollback("net", "#reprobefail");
+
+    const far = farBehindByChannel()[channelKey("net", "#reprobefail")];
+    expect(far).toEqual({ missed: 1500, resumeFrom: 300 });
+    // The fallback number is SMALLER than the cursor-anchored one (1807 in
+    // the case above, same fixture): the anchor term's sign is <= 0.
+    expect(far?.missed as number).toBeLessThan(1807);
+  });
+
+  // Where the SIDEBAR number comes from while the bar is up. The seed is
+  // whatever the server last pushed for the key; the bar is a separate probe.
+  // Two numbers, two server functions, ONE anchor — so the residual between
+  // them is a PREDICATE difference, not an anchor difference.
+  it("the far-behind badge is the server seed, untouched by the bar's probe", async () => {
+    const { loadInitialScrollback } = await import("../lib/scrollback");
+    const { applyJoinReply } = await import("../lib/readCursor");
+    const { channelKey } = await import("../lib/channelKey");
+    const { setServerSeedCount, messagesUnread, eventsUnread } = await import("../lib/selection");
+
+    const key = channelKey("net", "#seedwins");
+    applyJoinReply("net", "#seedwins", 100);
+    // The join reply's `window_counts` — `Scrollback.count_after_split/6`,
+    // anchored at the SAME cursor the bar probes at.
+    setServerSeedCount(key, { messages: 187, events: 216 });
+    countMessagesAfterSpy.mockResolvedValue(1807);
+    listMessagesSpy.mockResolvedValue([row(1907), row(1906)]);
+
+    await loadInitialScrollback("net", "#seedwins");
+
+    expect(messagesUnread()[key]).toBe(187);
+    expect(eventsUnread()[key]).toBe(216);
+    // ...while the bar rendered 1807 from the same anchor. Same anchor, three
+    // numbers.
+    expect(anchorsProbed()).toEqual([100]);
+  });
+});

--- a/cicchetto/src/__tests__/unreadBadgeAtTail.test.ts
+++ b/cicchetto/src/__tests__/unreadBadgeAtTail.test.ts
@@ -28,7 +28,7 @@ vi.mock(import("../lib/api"), async (importOriginal) => {
     listChannels: vi.fn().mockResolvedValue([]),
     listMessages: vi.fn().mockResolvedValue([]),
     listMessagesAfter: vi.fn().mockResolvedValue([]),
-    countMessagesAfter: vi.fn().mockResolvedValue(0),
+    countMessagesAfter: vi.fn().mockResolvedValue({ gap: 0, messages: 0, events: 0 }),
     sendMessage: vi.fn(),
     me: vi.fn().mockResolvedValue({
       kind: "user",
@@ -156,7 +156,7 @@ describe("#981 unread badge on the window being read at the tail", () => {
   // on its own.
   it("keeps a FAR-BEHIND window's badge even while the pane reads its tail", async () => {
     const api = await import("../lib/api");
-    vi.mocked(api.countMessagesAfter).mockResolvedValue(3000);
+    vi.mocked(api.countMessagesAfter).mockResolvedValue({ gap: 3000, messages: 3000, events: 0 });
     vi.mocked(api.listMessages).mockResolvedValue([
       {
         id: 3100,
@@ -177,7 +177,7 @@ describe("#981 unread badge on the window being read at the tail", () => {
 
     applyJoinReply(SLUG, CHANNEL, 100);
     await loadInitialScrollback(SLUG, CHANNEL);
-    expect(farBehindByChannel()[key]).toEqual({ missed: 3000, resumeFrom: 100 });
+    expect(farBehindByChannel()[key]).toEqual({ missed: 3000, events: 0, resumeFrom: 100 });
 
     selection.setServerSeedCount(key, { messages: 3000, events: 0 });
     expect(selection.messagesUnread()[key]).toBe(3000);

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -2447,19 +2447,42 @@ export async function listMessagesAfter(
 // anchored pages on a cold load, the page just ingested on a reconnect. An
 // older server has no such route, and a client that hard-failed on that would
 // be worse than one that degrades.
+//
+// #2037 — the response now carries THREE numbers and this verb returns all
+// three, because the probe answers two questions and they must not be
+// conflated again:
+//
+//   * `gap` (the server's `count`) is the THRESHOLD input — raw rows a page
+//     would return, own-authored included. `isFarBehind(gap)` asks whether
+//     contiguous paging is achievable, which is a question about rows on the
+//     wire; the #2037 ruling puts it out of scope and it is unchanged.
+//   * `messages` / `events` are the DISPLAY split, the same partition the
+//     sidebar pills carry. The bar renders `messages`.
+//
+// Absent-tolerant, and deliberately: a server predating #2037 sends `count`
+// alone, and the pair then falls back to `{messages: count, events: 0}` —
+// i.e. exactly the pre-#2037 number in the pre-#2037 place. That degrades a
+// new bundle against an old server instead of breaking it, which is why
+// `min_protocol_version` does not move.
+export type GapProbe = { gap: number; messages: number; events: number };
+
 export async function countMessagesAfter(
   token: string,
   networkSlug: string,
   channelName: string,
   afterId: number,
-): Promise<number> {
+): Promise<GapProbe> {
   const res = await fetch(
     `/networks/${encodeURIComponent(networkSlug)}/channels/${encodeURIComponent(channelName)}/messages/count?after=${afterId}`,
     { headers: buildHeaders(token) },
   );
   if (!res.ok) throw await readError(res);
-  const body = (await res.json()) as { count: number };
-  return body.count;
+  const body = (await res.json()) as { count: number; messages?: number; events?: number };
+  return {
+    gap: body.count,
+    messages: typeof body.messages === "number" ? body.messages : body.count,
+    events: typeof body.events === "number" ? body.events : 0,
+  };
 }
 
 // Mirror of `GrappaWeb.MessagesController.create/2`. Server hardcodes

--- a/cicchetto/src/lib/displayPrefs.ts
+++ b/cicchetto/src/lib/displayPrefs.ts
@@ -2,6 +2,7 @@ import { createEffect } from "solid-js";
 import { token } from "./auth";
 import { type ChannelKey, decodeChannelKey } from "./channelKey";
 import { getColoredNicklist, setColoredNicklist } from "./colorNicklist";
+import { getShowEventBadge, setShowEventBadge } from "./eventBadge";
 import { identityMoved } from "./identityMoved";
 import {
   getAllPresencePrefs,
@@ -24,7 +25,8 @@ import { type DisplayPrefs, getDisplayPrefs, putDisplayPrefs } from "./userSetti
 // server round-trip on top.
 //
 // #1766 added a FOURTH owner module (`showBottomBar.ts`) on exactly that shape,
-// and #2029 a FIFTH (`stripFormatting.ts`). Every function below that names the
+// and #2029 a FIFTH (`stripFormatting.ts`), and #2037 a SIXTH
+// (`eventBadge.ts`). Every function below that names the
 // wire map has to grow with it — the default baseline, `buildWireMap`,
 // `applyServerPrefs` and a `syncedSet*` — and the server's
 // `default_display_prefs/0` is the authority for the default. Four touch points
@@ -66,6 +68,7 @@ const DEFAULT_DISPLAY_PREFS: Required<DisplayPrefs> = {
   presence_filter: {},
   show_bottom_bar: true,
   strip_formatting: false,
+  show_event_badge: false,
 };
 
 // #449 (issue222 regression fix) — the "unconfirmed local write" marker.
@@ -97,7 +100,7 @@ function hasUnsyncedWrite(): boolean {
   return localStorage.getItem(UNSYNCED_KEY) === "1";
 }
 
-// Read the five owner modules into the wire shape (the seed-up + every PUT
+// Read the six owner modules into the wire shape (the seed-up + every PUT
 // body). Pure snapshot; no reactivity intended. `show_bottom_bar` (#1766) and
 // `strip_formatting` (#2029) are OPTIONAL on the type (an older server omits
 // them on the way IN) but always populated here — cic is the writer, and it
@@ -109,10 +112,11 @@ export function buildWireMap(): Required<DisplayPrefs> {
     presence_filter: getAllPresencePrefs(),
     show_bottom_bar: getShowBottomBar(),
     strip_formatting: getStripFormatting(),
+    show_event_badge: getShowEventBadge(),
   };
 }
 
-// Distribute a server-authoritative payload into the five owner modules'
+// Distribute a server-authoritative payload into the six owner modules'
 // LOCAL setters (write-through to signal + localStorage). No re-PUT — this is
 // the server-wins apply path only. The presence map is a full replace so unset
 // channels stay unset.
@@ -135,6 +139,12 @@ export function applyServerPrefs(prefs: DisplayPrefs): void {
   // here it is even the DEFAULT one, so `||` would make the pref impossible to
   // turn back off from a second device.
   setStripFormatting(prefs.strip_formatting ?? DEFAULT_DISPLAY_PREFS.strip_formatting);
+  // #2037 B — coalesced for the third time and for the same reason (`--cic`
+  // ships this bundle ahead of the server). `??` and not `||` matters MORE
+  // here than for its two predecessors: `false` is this pref's default, so
+  // `||` would make it impossible to turn the badge back OFF from a second
+  // device once any device had turned it on.
+  setShowEventBadge(prefs.show_event_badge ?? DEFAULT_DISPLAY_PREFS.show_event_badge);
 }
 
 // Reactive server sync — re-runs on every `token()` change (registered inside a
@@ -236,6 +246,11 @@ export function syncedSetShowBottomBar(on: boolean): void {
 
 export function syncedSetStripFormatting(on: boolean): void {
   setStripFormatting(on);
+  pushDisplayPrefs();
+}
+
+export function syncedSetShowEventBadge(on: boolean): void {
+  setShowEventBadge(on);
   pushDisplayPrefs();
 }
 

--- a/cicchetto/src/lib/eventBadge.ts
+++ b/cicchetto/src/lib/eventBadge.ts
@@ -1,0 +1,72 @@
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
+
+// #2037 B — "show the events badge" display preference. Boolean, OFF by
+// default, and it is the FIRST of the six whose default takes something away.
+//
+// vjt's ruling on #2037, verbatim: "dobbiamo avere due bucket: messaggi e
+// !messaggi. i !messaggi non sono interessanti e devono solo finire nell'opt-in
+// badge." So the sidebar's faint pill — join/part/quit/nick/mode counts, and
+// see the warning below for what else — stops rendering unless the operator
+// asks for it.
+//
+// The reported confusion (#2037) was three numbers on one screen for what the
+// operator read as one quantity. Two of the three are now the same quantity by
+// construction (the far-behind bar and the bold pill both read the messages
+// bucket); this removes the third from the default view rather than trying to
+// explain it.
+//
+// ⚠️ WHAT THIS HIDES IS WIDER THAN join/part, and that is deliberate, not a
+// refactor accident. The events bucket is `kind not in @content_kinds`, which
+// includes `topic`, `kick` and `server_event` — the three that sit OUTSIDE
+// `Message.suppressed_presence_kinds/0` on purpose (#458), because the pane
+// still RENDERS them even on a presence-denoised channel. Rendering in the pane
+// and counting in a badge are different questions, and this pref answers only
+// the second. A KICK therefore stops contributing to a badge by default. If a
+// kick must stay loud it belongs in the mention/severity channel (#267) — not
+// smuggled into the message bucket, which would put a non-message back into the
+// number the bar now shares with the pill and undo the whole of #2037 A.
+//
+// ## SYNCED, on #1766's criterion
+//
+// Same shape and same posture as stripFormatting.ts: one of the #449
+// server-backed display prefs, coordinated by `displayPrefs.ts` over
+// `GET/PUT /me/settings/display-prefs`. A per-DEVICE toggle is right when the
+// complaint is about a VIEWPORT (#914's `hideNextActive`) and wrong when it is
+// about the ACCOUNT. "Is my sidebar cluttered with join/part counts" is
+// identical on the phone and on the desktop — the account axis.
+//
+// localStorage is the boot/offline cache for a FOUC-free first paint, not the
+// source of truth. `setShowEventBadge` stays LOCAL-only (signal + write-
+// through); the coordinator's synced setter adds the PUT.
+//
+// ## Why a signal
+//
+// It is read at RENDER time by `WindowBadges`, on every sidebar row. A bare
+// `localStorage.getItem` there would never re-run, so toggling the checkbox
+// would leave the pills up until a reload.
+
+const STORAGE_KEY = "cicchetto.showEventBadge";
+const DEFAULT_ON = false;
+
+function readStored(): boolean {
+  const v = localStorage.getItem(STORAGE_KEY);
+  return v === null ? DEFAULT_ON : v === "true";
+}
+
+// Module-singleton signal seeded from storage. `createRoot` anchors it for the
+// app lifetime (same shape as stripFormatting.ts) — the preference is
+// identity-agnostic, so no token-rotation reset arm is needed.
+const { current, setCurrent } = moduleRoot(() => {
+  const [current, setCurrent] = createSignal<boolean>(readStored());
+  return { current, setCurrent };
+});
+
+export function getShowEventBadge(): boolean {
+  return current();
+}
+
+export function setShowEventBadge(on: boolean): void {
+  localStorage.setItem(STORAGE_KEY, on ? "true" : "false");
+  setCurrent(on);
+}

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -2,6 +2,8 @@ import { batch, createSignal } from "solid-js";
 import {
   sendMessage as apiSendMessage,
   countMessagesAfter,
+  type GapProbe,
+  isContentKind,
   listMessages,
   listMessagesAfter,
   type MessageRelay,
@@ -212,6 +214,17 @@ type CappedRing = {
   // Unread rows (id > cursor) held BEFORE the drop — the banner's count the
   // first time the bound bites. Afterwards the caller accumulates.
   unreadHeld: number;
+  // #2037 — the same two figures restricted to `@content_kinds`. The banner's
+  // number is the MESSAGES bucket now, so accumulating raw row counts into it
+  // would mix units: 200 evicted JOINs would inflate a figure the sidebar's
+  // bold pill reports without them.
+  //
+  // The ARMING condition stays on the raw `unreadDropped`, deliberately. What
+  // arms far-behind is "a row at/after the cursor left the store", which is
+  // true of a JOIN too — the divider can no longer be placed either way. Only
+  // the DISPLAYED quantity is content-only.
+  contentDropped: number;
+  contentHeld: number;
   cursor: number | null;
 };
 
@@ -235,6 +248,10 @@ export const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): C
   // one row early (see the two invariants restated below).
   const firstUnread = cursor === null ? -1 : rows.findIndex((m) => m.id > cursor);
   const unreadCount = firstUnread === -1 ? 0 : rows.length - firstUnread;
+  // #2037 — the content-only twins, over the SAME slice the raw counts use so
+  // the two can never describe different regions.
+  const unreadRows = firstUnread === -1 ? [] : rows.slice(firstUnread);
+  const contentCount = unreadRows.filter((m) => isContentKind(m.kind)).length;
 
   // #1229 — the protected region has a ceiling of its own, applied BEFORE the
   // ring cap because it can bite while the total is still under it (900 unread
@@ -291,6 +308,8 @@ export const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): C
       rows: rows.slice(rows.length - UNREAD_RETENTION_CAP),
       unreadDropped: overflowUnread,
       unreadHeld: unreadCount,
+      contentDropped: contentCount - keptContentCount(rows, UNREAD_RETENTION_CAP),
+      contentHeld: contentCount,
       cursor,
     };
   }
@@ -306,9 +325,17 @@ export const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): C
     rows: dropCount > 0 ? rows.slice(dropCount) : rows,
     unreadDropped: 0,
     unreadHeld: unreadCount,
+    contentDropped: 0,
+    contentHeld: contentCount,
     cursor,
   };
 };
+
+// #2037 — content rows surviving inside the kept tail slice. Subtracting this
+// from the held count gives what the bite actually took, in the same unit the
+// banner reports.
+const keptContentCount = (rows: ScrollbackMessage[], keep: number): number =>
+  rows.slice(Math.max(0, rows.length - keep)).filter((m) => isContentKind(m.kind)).length;
 
 // #788 — how THE identity rule applies to this module. The predicate itself,
 // and why a continuation that outlived its identity must do nothing further
@@ -440,8 +467,17 @@ const exports = identityScopedStore((onIdentityChange) => {
   // `anchorAtTail`), cleared when the operator jumps back into that region or
   // the window is purged.
   //
-  //   * `missed` — the server's true row count after the anchor, at the
-  //     moment of the decision. What the jump affordance shows.
+  //   * `missed` — the MESSAGES the operator has not read after the anchor
+  //     (`@content_kinds`), at the moment of the decision. What the jump
+  //     affordance shows. #2037 narrowed it from the raw row count: the raw
+  //     figure is still what decides `isFarBehind`, but it is no longer
+  //     rendered, because the bar was reporting a quantity nothing else on
+  //     screen shared. This is now the SAME number the sidebar's bold pill
+  //     carries — and literally so: `selection.ts` reads THIS field for a
+  //     far-behind key rather than the seed, so the two cannot drift.
+  //   * `events` — its sibling bucket. Not rendered by the bar; carried so
+  //     the sidebar's faint pill has one origin with the bold one (#2037 B
+  //     puts it behind an opt-in).
   //   * `resumeFrom` — the anchor itself: the newest row the pane held before
   //     it gave up on contiguity (the read cursor on a cold open, the last
   //     backfilled row on a reconnect). Where the jump lands.
@@ -453,7 +489,7 @@ const exports = identityScopedStore((onIdentityChange) => {
   // in-pane unread divider (whose count would otherwise describe the loaded
   // rows rather than the unread region).
   const [farBehindByChannel, setFarBehindByChannel] = createSignal<
-    Record<ChannelKey, { missed: number; resumeFrom: number }>
+    Record<ChannelKey, { missed: number; events: number; resumeFrom: number }>
   >({});
 
   // #947 — "the pane's unread region is TRUNCATED, and here is what the server
@@ -467,9 +503,13 @@ const exports = identityScopedStore((onIdentityChange) => {
   //
   //   * `count` — the same server measurement the jump affordance advertised
   //     (`far.missed`). Deliberately the SAME number and not a second one:
-  //     it counts rows the divider's predicate would exclude (own-presence,
-  //     operator echoes), so it can run slightly high, and the alternative is
-  //     showing the operator a third figure for one question.
+  //     the alternative is showing the operator a third figure for one
+  //     question, which is the whole of #2037.
+  //     #2037 also narrowed what that number IS. It used to be the raw row
+  //     count, which ran high against the divider's predicate (own-presence,
+  //     operator echoes) and was tolerated for it; it is now the MESSAGES
+  //     bucket, own-authored already excluded server-side, so the two agree
+  //     on the same population instead of merely being one figure.
   //   * `at` — the cursor it was measured after. The record is spent only
   //     while the frozen divider is still anchored there, which is what makes
   //     it self-invalidating rather than a cache somebody has to remember to
@@ -615,6 +655,8 @@ const exports = identityScopedStore((onIdentityChange) => {
     // no longer place.
     let unreadDropped = 0;
     let unreadHeld = 0;
+    let contentDropped = 0;
+    let contentHeld = 0;
     let prunedCursor = 0;
     // #1229 — the rows and the far-behind flag are ONE state transition and must
     // reach consumers in ONE flush. Published as two writes, Solid runs every
@@ -650,6 +692,8 @@ const exports = identityScopedStore((onIdentityChange) => {
         evicted = capped.rows.length < next.length;
         unreadDropped = capped.unreadDropped;
         unreadHeld = capped.unreadHeld;
+        contentDropped = capped.contentDropped;
+        contentHeld = capped.contentHeld;
         prunedCursor = capped.cursor ?? 0;
         return { ...prev, [key]: capped.rows };
       });
@@ -669,7 +713,15 @@ const exports = identityScopedStore((onIdentityChange) => {
           return {
             ...prev,
             [key]: {
-              missed: current === undefined ? unreadHeld : current.missed + unreadDropped,
+              // #2037 — accumulates in the CONTENT unit, the same one the
+              // probe writes and the pill reads. Arming still keys on the raw
+              // `unreadDropped` above: a JOIN leaving the store unplaces the
+              // divider exactly as a message does.
+              missed: current === undefined ? contentHeld : current.missed + contentDropped,
+              events:
+                current === undefined
+                  ? unreadHeld - contentHeld
+                  : current.events + (unreadDropped - contentDropped),
               resumeFrom: prunedCursor,
             },
           };
@@ -771,7 +823,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     slug: string,
     name: string,
     anchor: number,
-  ): Promise<number | null> => {
+  ): Promise<GapProbe | null> => {
     try {
       return await countMessagesAfter(t, slug, name, anchor);
     } catch (err) {
@@ -806,6 +858,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     slug: string,
     name: string,
     missed: number,
+    events: number,
     resumeFrom: number,
   ): Promise<void> => {
     const key = channelKey(slug, name);
@@ -819,7 +872,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     });
     for (const msg of rows) recordSeen(key, msg);
     loadMoreExhausted.delete(key);
-    setFarBehindByChannel((prev) => ({ ...prev, [key]: { missed, resumeFrom } }));
+    setFarBehindByChannel((prev) => ({ ...prev, [key]: { missed, events, resumeFrom } }));
   };
 
   // #693 — the DECISION is measured at the anchor the resume was about to use
@@ -846,16 +899,19 @@ const exports = identityScopedStore((onIdentityChange) => {
     slug: string,
     name: string,
     anchor: number,
-    missedAtAnchor: number,
-  ): Promise<{ missed: number; resumeFrom: number }> => {
+    probeAtAnchor: GapProbe,
+  ): Promise<{ missed: number; events: number; resumeFrom: number }> => {
+    const atAnchor = {
+      missed: probeAtAnchor.messages,
+      events: probeAtAnchor.events,
+      resumeFrom: anchor,
+    };
     const cursor = getReadCursor(slug, name);
-    if (cursor === null || cursor >= anchor) {
-      return { missed: missedAtAnchor, resumeFrom: anchor };
-    }
-    const missed = await probeGap(t, slug, name, cursor);
-    return missed === null
-      ? { missed: missedAtAnchor, resumeFrom: anchor }
-      : { missed, resumeFrom: cursor };
+    if (cursor === null || cursor >= anchor) return atAnchor;
+    const probe = await probeGap(t, slug, name, cursor);
+    return probe === null
+      ? atAnchor
+      : { missed: probe.messages, events: probe.events, resumeFrom: cursor };
   };
 
   const clearFarBehind = (key: ChannelKey): void => {
@@ -1052,10 +1108,13 @@ const exports = identityScopedStore((onIdentityChange) => {
         // The probe is ONE extra small GET per cursor-present channel-open,
         // behind the load-once gate, on a human click; the pane is empty here
         // so `anchorAtTail` has nothing to discard.
-        const gap = await probeGap(t, slug, name, cursor);
+        const probe = await probeGap(t, slug, name, cursor);
         if (identityMoved(t)) return;
-        if (gap !== null && isFarBehind(gap)) {
-          await anchorAtTail(t, slug, name, gap, cursor);
+        // #2037 — the THRESHOLD reads `probe.gap` (raw rows, the #693
+        // question: is contiguous paging achievable) and the DISPLAY reads
+        // `probe.messages`. Two questions, two fields, one round trip.
+        if (probe !== null && isFarBehind(probe.gap)) {
+          await anchorAtTail(t, slug, name, probe.messages, probe.events, cursor);
         } else {
           const [afterPage, beforePage] = await Promise.all([
             listMessagesAfter(t, slug, name, cursor, PAGE_LIMIT),
@@ -1473,12 +1532,12 @@ const exports = identityScopedStore((onIdentityChange) => {
         // ordinary short-page reconnect, which is nearly all of them.
         const last = page[page.length - 1];
         const anchor = last ? last.id : cursor;
-        const gap = await probeGap(t, slug, name, anchor);
+        const probe = await probeGap(t, slug, name, anchor);
         if (identityMoved(t)) return;
-        if (gap !== null && isFarBehind(gap)) {
-          const target = await resolveJumpTarget(t, slug, name, anchor, gap);
+        if (probe !== null && isFarBehind(probe.gap)) {
+          const target = await resolveJumpTarget(t, slug, name, anchor, probe);
           if (identityMoved(t)) return;
-          await anchorAtTail(t, slug, name, target.missed, target.resumeFrom);
+          await anchorAtTail(t, slug, name, target.missed, target.events, target.resumeFrom);
         }
       }
     } catch (err) {

--- a/cicchetto/src/lib/selection.ts
+++ b/cicchetto/src/lib/selection.ts
@@ -440,10 +440,29 @@ const exports = identityScopedStore((onIdentityChange) => {
       result[key] = { messages: seed.messages, events: seed.events };
     }
 
+    const farBehind = farBehindByChannel();
+
+    // #2037 — a far-behind window reads its counts from the far-behind entry,
+    // not from the seed. Both are `count_after_split/6` at the read cursor, so
+    // this is not a change of definition; what it buys is that the bar and the
+    // pill become the SAME VARIABLE rather than two values that happen to
+    // agree. #2037 measured what "happen to agree" is worth: the bar was
+    // rendering a raw row count against a split badge and nothing in the tree
+    // could notice.
+    //
+    // It is also the fresher of the two. The seed is written by `/me` and by
+    // the join reply and by nothing else — the per-message `window_counts`
+    // push carries `messages`/`events` but cic ignores them (#239, they are
+    // client-derived for the presence filter), and a far-behind key skips
+    // client derivation by design. So the seed for such a window is frozen at
+    // login; the probe was taken when the pane opened.
+    for (const [rawKey, far] of Object.entries(farBehind)) {
+      result[rawKey as ChannelKey] = { messages: far.missed, events: far.events };
+    }
+
     // Locally-hydrated channels — count rows past the cursor by kind.
     // Override any seed entry: local truth wins because the seed is
     // a sync-time snapshot that may be stale by the time we render.
-    const farBehind = farBehindByChannel();
     for (const [rawKey, rows] of Object.entries(sb)) {
       const key = rawKey as ChannelKey;
       const decoded = decodeChannelKey(key);

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -155,7 +155,17 @@ let _socket: Socket | null = null;
 // any payload the codegen does not cover. `MIN_SERVER_PROTOCOL_VERSION` stays
 // at 9, correctly: the new key is absent-tolerant in both directions, so this
 // bundle still serves a v9 server — the two axes behaving as designed.
-export const CLIENT_PROTOCOL_VERSION = 15;
+//
+// 15 → 16 (#2037): the third, and the third time `wire_pin --check` was blind
+// for the same reason — `GrappaWeb.MessagesJSON` is not a codegen source
+// either. The gap-probe response grew `messages` + `events` beside `count`, so
+// the far-behind bar renders the same quantity the sidebar's bold pill does
+// instead of a raw row count nothing else on screen shared.
+// `MIN_SERVER_PROTOCOL_VERSION` stays at 9: `countMessagesAfter` falls back to
+// `{messages: count, events: 0}` when the pair is absent, which is exactly the
+// pre-#2037 number in the pre-#2037 place, so this bundle still serves an
+// older server.
+export const CLIENT_PROTOCOL_VERSION = 16;
 
 // #193 — force the correct WS scheme from the page origin, absolutely.
 //

--- a/cicchetto/src/lib/userSettings.ts
+++ b/cicchetto/src/lib/userSettings.ts
@@ -351,6 +351,9 @@ export type DisplayPrefs = {
   // that disagree about the shape degrade instead of breaking. Absent ⇒ the
   // default (strip OFF, colours render). `buildWireMap()` always populates it.
   strip_formatting?: boolean;
+  // #2037 B — the events pill opt-in. Optional for the same reason as the two
+  // above: an older server omits it on the way in.
+  show_event_badge?: boolean;
 };
 
 export type DisplayPrefsResponse = {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50955,3 +50955,133 @@ one instant — that is read off two clauses, not measured, and measuring it
 needs a live session. That the May snapshot is representative of the incident
 channel; it establishes a floor on how implausible 216 carve-out rows are,
 not a distribution. That the residual is explained — it is not._
+<!-- entry #2037b -->
+
+---
+
+## 2026-09-10 — #2037b: one predicate, two buckets, and a bar that is now the badge
+
+#2037a measured the three reported numbers and closed the anchor: the bar's
+term is bounded above by zero, so re-anchoring the probe moves the bar DOWN
+by at most one page and leaves the 1404-row residual exactly where it is.
+This entry records what was BUILT on top of that, under three rulings from
+vjt on the issue (2026-09-10, 08:54 / 08:56 / 09:00): use one logic for the
+counting; messages are what land in both the badge and the far-behind bar;
+the threshold stays as it is today.
+
+### The partition, named once
+
+There is ONE split and it already existed:
+
+    messages := kind IN     Grappa.Scrollback.Message.@content_kinds
+    events   := kind NOT IN @content_kinds
+
+`Scrollback.count_after_split/6` (per window) and
+`ReadCursor.bulk_unread_split/3` (the bulk `/me` seed) were both already
+computing exactly this. #2037 introduced no new predicate; it stopped a
+FOURTH surface — the far-behind bar — from using a different one. The split
+gained a name this round, `Grappa.Scrollback.count_split()`, because it is
+now a wire shape rather than only an internal return.
+
+The threshold is deliberately NOT in the partition. `count_after/6` keeps its
+predicate (raw rows, own-authored included) and its one caller, the
+`probeGap` → `isFarBehind` decision. Feeding a messages-only number into the
+threshold would have a channel with 3000 hidden JOINs and 40 messages report
+a 40-row gap and then take a contiguous-paging path it cannot serve. That is
+the 09:00 ruling and it is a correctness argument, not an omission.
+
+### The property: the bar and the badge are ONE VARIABLE
+
+The acceptance criterion was that the two numbers cannot drift apart again.
+Two values that happen to agree do not satisfy it; one value read twice does.
+So `far().missed` IS the messages count, `perChannelUnread` reads the
+far-behind entry for a far-behind key instead of the seed, and the bar
+renders the same field. Nothing compares them, because there is nothing to
+compare.
+
+Serving the seed at render time was the one-line alternative and was rejected
+for a MEASURED reason, not a stylistic one: `far.missed` also feeds
+`measuredUnread`, which places the in-pane divider. Narrowing only the
+sidebar would have left the divider on the raw number, so the operator taps
+"187 unread" and lands on "1807 unread messages". A definition that reaches
+one of its two consumers is the defect this issue is about, reproduced one
+layer down.
+
+The probe is also the fresher of the two inputs, which is a side effect worth
+recording because it is easy to mistake for a fix. The seed is written by
+`/me` and by the join reply and by nothing else: the per-message
+`window_counts` push carries the pair, but cic ignores it on purpose
+(`subscribe.ts`, #239 — messages/events stay client-derived for the presence
+filter) and a far-behind key skips client derivation by design. So a
+far-behind window's seed is frozen at login while the probe is taken when the
+pane opens. That narrows the stale-seed path for exactly the windows where it
+went stale. It is NOT a fix aimed at the residual and is not claimed as one.
+
+The prune path (#1229) had to follow or the tree would carry two definitions
+again: it arms far-behind from LOCAL eviction and was accumulating raw row
+counts into the same field. It now accumulates the content unit. The ARMING
+stays on the raw count, deliberately — what arms far-behind is "a row at or
+after the cursor left the store", which a JOIN does as surely as a message,
+and the divider cannot be placed either way. Only the displayed quantity
+narrowed.
+
+### One resolution per request
+
+Both halves of the split come from ONE `resolve_hide_presence/3` call in
+`MessagesController.count/2`. That closes by construction the divergence
+#2037a measured between the two `PresenceFilter.Resolver` doors: within a
+request there is one resolution and both counters get it. It does NOT close
+the divergence between `/me` and a later probe, which is a different pair of
+instants and has its own issue.
+
+### The `kick` consequence, said out loud
+
+`show_event_badge` is the sixth #449 display pref and the first whose DEFAULT
+takes something away. It is server-backed on #1766's criterion: a per-DEVICE
+toggle is right when the complaint is about a VIEWPORT and wrong when it is
+about the ACCOUNT, and "is my sidebar cluttered with join/part counts" is
+identical on the phone and the desktop.
+
+What it hides is WIDER than join/part, and the ruling asks for that to be
+stated rather than discovered. The events bucket is `kind not in
+@content_kinds`, so `topic`, `kick` and `server_event` follow it — the three
+kinds that sit OUTSIDE `Message.suppressed_presence_kinds/0` on purpose
+(#458), because the PANE still renders them on a denoised channel. Rendering
+in the pane and earning a badge are different questions and this pref answers
+only the second. **A KICK therefore stops contributing to a badge by
+default.** That is a deliberate behaviour change.
+
+Putting `kick` back into the message bucket would smuggle a non-message into
+the very number the bar now shares with the bold pill and undo the other
+half. A kick that must stay loud belongs in the mention/severity channel
+(#267), which is a different axis from "how many unread rows".
+
+Two mechanics that are easy to get wrong and were not: the count is ZEROED
+rather than the element hidden, because `events()` feeds `title` and
+`aria-label` as well as the text and an element hidden by a `<Show>` whose
+accessible name still says "216 unread events" is the wrong half of the
+change; and `applyServerPrefs` uses `??` and not `||`, which matters more for
+this key than for its predecessors because `false` is the default — `||`
+would make the badge impossible to turn back OFF from a second device once
+any device had turned it on.
+
+### Protocol 16, and the third `wire_pin` blindness
+
+`@protocol_version` goes 15 → 16 for the two new fields on the count
+response. `mix grappa.wire_pin --check` did not force it, for the THIRD
+release running: its digest does not span hand-written `*_json.ex` views, and
+v15 already recorded that as a property rather than an accident. The bump is
+a deliberate manual act and `protocol_test.exs` is the only automatic guard
+on the pair. `min_protocol_version` stays at 1: `countMessagesAfter` falls
+back to `{messages: count, events: 0}` when the pair is absent, which is
+exactly the pre-#2037 number in the pre-#2037 place, so a new bundle degrades
+against an old server instead of breaking.
+
+_Not asserted: that any of this explains the 1404-row residual. It does not
+and does not try. The four (bar posture, seed posture) assignments from
+#2037a remain excluded by measurement, so a premise of the MODEL has to give
+rather than a premise of the reading, and the reading that the two pills are
+not that window's pair is EXCLUDED by vjt — he settled on 2026-09-10 that it
+is one and the same window ("si stessa window", his words on IRC, reported
+into the session; I do not read IRC). The quantity was unified. The mystery
+was not closed._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51069,13 +51069,47 @@ any device had turned it on.
 
 `@protocol_version` goes 15 → 16 for the two new fields on the count
 response. `mix grappa.wire_pin --check` did not force it, for the THIRD
-release running: its digest does not span hand-written `*_json.ex` views, and
-v15 already recorded that as a property rather than an accident. The bump is
-a deliberate manual act and `protocol_test.exs` is the only automatic guard
-on the pair. `min_protocol_version` stays at 1: `countMessagesAfter` falls
-back to `{messages: count, events: 0}` when the pair is absent, which is
-exactly the pre-#2037 number in the pre-#2037 place, so a new bundle degrades
-against an old server instead of breaking.
+release running — and this time the gate printed the proof of its own
+blindness rather than leaving it to be argued. It failed on this branch, but
+on the VERSION field alone, and its own output is the measurement:
+
+```
+shape digest   pinned sha256:f3c18a4c…4bf3c0
+               now    sha256:f3c18a4c…4bf3c0
+protocol       pinned 15
+                now   16
+```
+
+The digest is byte-for-byte identical ACROSS a two-field addition to the
+wire. So the gate did not catch the shape change and then ask for a bump; it
+noticed that a human had already moved the number and asked to be re-pinned.
+
+Reversing the order is the discriminating control, and it was RUN rather than
+reasoned about: with both new fields still in `messages_json.ex`, put
+`@protocol_version` back to 15 and re-pin at 15, and the gate answers
+
+```
+priv/wire/shape.pin: wire shape and protocol 15 agree.     rc=0
+```
+
+That is green on exactly the violation the gate exists for — a wire-shape
+change carried in under a still number. (Measured on this branch, then
+reverted; `lib/grappa/protocol.ex` and the pin are byte-identical to their
+committed state afterwards.)
+
+Two more measurements pin down why, and both are one command:
+`grep count_split cicchetto/src/lib/wireTypes.ts cicchetto/src/lib/wireSchema.ts`
+finds nothing — the count response is absent from BOTH generated artefacts,
+so it was never inside the digest's span; and `mix grappa.gen_wire_types
+--check` answers `in sync.` on the same tree, which is the failure mode
+CLAUDE.md already names (it compares each artefact with its own SOURCE, so
+a route the generator does not cover is "in sync" by construction).
+
+The bump therefore remains a deliberate manual act, and `protocol_test.exs`
+is the only automatic guard on the pair. `min_protocol_version` stays at 1:
+`countMessagesAfter` falls back to `{messages: count, events: 0}` when the
+pair is absent, which is exactly the pre-#2037 number in the pre-#2037
+place, so a new bundle degrades against an old server instead of breaking.
 
 _Not asserted: that any of this explains the 1404-row residual. It does not
 and does not try. The four (bar posture, seed posture) assignments from

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51190,3 +51190,111 @@ not that window's pair is EXCLUDED by vjt — he settled on 2026-09-10 that it
 is one and the same window ("si stessa window", his words on IRC, reported
 into the session; I do not read IRC). The quantity was unified. The mystery
 was not closed._
+<!-- entry #2037c -->
+
+---
+
+## 2026-09-10 — #2037c: the wire pin was blind to every hand-written JSON view, and a list was never going to fix it
+
+`mix grappa.wire_pin --check` is the gate behind the #1393d ruling: a wire
+shape that moves without `Grappa.Protocol.version/0` moving is RED. It failed
+to see #2037's own wire change. It caught the commit only on the VERSION
+field, printing a byte-identical digest across a two-field ADDITION — the
+gate's own output was the proof of its blindness.
+
+### Measured on demand, this session, not inherited
+
+A field named `mutant_probe` was added to `GrappaWeb.MessagesJSON.count/1` —
+`@spec` and body together — on the untouched branch:
+
+| tree | command | rc | verdict |
+|---|---|---|---|
+| pre-cure + the new field | `wire_pin --check` | **0** | `wire shape and protocol 16 agree.` |
+| the same tree | `gen_wire_types --check` | 0 | `in sync.` on BOTH artefacts |
+| the same tree | grep the artefacts | — | `mutant_probe` **0×** in each |
+
+with a positive control on the grep (223 / 190 hits for a token that is in
+them) and a negative control (0). So the addition was invisible to the drift
+gate, invisible to the tripwire, and absent from both generated files.
+
+The second row is the live instance of what CLAUDE.md already claims in the
+abstract — the generator compares the artefact with its own SOURCE and answers
+`in sync.` in exactly the case to catch. It had been recorded from a Wire
+typespec; here it is measured on a hand-written `*_json.ex`, where the source
+it compares against never mentioned the field at all.
+
+### Why the obvious cure is not one
+
+This is a RECURRENCE. #1679 met the same class — `/boot` invisible to the
+tripwire — and cured it by adding `GrappaWeb.BootJSON` to `gen_wire_types`'s
+hand-kept `@extra_modules` and writing a comment telling the next author to
+remember. The note did not hold, and it could not: an inclusion list is
+**fail-OPEN**, so forgetting it costs nothing and says nothing. Measured
+today, two views that were never added — `PushSubscriptionJSON` (3 declared
+types) and `UserSettingsJSON` (9) — have been outside the digest the whole
+time.
+
+Widening that list still would not have caught #2037, and this is the part
+that decided the design: of the twelve `GrappaWeb.*JSON` views, **eight
+declare no named `@type` at all**, `MessagesJSON` among them. The codegen
+renders named types, so listing those modules buys exactly zero. All twelve
+DO carry `@spec`s — 29 of them.
+
+### What shipped
+
+`wire_pin` grew a third digest component: the `@spec`s of the EXPORTED
+functions of every `GrappaWeb.*JSON` module, read from BEAM chunks, over a
+module set derived from the build output (`Elixir.GrappaWeb.*JSON.beam` under
+the compile path) rather than typed by hand. Fail-CLOSED twice — a new view is
+covered the moment it compiles, and a discovery that finds nothing RAISES
+rather than contributing an empty string to a digest that would go on
+agreeing.
+
+The module name comes from the beam FILENAME, which IS the module. Not from
+camelizing a source path: `gen_wire_types` records that guess turning
+`controllers/me_json.ex` into `GrappaWeb.Controllers.MeJson`, a module that
+does not exist, dropped SILENTLY — zero coverage while looking widened.
+
+Reading BEAM chunks rather than source is what keeps it from firing on
+comments and reformatting, the property the two-artefact digest already had
+and had to keep.
+
+### Deliberately NOT routed through the codegen
+
+Adding the twelve views to `@extra_modules` and letting `gen_wire_types` emit
+them would drag their shapes into `wireTypes.ts` **and `wireSchema.ts`** — and
+the schema one is RUNTIME validation in cic. Widening a runtime validator is a
+client change with its own blast radius; this is a gate change. They do not
+belong in one commit, and the gate does not need the client to move for the
+server-side hole to close.
+
+### Cost paid once, and the route was the documented one
+
+Widening what the digest COVERS is not a wire-shape change and the gate cannot
+tell — it saw a moved digest and a still number, which is the violation, and
+`--update` refused. That is the moduledoc's own scenario, and its prescribed
+route was taken: DELETE `priv/wire/shape.pin` and re-create it, visible in
+review, rather than adding a `--force` flag that would be the hole the refusal
+exists to close. Re-created at protocol **16** — unchanged, because the WIRE
+did not move, only the gate's view of it. The pin's header states its coverage
+on purpose, so it was rewritten in the same commit; a header describing a
+coverage that no longer exists is the same lie, moved.
+
+### Proof the cure is a gate and not decoration
+
+The identical `mutant_probe` addition, re-applied after the cure:
+`wire_pin --check` rc **1**, digest `sha256:cdc283e8…` → `sha256:e9de1fa8…`.
+Reverted: rc 0. A gate that has never failed on the case it must catch is
+decoration, and that is literally the defect being cured here — repeating it
+in the cure was not an option.
+
+### Two limits, stated so they are not rediscovered
+
+A view whose BODY grows a key while its `@spec` stands still is still
+invisible to this component. Dialyzer is the leg that catches that one, and
+that is an ARGUMENT — it was not measured in this session, and it is written
+down as an argument rather than dressed as a measurement.
+
+A spec that references a remote type is digested as the reference TEXT, so a
+change inside `Grappa.Scrollback.count_split()` moves nothing unless that type
+reaches the digest by another route.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50853,3 +50853,105 @@ Neither is the IME case covered: like `ComposeBox` before it, this handler has
 no `isComposing` guard, so an Enter that confirms a candidate mid-composition
 submits. That is a shared gap of the two surfaces and wants one issue over both,
 not a divergence introduced on one of them here._
+<!-- entry #2037a -->
+
+---
+
+## 2026-09-10 — #2037: three unread numbers, and the four ways they cannot be one window
+
+The report is one operator returning after ~21h: the far-behind bar says
+`1807 unread`, the sidebar pills say `187` and `216`, and `187 + 216 = 403`.
+The issue body attributes the direction to own-authored rows plus the
+content/events split, states plainly that those do not account for the
+`1404` residual, and nominates the ANCHOR. This entry records what the
+residual is NOT, which is all that got settled.
+
+### The anchor cannot contribute in the observed direction
+
+Measured on the client, where the anchor lives
+(`cicchetto/src/__tests__/unread2037AnchorProbe.test.ts`). The cold-open path
+probes ONCE, at the read cursor — the same integer
+`ReadCursor.bulk_unread_split/3` anchors the badge seed at, so that path has
+no anchor term at all. The reconnect path is the only one holding two
+anchors, and it renders the CURSOR-anchored number. The one branch that
+renders the other is the re-probe failure the issue names, and it renders the
+SMALLER number, because the fallback anchor sits further FORWARD and
+`count_after/6` is monotone non-increasing in `m.id > ?`.
+
+So the anchor term is bounded ABOVE by zero. **Anyone who closes this by
+re-anchoring the probe moves the bar DOWN by at most one page and leaves the
+1404 exactly where it is.** The positive control is what makes that claim
+worth anything: it asserts two DISTINCT anchors actually reached the wire
+before the sign is read, without which the same assertion passes a harness
+that only ever probed once.
+
+### The two presence resolvers are two doors, and they can disagree
+
+The body says *"Both paths DO share the presence-hidden filter, so that is
+not a divergence source."* They share the RULE (`PresenceFilter.hidden?/2`)
+and nothing else. The bar reaches it through `Resolver.hidden?/4` →
+`Session.list_members/3`; the seed through `Resolver.hidden_channels/3` →
+`Session.list_member_counts/2`. Two calls, at two instants.
+
+Measured through the real `Grappa.Session` facade against a `Session.Server`
+stand-in registered under the real registry key: with no session both SHOW,
+with consistent over-threshold answers both HIDE, and with the two calls
+answered independently the bar SHOWS while the seed HIDES — the sign the
+issue needs. The cost of that one disagreement on a 78-row fixture is 69
+rows, i.e. own-authored UNION suppressed-presence (they overlap on the
+operator's own presence rows, so the residual is the union and the assertion
+says so exactly rather than `> 0`).
+
+Reachability is a READING, not a measurement: both `handle_call` clauses read
+the same `state.seeded_channels` and `state.members`, so a real server cannot
+answer asymmetrically within one instant. The divergence needs two instants,
+or a call failure at one door — `member_count_for_unset/4`'s catch-all folds
+`:uninitialized`, `{:error, :timeout}` and `{:error, :no_session}` to one
+`nil`, and decision D reads nil as SHOW. For a history FETCH that is correct.
+For a COUNT it converts "I could not reach the session" into "count every
+JOIN/PART", and freezes it into the far-behind state.
+
+### And that mechanism is not what happened, by measurement
+
+Write, for one window at one anchor, `C` = non-own content, `E_s` = non-own
+suppressed presence, `E_c` = non-own carve-out (`topic`/`kick`/`server_event`,
+outside `suppressed_presence_kinds/0` per #458), `O` = own-authored,
+`O_s` = own presence. Then `bar(SHOW) = C + E_s + E_c + O`,
+`bar(HIDE) = C + E_c + (O − O_s)`, `pills(SHOW) = C | E_s + E_c`,
+`pills(HIDE) = C | E_c`. Against 187 / 216 / 1807 all four assignments fail:
+the two SHOW-seed ones require ~1404 own-authored rows in 21h, and the two
+HIDE-seed ones additionally require `E_c = 216`.
+
+`E_c = 216` is the one that is measurable off-line, and it was measured
+against the on-host prod snapshot (13320 rows, opened `immutable=1`). On
+channel-shaped windows the entire carve-out population is 13 `topic` rows and
+4 `kick` rows; `server_event` never lands in a channel window at all. The
+largest carve-out in any single channel window, ever, is 9. The incident
+needs 216 in one window in 21 hours — 24× the observed maximum, 30× on the
+ratio against content. The suppressed-presence half of the same snapshot is
+by contrast entirely ordinary (`suppressed/content` ranges 0.078 to 5.43, and
+the assignment needs 7.5).
+
+So the reading that "216 is exactly what is left over once presence is
+hidden" is dead, and it was mine. Two numbers agreeing was the whole of that
+argument; the control that discriminates between agreement and coincidence
+says no.
+
+### What is left
+
+At least one premise of the report is false, and the anchor is not it. The
+economical candidate is that the two pills are not one window's pair, or not
+the bar's window — which the same snapshot makes circumstantial rather than
+speculative: every one of the five furthest-behind cursors in it is a
+`$server` window (1584, 1531, 1370, 1052, 113 rows behind), the furthest
+channel window is 68 behind, and `$server` is 99.9% content, so its own pill
+pair reads ~N messages and ~0 events. A 1807-row far-behind bar looks like a
+`$server` window, and a `$server` window does not produce 187/216.
+
+_Not asserted: that the resolver divergence caused the incident (measured
+that it CAN happen and what it costs; measured that the arithmetic it needs
+does not hold). That a real `Session.Server` cannot produce the asymmetry in
+one instant — that is read off two clauses, not measured, and measuring it
+needs a live session. That the May snapshot is representative of the incident
+channel; it establishes a floor on how implausible 216 carve-out rows are,
+not a distribution. That the residual is explained — it is not._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51056,6 +51056,56 @@ the very number the bar now shares with the bold pill and undo the other
 half. A kick that must stay loud belongs in the mention/severity channel
 (#267), which is a different axis from "how many unread rows".
 
+### A default that takes something away makes existing specs VACUOUS
+
+Worth its own heading because it is the part that nearly shipped wrong, and
+it is a general consequence of the FIRST opt-out-shaped default rather than
+anything specific to this pref.
+
+Four e2e specs read the sidebar's events pill, and under the new default
+`sidebarEventsBadge(...)` resolves to nothing at all. One of them asserts the
+pill is VISIBLE (#265) and failed loudly, which is the easy case. The other
+three assert `toHaveCount(0)`:
+
+* #239 — the presence-filtered JOIN did NOT bump the events badge
+* r6 — the operator's own ACTION earns no events badge
+* #532 A — no event badge on the archived row after a self-PART
+
+All three would have stayed GREEN while testing nothing, because the pref
+suppresses the element whether or not the thing under test happened. The full
+suite says so directly: four reds, and the three vacuous ones were not among
+them. So each now calls `setShowEventBadge(token, true)` before `loginAs` —
+before, because `displayPrefs.ts` applies the server's map on the post-login
+refresh.
+
+The general rule, for the next pref whose default removes a surface: grep for
+every assertion on that surface and split them by SIGN. The positive ones
+fail and find themselves; the negative ones pass and have to be found.
+
+No restore is needed and none was added. Every e2e test runs on its own
+throwaway subject (`provisionSpecSubject`, named off the title path and
+DELETEd at teardown), so a pref set inside one body cannot reach another
+spec — an earlier version of the #2037 spec carried an `afterEach` justified
+by a cross-spec poisoning that cannot happen, and the justification was
+wrong before the machinery was unnecessary.
+
+### The unit is not yet ONE unit — `far.missed` still has two producers
+
+Recorded because A closed most of this gap and the remainder is easy to
+mistake for closed. `far.missed` is written by two paths: the server PROBE
+(`count_after_split/6`, which excludes own-authored rows per #576/#532 A) and
+the client PRUNE (`capScrollbackRing`, which filters `isContentKind` and has
+no own-nick arm at all). Before A they counted different things entirely;
+after A they agree on everything except own-authored content.
+
+That is better and it is also a worse FAILURE MODE: two numbers differing by
+a lot are visibly two numbers, and two numbers differing by three are
+indistinguishable from one until somebody counts. The same window at the same
+cursor reports a different figure depending on whether it went far behind by
+local eviction or by a gap probe. Filed as its own issue rather than fixed
+here — it is a second behaviour change on a path that already carries one,
+and none of the three rulings asked for it.
+
 Two mechanics that are easy to get wrong and were not: the count is ZEROED
 rather than the element hidden, because `events()` feeds `title` and
 `aria-label` as well as the text and an element hidden by a `<Show>` whose

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51105,8 +51105,29 @@ so it was never inside the digest's span; and `mix grappa.gen_wire_types
 CLAUDE.md already names (it compares each artefact with its own SOURCE, so
 a route the generator does not cover is "in sync" by construction).
 
-The bump therefore remains a deliberate manual act, and `protocol_test.exs`
-is the only automatic guard on the pair. `min_protocol_version` stays at 1:
+The bump therefore remains a deliberate manual act — and this round names
+which guard actually caught it being done HALF-WAY, because it was not the
+one v15's own entry nominated. Three things could have fired:
+
+* `wire_pin --check` — fired, but only after the number had already moved,
+  and only to ask to be re-pinned. See above.
+* `protocol_test.exs` (#1973) — GREEN. It pins cic's
+  `CLIENT_PROTOCOL_VERSION` against the server's, and both had been moved to
+  16, so it had nothing to say. v15's entry called it "the ONLY automatic
+  guard standing on this change"; on this change it stood and saw nothing.
+* the `@spec version() :: 15` LITERAL — RED, at
+  `lib/grappa/protocol.ex:373`, `invalid_contract`, "success typing () :: 16
+  but the spec is () :: 15". That is the one that caught it.
+
+The literal was chosen for a Dialyzer-idiom reason (a constant-returning
+function's spec matches its success typing under `:underspecs`) and its
+comment already claimed the tripwire role as a secondary benefit. It is now
+the PRIMARY automatic guard on the pair, by measurement, which is worth
+knowing mostly because it is a strange place for a protocol invariant to
+live: it fires in the dialyzer stage, minutes after the suite is green, and
+it says nothing about the wire.
+
+`min_protocol_version` stays at 1:
 `countMessagesAfter` falls back to `{messages: count, events: 0}` when the
 pair is absent, which is exactly the pre-#2037 number in the pre-#2037
 place, so a new bundle degrades against an old server instead of breaking.

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -327,7 +327,39 @@ defmodule Grappa.Protocol do
   # requires. #1973's `protocol_test.exs` pin is what caught the half-done bump
   # here — and with `wire_pin --check` blind to this payload, that pin was the
   # ONLY automatic guard standing on this change.
-  @protocol_version 15
+  # v16 (#2037) — TWO shape changes, one number, because they ship together and
+  # the version names a wire STATE rather than counting edits.
+  #
+  # (A) the gap-probe response (`GET …/messages/count?after=`) grows
+  # `messages` + `events` beside the existing `count`. Three numbers because the route answers two questions:
+  # `count` stays the THRESHOLD's raw feed (`isFarBehind`, out of scope per
+  # the #2037 ruling) and the new pair is the DISPLAY split, so the
+  # far-behind bar renders the same quantity the sidebar's bold pill already
+  # shows instead of a third opinion on it.
+  #
+  # 🔴 `mix grappa.wire_pin --check` DOES NOT force this bump either, and the
+  # reason is the one v15 recorded and generalised: the digest spans the
+  # codegen artefacts, whose sources are `lib/grappa/**/*wire.ex` plus a
+  # hand-kept list of web envelopes, and `GrappaWeb.MessagesJSON` is on
+  # neither. That is now THREE carriers (`BootJSON` #1679,
+  # `UserSettingsJSON` #2029, this) hitting the same silence, which is what
+  # v15 predicted when it called it a property of every hand-written
+  # `*_json.ex` rather than an accident. Bumped deliberately, by hand.
+  #
+  # (B) `display_prefs` grows a SIXTH key, `show_event_badge` — the opt-in the
+  # same ruling puts the `!messaggi` badge behind. Same carrier as v15's
+  # `strip_formatting` and v6's `show_bottom_bar`, and the same reason it
+  # counts. It is the first display pref whose DEFAULT takes something away,
+  # which is a product change and not a protocol one; the wire only sees a
+  # sixth boolean.
+  #
+  # @min_protocol_version stays at 1. Both are purely additive and cic
+  # reads them absent-tolerantly (a missing `messages` falls back to `count`,
+  # the pre-#2037 number), so a new bundle against an older server degrades
+  # to the old behaviour instead of breaking. cic's
+  # `CLIENT_PROTOCOL_VERSION` moves 15 → 16 in lockstep because it says what
+  # cic SPEAKS, not what it requires.
+  @protocol_version 16
   @min_protocol_version 1
 
   @doc "The protocol version the server currently speaks."

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -370,7 +370,7 @@ defmodule Grappa.Protocol do
   # alongside `@protocol_version`; the spec doubles as the bump tripwire,
   # and now that the bump is routine the tripwire is what keeps it from
   # being done half-way.
-  @spec version() :: 15
+  @spec version() :: 16
   def version, do: @protocol_version
 
   @doc """

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -377,6 +377,19 @@ defmodule Grappa.Scrollback do
 
   @type subject :: Subject.t()
 
+  @typedoc """
+  The unread split one window's counting doors return: `@content_kinds`
+  under `:messages`, every other kind under `:events`.
+
+  Named (#2037) because it is now a WIRE shape and not only an internal
+  return: `GrappaWeb.MessagesJSON.count/1` renders it, so the far-behind
+  bar and the sidebar pills read the same partition. Both producers —
+  `count_after_split/6` here and `ReadCursor.bulk_unread_split/3`'s
+  per-window value — answer in it, which is what makes "one predicate"
+  checkable rather than a convention.
+  """
+  @type count_split :: %{messages: non_neg_integer(), events: non_neg_integer()}
+
   @doc """
   Fetches up to `limit` messages for `(subject, network_id, channel)`,
   ordered by `server_time` DESC then `id` DESC (stable inside same-ms
@@ -767,7 +780,7 @@ defmodule Grappa.Scrollback do
           integer(),
           String.t() | nil,
           boolean()
-        ) :: %{messages: non_neg_integer(), events: non_neg_integer()}
+        ) :: count_split()
   def count_after_split(subject, network_id, channel, after_id, own_nick, hide_presence)
       when is_integer(network_id) and is_integer(after_id) and
              (is_binary(own_nick) or is_nil(own_nick)) and is_boolean(hide_presence) do

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -237,7 +237,8 @@ defmodule Grappa.UserSettings do
           colored_nicklist: boolean(),
           presence_filter: %{String.t() => String.t()},
           show_bottom_bar: boolean(),
-          strip_formatting: boolean()
+          strip_formatting: boolean(),
+          show_event_badge: boolean()
         }
 
   @notification_prefs_key "notification_prefs"
@@ -1585,7 +1586,8 @@ defmodule Grappa.UserSettings do
       colored_nicklist: false,
       presence_filter: %{},
       show_bottom_bar: true,
-      strip_formatting: false
+      strip_formatting: false,
+      show_event_badge: false
     }
   end
 
@@ -1643,6 +1645,15 @@ defmodule Grappa.UserSettings do
 
     * `time_format` ∈ #{inspect(@display_time_formats)}.
     * `colored_nicklist` is a boolean.
+    * `show_event_badge` (#2037 B) is a boolean, default FALSE — the ONE
+      display pref whose default takes something away. vjt's #2037 ruling
+      puts `!messaggi` behind an opt-in, so the sidebar's faint events pill
+      stops rendering unless asked for. Note what "events" spans: every kind
+      outside `@content_kinds`, which includes `topic`, `kick` and
+      `server_event` — the three deliberately OUTSIDE
+      `Message.suppressed_presence_kinds/0` (#458). A kick therefore stops
+      contributing to a badge by default; if one must stay loud it belongs in
+      the mention/severity channel (#267), not back in the message bucket.
     * `show_bottom_bar` (#1766) and `strip_formatting` (#2029) are booleans
       IF PRESENT; an absent key takes the default. The two keys added since
       the shape first shipped are exactly the two that tolerate absence, and
@@ -2279,7 +2290,8 @@ defmodule Grappa.UserSettings do
       colored_nicklist: read_display_bool(stored, :colored_nicklist, false),
       presence_filter: read_presence_filter(stored),
       show_bottom_bar: read_display_bool(stored, :show_bottom_bar, true),
-      strip_formatting: read_display_bool(stored, :strip_formatting, false)
+      strip_formatting: read_display_bool(stored, :strip_formatting, false),
+      show_event_badge: read_display_bool(stored, :show_event_badge, false)
     }
   end
 
@@ -2316,14 +2328,16 @@ defmodule Grappa.UserSettings do
          {:ok, cn} <- fetch_display_bool(prefs, :colored_nicklist),
          {:ok, pf} <- fetch_presence_filter(prefs),
          {:ok, sbb} <- fetch_optional_display_bool(prefs, :show_bottom_bar, true),
-         {:ok, sf} <- fetch_optional_display_bool(prefs, :strip_formatting, false) do
+         {:ok, sf} <- fetch_optional_display_bool(prefs, :strip_formatting, false),
+         {:ok, seb} <- fetch_optional_display_bool(prefs, :show_event_badge, false) do
       {:ok,
        %{
          "time_format" => tf,
          "colored_nicklist" => cn,
          "presence_filter" => pf,
          "show_bottom_bar" => sbb,
-         "strip_formatting" => sf
+         "strip_formatting" => sf,
+         "show_event_badge" => seb
        }}
     else
       {:error, message} -> {:error, display_prefs_changeset_error(message, subject)}

--- a/lib/grappa_web/controllers/messages_controller.ex
+++ b/lib/grappa_web/controllers/messages_controller.ex
@@ -188,9 +188,14 @@ defmodule GrappaWeb.MessagesController do
 
   @doc """
   `GET /networks/:network_id/channels/:channel_id/messages/count?after=<id>`
-  — the #693 gap probe. Returns `{"count": N}`: how many rows this subject
-  would be handed by `index/2`'s `?after=<id>` page if that page had no
-  ceiling.
+  — the #693 gap probe. Returns `{"count": N, "messages": M, "events": E}`.
+
+  `count` is how many rows this subject would be handed by `index/2`'s
+  `?after=<id>` page if that page had no ceiling — the THRESHOLD's feed,
+  unchanged. `messages` + `events` are the #2037 DISPLAY split: the same
+  `@content_kinds` partition the sidebar pills carry, so the far-behind bar
+  renders `messages` instead of a third opinion on a quantity that already
+  has one.
 
   Exists because a full page is not a measurement. cic's resume paths
   fetch `?after=<anchor>&limit=#{@max_http_limit}`; a full page proves
@@ -224,17 +229,34 @@ defmodule GrappaWeb.MessagesController do
           {:error, :no_session} -> nil
         end
 
+      # #2037 — resolved ONCE and threaded into BOTH doors. The two counts
+      # used to be reached from different surfaces (this route for the bar,
+      # `/me`'s `bulk_unread_split/3` for the pills), each resolving the
+      # presence posture through its own `PresenceFilter.Resolver` door at
+      # its own instant. Measured: one disagreement between those doors puts
+      # the whole suppressed-presence population between the two numbers.
+      # Within one request that cannot happen — there is one resolution and
+      # both doors get it.
+      hide_presence = resolve_hide_presence(subject, network, channel)
+
       count =
-        Scrollback.count_after(
+        Scrollback.count_after(subject, network.id, channel, after_id, own_nick, hide_presence)
+
+      # The DISPLAY split. `count` stays the threshold's raw feed (#693, and
+      # out of scope per the #2037 ruling); `messages` is what the far-behind
+      # bar renders, and it is the same partition the sidebar's bold pill
+      # already shows.
+      split =
+        Scrollback.count_after_split(
           subject,
           network.id,
           channel,
           after_id,
           own_nick,
-          resolve_hide_presence(subject, network, channel)
+          hide_presence
         )
 
-      render(conn, :count, count: count)
+      render(conn, :count, count: count, split: split)
     end
   end
 

--- a/lib/grappa_web/controllers/messages_json.ex
+++ b/lib/grappa_web/controllers/messages_json.ex
@@ -35,8 +35,32 @@ defmodule GrappaWeb.MessagesJSON do
   Renders the `:count` action (#693) — the uncapped row count after an
   anchor. An object rather than a bare integer so the shape stays
   additive: a future sibling figure (say, a tail id) is a new key, not a
-  breaking change of the response type.
+  breaking change of the response type. #2037 is that future arriving.
+
+  ## Three numbers, because the route answers TWO questions (#2037)
+
+  `count` is the THRESHOLD's feed and is unchanged from #693: raw rows a
+  `?after=` page would return, own-authored included. cic's
+  `isFarBehind(gap)` asks "is contiguous paging achievable", which is a
+  question about rows on the wire, and the #2037 ruling puts it out of
+  scope explicitly.
+
+  `messages` + `events` are the DISPLAY split — the same
+  `@content_kinds`-vs-rest partition `ReadCursor.bulk_unread_split/3`
+  seeds the sidebar pills with. The far-behind bar renders `messages`,
+  so the bar and the bold pill are the same quantity rather than two
+  opinions about one.
+
+  All three come from ONE `resolve_hide_presence/3` in the caller, so
+  the split can never be resolved on a different presence posture than
+  the count — which is precisely the divergence #2037 measured between
+  the two `PresenceFilter.Resolver` doors.
   """
-  @spec count(%{count: non_neg_integer()}) :: %{count: non_neg_integer()}
-  def count(%{count: n}), do: %{count: n}
+  @spec count(%{count: non_neg_integer(), split: Grappa.Scrollback.count_split()}) :: %{
+          count: non_neg_integer(),
+          messages: non_neg_integer(),
+          events: non_neg_integer()
+        }
+  def count(%{count: n, split: %{messages: messages, events: events}}),
+    do: %{count: n, messages: messages, events: events}
 end

--- a/lib/mix/tasks/grappa/wire_pin.ex
+++ b/lib/mix/tasks/grappa/wire_pin.ex
@@ -38,6 +38,51 @@ defmodule Mix.Tasks.Grappa.WirePin do
   suite went green against it. `priv/wire/` has its own override in
   `_lib.sh`, alongside the drift-pin inputs there for the same reason.
 
+  ## The third component, and why a list could not be it (#2037)
+
+  🔴 **Measured in this session, on this branch, not inherited:** a brand
+  new field added to `GrappaWeb.MessagesJSON.count/1` — spec and body
+  together — left `mix grappa.wire_pin --check` answering
+  `wire shape and protocol 16 agree.` at rc 0, and
+  `mix grappa.gen_wire_types --check` answering `in sync.` on the same
+  tree, with the field appearing **0 times** in either generated artefact
+  (positive control: 223 / 190 hits for a token that is in them; negative
+  control 0). #2037 hit the same hole for real and the gate failed only on
+  the VERSION field, printing a byte-identical digest across a two-field
+  wire ADDITION.
+
+  This is a RECURRENCE. #1679 met the class — `/boot` invisible to the
+  tripwire — and cured it by adding one module to `gen_wire_types`'s
+  hand-kept `@extra_modules` and writing a comment telling the next author
+  to remember. The note did not hold, and it could not: the list is
+  **fail-OPEN**, so forgetting it costs nothing and says nothing.
+
+  Widening that list is not the cure either, measured: of the twelve
+  `GrappaWeb.*JSON` views, **eight declare no named `@type` at all** —
+  `MessagesJSON` among them, which is where #2037's fields live. The
+  codegen renders named types, so listing those modules buys exactly
+  nothing. All twelve DO carry `@spec`s (29 of them).
+
+  So the third component digests what the views **declare** — the
+  `@spec`s of their EXPORTED functions, read from BEAM chunks, over a
+  module set derived from the build output rather than typed by hand
+  (`json_view_spec_text/0`). It is fail-CLOSED twice: a new view is
+  covered the moment it compiles, and a discovery that finds nothing
+  RAISES instead of contributing an empty string.
+
+  Deliberately NOT routed through the codegen: it would drag twelve views'
+  shapes into `wireTypes.ts` and `wireSchema.ts`, and the schema one is
+  RUNTIME validation for cic. Widening a runtime validator is a client
+  change; this is a gate change, and they do not belong in one commit.
+
+  ⚠️ **Two limits, stated so they are not rediscovered as surprises.**
+  A view whose BODY grows a key while its `@spec` stands still is still
+  invisible here — Dialyzer is the leg that catches that one, and that is
+  an ARGUMENT rather than something measured in this session. And a spec
+  that references a remote type is digested as the reference TEXT, so a
+  change INSIDE `Grappa.Scrollback.count_split()` moves nothing unless
+  that type is in the digest's set by another route.
+
   The digest is taken over BOTH generated artefacts — `generate/0`
   (`wireTypes.ts`) and `generate_schema/0` (`wireSchema.ts`) — concatenated.
   Covering only the schema was the first design and it rested on an
@@ -96,6 +141,10 @@ defmodule Mix.Tasks.Grappa.WirePin do
 
   @pin_path "priv/wire/shape.pin"
   @protocol_source "lib/grappa/protocol.ex"
+
+  # The hand-written web JSON views, matched on the BUILD OUTPUT so the set
+  # is derived and cannot be under-kept. See `json_view_modules/0`.
+  @json_view_beam_glob "Elixir.GrappaWeb.*JSON.beam"
 
   @version_re ~r/^protocol_version = (\d+)$/m
   @digest_re ~r/^shape_digest = (sha256:[0-9a-f]+)$/m
@@ -195,12 +244,78 @@ defmodule Mix.Tasks.Grappa.WirePin do
   end
 
   @doc """
-  Everything the wire codegen emits, as one string. Regenerated in memory,
-  so a typespec edit that was never regenerated is caught here too.
+  Everything the wire shape is made of, as one string: what the codegen
+  emits, plus what the hand-written web JSON views declare. Regenerated in
+  memory, so a typespec edit that was never regenerated is caught here too.
   """
   @spec shape_text() :: String.t()
   def shape_text do
-    GenWireTypes.generate() <> "\n" <> GenWireTypes.generate_schema()
+    GenWireTypes.generate() <>
+      "\n" <> GenWireTypes.generate_schema() <> "\n" <> json_view_spec_text()
+  end
+
+  @doc """
+  Every `GrappaWeb.*JSON` view, DERIVED from the compiled beams.
+
+  The module name comes from the beam FILENAME, which IS the module — not
+  from camelizing a source path. That distinction is the one
+  `gen_wire_types` records having been bitten by: `controllers/me_json.ex`
+  camelizes to `GrappaWeb.Controllers.MeJson`, a module that does not
+  exist, which fails `Code.ensure_loaded?`, becomes `nil` and is dropped
+  SILENTLY — zero coverage while looking widened.
+  """
+  @spec json_view_modules() :: [module()]
+  def json_view_modules do
+    Mix.Project.compile_path()
+    |> Path.join(@json_view_beam_glob)
+    |> Path.wildcard()
+    |> Enum.map(&(&1 |> Path.basename(".beam") |> String.to_atom()))
+    |> Enum.sort()
+  end
+
+  @doc """
+  What the hand-written views DECLARE they return, as one deterministic
+  string — module order sorted, spec order sorted, read from BEAM chunks so
+  comments and formatting are invisible to it.
+
+  Raises when discovery finds nothing. An empty contribution would be a
+  silent fail-OPEN, which is the exact defect this component exists to
+  remove: the digest would go on agreeing while covering one component
+  fewer, and nothing would say so.
+  """
+  @spec json_view_spec_text() :: String.t()
+  def json_view_spec_text do
+    case json_view_modules() do
+      [] ->
+        raise "wire_pin: no #{@json_view_beam_glob} in #{Mix.Project.compile_path()} — " <>
+                "the hand-written view discovery is broken, and a digest taken without it " <>
+                "would silently cover less than the pin claims"
+
+      mods ->
+        Enum.map_join(mods, "\n", &render_view_specs/1)
+    end
+  end
+
+  defp render_view_specs(mod) do
+    "// === #{inspect(mod)} ===\n" <> Enum.map_join(exported_specs(mod), "\n", &"  @spec #{&1}")
+  end
+
+  # EXPORTED only. A `@spec` on a private helper is not a wire shape, and
+  # digesting it would redden the gate on a refactor that no client can see.
+  defp exported_specs(mod) do
+    with true <- Code.ensure_loaded?(mod),
+         {:ok, specs} <- Code.Typespec.fetch_specs(mod) do
+      exported = MapSet.new(mod.__info__(:functions))
+
+      specs
+      |> Enum.filter(fn {name_arity, _} -> MapSet.member?(exported, name_arity) end)
+      |> Enum.flat_map(fn {{name, _}, forms} ->
+        Enum.map(forms, &Macro.to_string(Code.Typespec.spec_to_quoted(name, &1)))
+      end)
+      |> Enum.sort()
+    else
+      _ -> []
+    end
   end
 
   @doc """
@@ -220,9 +335,12 @@ defmodule Mix.Tasks.Grappa.WirePin do
     #
     # The two facts below belong together. `protocol_version` is the value of
     # `Grappa.Protocol.version/0` at the moment `shape_digest` was taken over
-    # BOTH generated artefacts — `wireTypes.ts` and `wireSchema.ts`,
-    # concatenated. A shape change with a still number is the violation the
-    # gate exists for, and --update refuses to write it away.
+    # THREE components, concatenated: the two generated artefacts
+    # (`wireTypes.ts` and `wireSchema.ts`) and the `@spec`s the hand-written
+    # `GrappaWeb.*JSON` views export (#2037 — a field added to one of those
+    # views moved neither artefact, and this gate said `agree.`). A shape
+    # change with a still number is the violation the gate exists for, and
+    # --update refuses to write it away.
     #
     # This line states the COVERAGE on purpose: widening or narrowing what
     # the digest spans is not a wire-shape change, the gate cannot tell one

--- a/priv/wire/shape.pin
+++ b/priv/wire/shape.pin
@@ -9,5 +9,5 @@
 # This line states the COVERAGE on purpose: widening or narrowing what
 # the digest spans is not a wire-shape change, the gate cannot tell one
 # from the other, and reading the pin is the only place a review sees it.
-protocol_version = 15
+protocol_version = 16
 shape_digest = sha256:f3c18a4c920e1bbf97d9fa7af80d1970fb3bbe47ef6e062d7f6f92817b4bf3c0

--- a/priv/wire/shape.pin
+++ b/priv/wire/shape.pin
@@ -2,12 +2,15 @@
 #
 # The two facts below belong together. `protocol_version` is the value of
 # `Grappa.Protocol.version/0` at the moment `shape_digest` was taken over
-# BOTH generated artefacts — `wireTypes.ts` and `wireSchema.ts`,
-# concatenated. A shape change with a still number is the violation the
-# gate exists for, and --update refuses to write it away.
+# THREE components, concatenated: the two generated artefacts
+# (`wireTypes.ts` and `wireSchema.ts`) and the `@spec`s the hand-written
+# `GrappaWeb.*JSON` views export (#2037 — a field added to one of those
+# views moved neither artefact, and this gate said `agree.`). A shape
+# change with a still number is the violation the gate exists for, and
+# --update refuses to write it away.
 #
 # This line states the COVERAGE on purpose: widening or narrowing what
 # the digest spans is not a wire-shape change, the gate cannot tell one
 # from the other, and reading the pin is the only place a review sees it.
 protocol_version = 16
-shape_digest = sha256:f3c18a4c920e1bbf97d9fa7af80d1970fb3bbe47ef6e062d7f6f92817b4bf3c0
+shape_digest = sha256:cdc283e8284f409aaa12b058fd21d3d95c27eab034c3d94bcea2ca0dd11fde9a

--- a/test/grappa/unread_2037_probe_test.exs
+++ b/test/grappa/unread_2037_probe_test.exs
@@ -1,0 +1,424 @@
+defmodule Grappa.Unread2037ProbeTest do
+  @moduledoc """
+  issue 2037 — MEASUREMENT INSTRUMENT, not a regression test.
+
+  The report has three numbers on one screen for what the operator reads as
+  one quantity (`1807` in the far-behind bar, `187` + `216` in the sidebar
+  pills) and the issue body says in as many words that own-authored rows
+  plus the content/events split do NOT account for the `1807 - 403 = 1404`
+  residual. This file measures the residual TERM BY TERM against a real
+  `messages` table, so the residual stops being a guess.
+
+  It measures the three counting doors the two surfaces reach:
+
+    * `Scrollback.count_after/6`        — the bar (`GET …/messages/count`)
+    * `Scrollback.count_after_split/6`  — the join-reply / per-message badge
+    * `ReadCursor.bulk_unread_split/3`  — the `/me` cold-load badge seed
+
+  ## Controls run FIRST and gate the print
+
+  Nothing is printed unless BOTH controls hold, because a harness that
+  mis-seeds its own fixture prints a number that describes the harness:
+
+    * NEGATIVE — a window whose rows are all peer content, one anchor, one
+      presence posture: every door must return the SAME total. A non-zero
+      residual here means the fixture, not the code, is divergent.
+    * POSITIVE — the same window plus K own-authored content rows: the
+      residual must be EXACTLY K. A residual that is merely non-zero would
+      pass a harness that is off by an unrelated term.
+
+  Both are asserted before the first `IO.puts`. `mix test` failure IS the
+  abort path: an assertion raises and the reporting block never runs.
+  """
+  use Grappa.DataCase, async: true
+
+  import Grappa.AuthFixtures, only: [user_fixture: 0, network_fixture: 0]
+
+  alias Grappa.PresenceFilter.Resolver
+  alias Grappa.{ReadCursor, Scrollback, ScrollbackHelpers}
+  alias Grappa.Scrollback.Message
+
+  # A Session.Server stand-in registered under the real registry key, so
+  # `Resolver.hidden?/4` and `Resolver.hidden_channels/3` reach it through the
+  # production `Grappa.Session` facade rather than through a mock of the
+  # resolver itself. Its whole purpose is that the two calls can be answered
+  # INDEPENDENTLY — which is the question being measured.
+  defmodule SessionStub do
+    @moduledoc false
+    use GenServer
+
+    @spec start_link({Grappa.Subject.t(), integer(), map()}) :: GenServer.on_start()
+    def start_link({subject, network_id, replies}) do
+      GenServer.start_link(__MODULE__, replies,
+        name: {:via, Registry, {Grappa.SessionRegistry, Grappa.Session.Server.registry_key(subject, network_id)}}
+      )
+    end
+
+    @impl GenServer
+    def init(replies), do: {:ok, replies}
+
+    @impl GenServer
+    def handle_call({:list_members, _}, _, replies),
+      do: {:reply, Map.fetch!(replies, :list_members), replies}
+
+    def handle_call(:list_member_counts, _, replies),
+      do: {:reply, Map.fetch!(replies, :list_member_counts), replies}
+  end
+
+  @own_nick "vjt"
+  @channel "#sniffo"
+
+  # ---------------------------------------------------------------------------
+  # Fixture
+  # ---------------------------------------------------------------------------
+
+  # One window, seeded row by row so every population is known by
+  # construction. `server_time` doubles as the sequence number; ids come out
+  # monotonic because the inserts are serial.
+  defp seed_window(subject_attrs, network_id, spec) do
+    peer_content = Keyword.fetch!(spec, :peer_content)
+    peer_presence = Keyword.fetch!(spec, :peer_presence)
+    own_content = Keyword.fetch!(spec, :own_content)
+    own_presence = Keyword.fetch!(spec, :own_presence)
+    peer_topic = Keyword.fetch!(spec, :peer_topic)
+
+    anchor = insert_row(subject_attrs, network_id, 0, :privmsg, "peer", "anchor")
+
+    rows =
+      Enum.flat_map(
+        [
+          {peer_content, :privmsg, "peer"},
+          {peer_presence, :join, "peer"},
+          {own_content, :privmsg, @own_nick},
+          {own_presence, :part, @own_nick},
+          {peer_topic, :topic, "peer"}
+        ],
+        fn {n, kind, sender} -> for _ <- 1..n//1, do: {kind, sender} end
+      )
+
+    rows
+    |> Enum.with_index(1)
+    |> Enum.each(fn {{kind, sender}, i} ->
+      insert_row(subject_attrs, network_id, i, kind, sender, "row-#{i}")
+    end)
+
+    anchor.id
+  end
+
+  defp insert_row(subject_attrs, network_id, server_time, kind, sender, body) do
+    attrs =
+      Map.merge(subject_attrs, %{
+        network_id: network_id,
+        channel: @channel,
+        server_time: server_time,
+        kind: kind,
+        sender: sender,
+        body: body
+      })
+
+    {:ok, message} = ScrollbackHelpers.insert(attrs)
+    message
+  end
+
+  # ---------------------------------------------------------------------------
+  # The three doors, at a caller-chosen anchor and presence posture
+  # ---------------------------------------------------------------------------
+
+  defp bar(subject, network_id, anchor, hide_presence),
+    do: Scrollback.count_after(subject, network_id, @channel, anchor, @own_nick, hide_presence)
+
+  defp split(subject, network_id, anchor, hide_presence) do
+    %{messages: m, events: e} =
+      Scrollback.count_after_split(subject, network_id, @channel, anchor, @own_nick, hide_presence)
+
+    %{messages: m, events: e, total: m + e}
+  end
+
+  defp bulk(subject, network_id, slug, hide_presence?) do
+    hidden =
+      if hide_presence?, do: %{slug => MapSet.new([@channel])}, else: %{}
+
+    %{messages: m, events: e} =
+      subject
+      |> ReadCursor.bulk_unread_split(%{slug => {network_id, @own_nick}}, hidden)
+      |> get_in([slug, @channel])
+
+    %{messages: m, events: e, total: m + e}
+  end
+
+  # ---------------------------------------------------------------------------
+  # The measurement
+  # ---------------------------------------------------------------------------
+
+  test "issue 2037 — decompose the bar-vs-badge residual, term by term" do
+    user = user_fixture()
+    net = network_fixture()
+    subject = {:user, user.id}
+    attrs = %{user_id: user.id}
+
+    # A single window with every population present and distinct in size, so
+    # no term can be confused with another by coincidence of magnitude.
+    pop = [peer_content: 7, peer_presence: 61, own_content: 5, own_presence: 3, peer_topic: 2]
+    anchor = seed_window(attrs, net.id, pop)
+    {:ok, _} = ReadCursor.set(subject, net.id, @channel, anchor)
+
+    total_rows = Enum.sum(Keyword.values(pop))
+    own_rows = pop[:own_content] + pop[:own_presence]
+    suppressed_rows = pop[:peer_presence] + pop[:own_presence]
+
+    # -- CONTROLS ------------------------------------------------------------
+    # NEGATIVE: a second window with peer content only. One anchor, one
+    # posture, no own rows, no presence rows -> every door must agree.
+    ctrl_user = user_fixture()
+    ctrl_subject = {:user, ctrl_user.id}
+    ctrl_attrs = %{user_id: ctrl_user.id}
+
+    ctrl_anchor =
+      seed_window(ctrl_attrs, net.id,
+        peer_content: 9,
+        peer_presence: 0,
+        own_content: 0,
+        own_presence: 0,
+        peer_topic: 0
+      )
+
+    {:ok, _} = ReadCursor.set(ctrl_subject, net.id, @channel, ctrl_anchor)
+
+    neg_bar = bar(ctrl_subject, net.id, ctrl_anchor, false)
+    neg_split = split(ctrl_subject, net.id, ctrl_anchor, false)
+    neg_bulk = bulk(ctrl_subject, net.id, net.slug, false)
+
+    assert neg_bar == 9, "NEG CTRL: the bar does not see the seeded population"
+    assert neg_bar - neg_split.total == 0, "NEG CTRL: bar vs per-window split diverged with nothing to diverge on"
+    assert neg_bar - neg_bulk.total == 0, "NEG CTRL: bar vs bulk seed diverged with nothing to diverge on"
+
+    # POSITIVE: the real window, same anchor, same posture. The residual must
+    # be EXACTLY the own-authored population — not merely non-zero.
+    pos_bar = bar(subject, net.id, anchor, false)
+    pos_split = split(subject, net.id, anchor, false)
+
+    assert pos_bar == total_rows,
+           "POS CTRL: the bar counted #{pos_bar} of #{total_rows} seeded rows"
+
+    assert pos_bar - pos_split.total == own_rows,
+           "POS CTRL: residual #{pos_bar - pos_split.total} != own-authored #{own_rows} — " <>
+             "the harness carries an unaccounted term of its own"
+
+    # -- TERMS ---------------------------------------------------------------
+    # T1 — own-authored, the term the issue body names. Same anchor, same
+    # posture; the ONLY predicate difference between the two doors.
+    t1 = pos_bar - pos_split.total
+
+    # T2 — presence posture. The bar resolves `hide_presence` through
+    # `Resolver.hidden?/4` (one GenServer call, at probe time); the seed
+    # resolves it through `Resolver.hidden_channels/3` (a different call, at
+    # /me time). Same rule module, two inputs, two instants. This measures
+    # what ONE disagreement costs.
+    t2_bulk_hidden = bulk(subject, net.id, net.slug, true)
+    t2 = pos_bar - t2_bulk_hidden.total - t1
+
+    # T3 — the anchor. Measured as a SIGN, not just a size: `count_after/6`
+    # is monotone non-increasing in the anchor, so an anchor that differs can
+    # only ever move the bar in ONE direction.
+    later_anchor = anchor + 30
+    t3_bar_later = bar(subject, net.id, later_anchor, false)
+    t3 = pos_bar - t3_bar_later
+
+    # T4 — the bulk seed vs the per-window split at the same anchor and the
+    # same posture. `bulk_unread_split/3`'s docstring claims these are
+    # IDENTICAL for a channel window; this is that claim, measured.
+    pos_bulk = bulk(subject, net.id, net.slug, false)
+    t4 = pos_split.total - pos_bulk.total
+
+    # T5 — scaling. A term that grows with the channel's traffic can carry a
+    # 1404-row residual; one that grows with the OPERATOR's traffic cannot.
+    scale_user = user_fixture()
+    scale_subject = {:user, scale_user.id}
+
+    scale_anchor =
+      seed_window(%{user_id: scale_user.id}, net.id,
+        peer_content: 7,
+        peer_presence: 610,
+        own_content: 5,
+        own_presence: 3,
+        peer_topic: 2
+      )
+
+    {:ok, _} = ReadCursor.set(scale_subject, net.id, @channel, scale_anchor)
+    scale_bar = bar(scale_subject, net.id, scale_anchor, false)
+    scale_t1 = scale_bar - split(scale_subject, net.id, scale_anchor, false).total
+    scale_t2 = scale_bar - bulk(scale_subject, net.id, net.slug, true).total - scale_t1
+
+    # -- REPORT --------------------------------------------------------------
+    IO.puts("""
+
+    ================================================================
+    issue 2037 — bar-vs-badge residual, measured at #{Mix.env()} on a real
+    `messages` table. Controls held (neg residual 0; pos residual == own).
+    ================================================================
+    window population (rows AFTER the anchor)
+      peer content            #{pop[:peer_content]}
+      peer presence (join)    #{pop[:peer_presence]}
+      own content             #{pop[:own_content]}
+      own presence (part)     #{pop[:own_presence]}
+      peer topic              #{pop[:peer_topic]}
+      TOTAL                   #{total_rows}
+      suppressed-presence set #{suppressed_rows}   (join|part|quit|nick_change|mode)
+
+    the three doors, SAME anchor (#{anchor}), SAME posture (presence shown)
+      count_after/6        (bar)          #{pos_bar}
+      count_after_split/6  (join badge)   #{pos_split.messages} + #{pos_split.events} = #{pos_split.total}
+      bulk_unread_split/3  (/me seed)     #{pos_bulk.messages} + #{pos_bulk.events} = #{pos_bulk.total}
+
+    TERMS
+      T1 own-authored       #{t1}
+         bar - split, same anchor, same posture. Bounded by what the
+         OPERATOR typed/did. Seeded: #{own_rows}.
+      T2 presence posture   #{t2}
+         one resolver disagreement (bar SHOWS, seed HIDES), net of T1.
+         Bounded by CHANNEL traffic. Seeded suppressed: #{suppressed_rows}.
+      T3 anchor             #{t3}  (bar@#{anchor}=#{pos_bar} -> bar@#{later_anchor}=#{t3_bar_later})
+         SIGN: a LATER anchor can only LOWER the bar. #{if t3 >= 0, do: "non-negative — confirmed", else: "NEGATIVE — monotonicity broken"}
+      T4 bulk vs per-window #{t4}
+         same anchor, same posture, channel window. Docstring claims 0.
+
+    SCALING (same operator traffic, channel presence x10: 61 -> 610)
+      T1  #{t1} -> #{scale_t1}   #{if scale_t1 == t1, do: "flat — cannot carry a channel-sized residual", else: "MOVED"}
+      T2  #{t2} -> #{scale_t2}   #{if scale_t2 > t2, do: "grows with channel traffic — CAN carry 1404", else: "flat"}
+    ================================================================
+    """)
+
+    # The report is the deliverable; these keep the file honest as a test.
+    assert t1 == own_rows
+    assert t3 >= 0
+    assert Enum.all?(Message.suppressed_presence_kinds(), &(&1 not in Message.content_kinds()))
+  end
+
+  # ---------------------------------------------------------------------------
+  # The ordered question: can the two presence paths RESPOND differently?
+  #
+  # The issue body says "Both paths DO share the presence-hidden filter, so
+  # that is not a divergence source." They share the RULE
+  # (`PresenceFilter.hidden?/2`) and nothing else: the bar resolves through
+  # `Resolver.hidden?/4` -> `Session.list_members/3`, the seed through
+  # `Resolver.hidden_channels/3` -> `Session.list_member_counts/2`. Two calls.
+  #
+  # Being written differently is not evidence. This measures whether they
+  # ANSWER differently, and at what cost, by driving both through the real
+  # `Grappa.Session` facade against a session whose two calls are answerable
+  # independently.
+  # ---------------------------------------------------------------------------
+  describe "the two presence resolvers" do
+    setup do
+      user = user_fixture()
+      net = network_fixture()
+      subject = {:user, user.id}
+
+      anchor =
+        seed_window(%{user_id: user.id}, net.id,
+          peer_content: 7,
+          peer_presence: 61,
+          own_content: 5,
+          own_presence: 3,
+          peer_topic: 2
+        )
+
+      {:ok, _} = ReadCursor.set(subject, net.id, @channel, anchor)
+
+      %{subject: subject, net: net, anchor: anchor}
+    end
+
+    defp start_stub(subject, net, list_members, list_member_counts) do
+      start_supervised!(
+        {SessionStub, {subject, net.id, %{list_members: list_members, list_member_counts: list_member_counts}}}
+      )
+    end
+
+    defp seed_hides?(subject, net) do
+      subject
+      |> Resolver.hidden_channels(%{net.slug => {net.id, @own_nick}}, %{
+        net.slug => %{@channel => %{}}
+      })
+      |> Map.get(net.slug, MapSet.new())
+      |> MapSet.member?(@channel)
+    end
+
+    defp bar_hides?(subject, net), do: Resolver.hidden?(subject, net.slug, net.id, @channel)
+
+    # NEG CTRL, arm 1 — no session at all. Both lookups fail the SAME way and
+    # decision D lands both on SHOW. Symmetric: no divergence to be had here,
+    # which is exactly why "they share the filter" reads true from a distance.
+    test "NEG CTRL — with no session, both resolvers SHOW", %{subject: subject, net: net} do
+      refute bar_hides?(subject, net)
+      refute seed_hides?(subject, net)
+    end
+
+    # NEG CTRL, arm 2 — one live session answering both calls CONSISTENTLY, at
+    # a member count over the threshold. Both HIDE. Still symmetric.
+    test "NEG CTRL — consistent answers over threshold: both HIDE", %{
+      subject: subject,
+      net: net
+    } do
+      big = Enum.map(1..250, &%{nick: "n#{&1}", modes: [], gender: nil})
+      start_stub(subject, net, {:ok, big}, {:ok, %{@channel => 250}})
+
+      assert bar_hides?(subject, net)
+      assert seed_hides?(subject, net)
+    end
+
+    # POS CTRL + the measurement. The two calls answer INDEPENDENTLY: the
+    # per-window one reports the channel unseeded (`:uninitialized`, which
+    # `member_count_for_unset/4`'s catch-all maps to nil, IDENTICALLY to
+    # `{:error, :timeout}` and `{:error, :no_session}`), while the bulk one
+    # still carries the count.
+    #
+    # The resolvers then disagree WITH THE SIGN THE ISSUE NEEDS: the bar shows
+    # presence, the seed hides it. The cost is measured, not assumed.
+    test "POS CTRL — asymmetric answers diverge, bar SHOWS while seed HIDES", %{
+      subject: subject,
+      net: net,
+      anchor: anchor
+    } do
+      start_stub(subject, net, {:ok, :uninitialized}, {:ok, %{@channel => 250}})
+
+      refute bar_hides?(subject, net)
+      assert seed_hides?(subject, net)
+
+      # What that one disagreement costs, in rows, at the same anchor.
+      bar_rows = bar(subject, net.id, anchor, bar_hides?(subject, net))
+      seed = bulk(subject, net.id, net.slug, seed_hides?(subject, net))
+
+      own_content = 5
+      own_presence = 3
+      peer_presence = 61
+      own = own_content + own_presence
+      suppressed = peer_presence + own_presence
+
+      # The two excluded populations OVERLAP on the operator's own presence
+      # rows, so the residual is their union, not their sum. Stated exactly —
+      # a `> 0` assertion here would pass on any bug that merely moved rows.
+      assert bar_rows - seed.total == own + suppressed - own_presence
+
+      IO.puts("""
+
+      ================================================================
+      issue 2037 — the two presence resolvers, measured
+      ================================================================
+        no session                -> bar SHOW, seed SHOW   (symmetric)
+        consistent, over-threshold-> bar HIDE, seed HIDE   (symmetric)
+        asymmetric answers        -> bar SHOW, seed HIDE   (DIVERGENT)
+
+        cost of that ONE disagreement, same anchor:
+          bar  #{bar_rows}
+          seed #{seed.messages} + #{seed.events} = #{seed.total}
+          residual #{bar_rows - seed.total}
+            = own-authored #{own} UNION suppressed-presence #{suppressed}
+              (they overlap on the #{own_presence} own presence rows)
+
+        The suppressed term is bounded by CHANNEL traffic, not by the
+        operator's. It is the only term of the pair that can grow to 1404.
+      ================================================================
+      """)
+    end
+  end
+end

--- a/test/grappa/user_settings_display_prefs_test.exs
+++ b/test/grappa/user_settings_display_prefs_test.exs
@@ -566,6 +566,7 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
       assert UserSettings.get_display_prefs(subject).presence_filter == %{"n #v" => "hide"}
     end
   end
+
   # ---------------------------------------------------------------------------
   # show_event_badge (#2037 B) — the SIXTH key, and the first whose default
   # TAKES something away

--- a/test/grappa/user_settings_display_prefs_test.exs
+++ b/test/grappa/user_settings_display_prefs_test.exs
@@ -42,7 +42,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
         "colored_nicklist" => false,
         "presence_filter" => %{},
         "show_bottom_bar" => true,
-        "strip_formatting" => false
+        "strip_formatting" => false,
+        "show_event_badge" => false
       },
       overrides
     )
@@ -61,7 +62,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
                colored_nicklist: false,
                presence_filter: %{},
                show_bottom_bar: true,
-               strip_formatting: false
+               strip_formatting: false,
+               show_event_badge: false
              }
     end
 
@@ -75,7 +77,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
                colored_nicklist: false,
                presence_filter: %{},
                show_bottom_bar: true,
-               strip_formatting: false
+               strip_formatting: false,
+               show_event_badge: false
              }
     end
 
@@ -95,7 +98,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
                colored_nicklist: false,
                presence_filter: %{},
                show_bottom_bar: true,
-               strip_formatting: false
+               strip_formatting: false,
+               show_event_badge: false
              }
     end
 
@@ -112,7 +116,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
                colored_nicklist: false,
                presence_filter: %{},
                show_bottom_bar: true,
-               strip_formatting: false
+               strip_formatting: false,
+               show_event_badge: false
              }
     end
   end
@@ -188,7 +193,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
                colored_nicklist: true,
                presence_filter: %{"libera #bofh" => "hide", "libera #cat" => "show"},
                show_bottom_bar: true,
-               strip_formatting: false
+               strip_formatting: false,
+               show_event_badge: false
              }
     end
 
@@ -558,6 +564,74 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
                UserSettings.put_display_prefs(subject, valid_wire(%{"presence_filter" => %{"n #v" => "hide"}}))
 
       assert UserSettings.get_display_prefs(subject).presence_filter == %{"n #v" => "hide"}
+    end
+  end
+  # ---------------------------------------------------------------------------
+  # show_event_badge (#2037 B) — the SIXTH key, and the first whose default
+  # TAKES something away
+  # ---------------------------------------------------------------------------
+  #
+  # vjt's ruling on #2037: "dobbiamo avere due bucket: messaggi e !messaggi. i
+  # !messaggi non sono interessanti e devono solo finire nell'opt-in badge."
+  # So the faint events pill stops rendering unless the operator asks for it,
+  # and OFF is therefore the default — unlike the other five, this default
+  # changes what an existing operator sees on their next load.
+  #
+  # Server-backed on #1766's criterion, same as the fifth: "is my sidebar
+  # cluttered with join/part counts" is a property of the ACCOUNT, identical on
+  # the phone and the desktop, not of a viewport.
+  #
+  # ⚠️ The behaviour change this carries is NOT limited to join/part. The
+  # events bucket is `kind not in @content_kinds`, which includes `topic`,
+  # `kick` and `server_event` — the three that sit OUTSIDE
+  # `suppressed_presence_kinds/0` on purpose (#458) because the pane still
+  # renders them. Under this pref a KICK stops contributing to a badge by
+  # default. That is deliberate and called out rather than discovered: a kick
+  # that needs to stay loud belongs in the mention/severity channel (#267),
+  # not smuggled back into the message bucket.
+
+  describe "show_event_badge (#2037 B)" do
+    test "defaults to FALSE — the events pill is opt-in, not opt-out" do
+      assert UserSettings.default_display_prefs().show_event_badge == false
+
+      assert UserSettings.get_display_prefs({:user, Ecto.UUID.generate()}).show_event_badge ==
+               false
+    end
+
+    test "round-trips true" do
+      user = user_fixture()
+
+      assert {:ok, _} =
+               UserSettings.put_display_prefs(
+                 {:user, user.id},
+                 valid_wire(%{"show_event_badge" => true})
+               )
+
+      assert UserSettings.get_display_prefs({:user, user.id}).show_event_badge == true
+    end
+
+    test "a PUT from a client predating the key is ACCEPTED, and reads as the default" do
+      user = user_fixture()
+      older_body = Map.delete(valid_wire(), "show_event_badge")
+
+      assert {:ok, _} = UserSettings.put_display_prefs({:user, user.id}, older_body)
+      assert UserSettings.get_display_prefs({:user, user.id}).show_event_badge == false
+    end
+
+    test "a five-key PUT still persists the keys it DID send" do
+      user = user_fixture()
+
+      older_body =
+        Map.delete(
+          valid_wire(%{"time_format" => "hm", "colored_nicklist" => true}),
+          "show_event_badge"
+        )
+
+      assert {:ok, _} = UserSettings.put_display_prefs({:user, user.id}, older_body)
+
+      prefs = UserSettings.get_display_prefs({:user, user.id})
+      assert prefs.time_format == "hm"
+      assert prefs.colored_nicklist == true
     end
   end
 end

--- a/test/grappa_web/controllers/messages_controller_test.exs
+++ b/test/grappa_web/controllers/messages_controller_test.exs
@@ -439,7 +439,7 @@ defmodule GrappaWeb.MessagesControllerTest do
 
       conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages/count?after=0")
 
-      assert json_response(conn, 200) == %{"count" => 5}
+      assert json_response(conn, 200) == %{"count" => 5, "messages" => 5, "events" => 0}
     end
 
     test "the count is NOT capped at the page ceiling — a 201-row gap reads 201",
@@ -459,7 +459,7 @@ defmodule GrappaWeb.MessagesControllerTest do
 
       conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages/count?after=0")
 
-      assert json_response(conn, 200) == %{"count" => 201}
+      assert json_response(conn, 200) == %{"count" => 201, "messages" => 201, "events" => 0}
     end
 
     test "?after=<tail id> returns 0", %{conn: conn, user: user, network: network} do
@@ -469,7 +469,7 @@ defmodule GrappaWeb.MessagesControllerTest do
 
       conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages/count?after=#{tail}")
 
-      assert json_response(conn, 200) == %{"count" => 0}
+      assert json_response(conn, 200) == %{"count" => 0, "messages" => 0, "events" => 0}
     end
 
     test "counts only VISIBLE rows when the channel pref hides presence (#458)",
@@ -482,7 +482,40 @@ defmodule GrappaWeb.MessagesControllerTest do
 
       conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages/count?after=0")
 
-      assert json_response(conn, 200) == %{"count" => 1}
+      assert json_response(conn, 200) == %{"count" => 1, "messages" => 1, "events" => 0}
+    end
+
+    # #2037 A — the response now carries THREE numbers because the route
+    # answers TWO questions. `count` is the threshold's feed (raw rows a
+    # fetch would return, own-authored included, #693) and is UNCHANGED.
+    # `messages` / `events` are the DISPLAY split, the same quantity
+    # `bulk_unread_split/3` seeds the sidebar pills with, so the bar and the
+    # badge stop being two opinions on one number.
+    test "the split carries the non-content rows under `events` when presence SHOWS (#2037)",
+         %{conn: conn, user: user, network: network} do
+      :ok = put_presence_pref(user, "azzurra #sniffo", "show")
+      seed_mixed(user, network)
+
+      conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages/count?after=0")
+
+      assert json_response(conn, 200) == %{"count" => 3, "messages" => 1, "events" => 2}
+    end
+
+    # The split follows the SAME presence posture `count` does — one
+    # `resolve_hide_presence/3` call feeds both, so a pinned-hidden channel
+    # cannot report a bar and a badge resolved on different postures. That
+    # divergence is the mechanism measured in #2037 and it is closed here by
+    # construction: there is one resolution per request.
+    test "the split follows the same presence posture as `count` (#2037)",
+         %{conn: conn, user: user, network: network} do
+      :ok = put_presence_pref(user, "azzurra #sniffo", "hide")
+      seed_mixed(user, network)
+
+      conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages/count?after=0")
+
+      body = json_response(conn, 200)
+      assert body == %{"count" => 1, "messages" => 1, "events" => 0}
+      assert body["count"] == body["messages"] + body["events"]
     end
 
     test "a missing ?after returns 400", %{conn: conn, user: user, network: network} do
@@ -525,7 +558,7 @@ defmodule GrappaWeb.MessagesControllerTest do
 
       conn = get(conn, "/networks/azzurra/channels/%23altro/messages/count?after=0")
 
-      assert json_response(conn, 200) == %{"count" => 5}
+      assert json_response(conn, 200) == %{"count" => 5, "messages" => 5, "events" => 0}
     end
 
     test "without Bearer returns 401" do

--- a/test/grappa_web/controllers/user_settings_controller_test.exs
+++ b/test/grappa_web/controllers/user_settings_controller_test.exs
@@ -680,7 +680,8 @@ defmodule GrappaWeb.UserSettingsControllerTest do
       "colored_nicklist" => false,
       "presence_filter" => %{},
       "show_bottom_bar" => true,
-      "strip_formatting" => false
+      "strip_formatting" => false,
+      "show_event_badge" => false
     }
   end
 
@@ -736,7 +737,8 @@ defmodule GrappaWeb.UserSettingsControllerTest do
                "colored_nicklist" => true,
                "presence_filter" => %{"libera #bofh" => "hide"},
                "show_bottom_bar" => true,
-               "strip_formatting" => false
+               "strip_formatting" => false,
+      "show_event_badge" => false
              }
     end
 

--- a/test/grappa_web/controllers/user_settings_controller_test.exs
+++ b/test/grappa_web/controllers/user_settings_controller_test.exs
@@ -738,7 +738,7 @@ defmodule GrappaWeb.UserSettingsControllerTest do
                "presence_filter" => %{"libera #bofh" => "hide"},
                "show_bottom_bar" => true,
                "strip_formatting" => false,
-      "show_event_badge" => false
+               "show_event_badge" => false
              }
     end
 

--- a/test/mix/tasks/grappa/wire_pin_test.exs
+++ b/test/mix/tasks/grappa/wire_pin_test.exs
@@ -140,6 +140,76 @@ defmodule Mix.Tasks.Grappa.WirePinTest do
     end
   end
 
+  # #2037 — the third component. The two generated artefacts are not the whole
+  # wire: the hand-written `GrappaWeb.*JSON` views ship response shapes the
+  # codegen never sees, and a field added to one of them left this gate GREEN.
+  # Measured live before the cure, on this branch: `mutant_probe` added to
+  # `MessagesJSON.count/1` (spec AND body) kept `--check` at rc 0 and
+  # `gen_wire_types --check` at `in sync.`, with the field appearing 0 times in
+  # either artefact. After the cure the same addition moves the digest.
+  describe "the hand-written web views are in the digest too" do
+    test "the digested text carries what a view DECLARES, not only the codegen" do
+      text = WirePin.shape_text()
+      views = WirePin.json_view_spec_text()
+
+      # Load-bearing, not decorative: the old two-artefact composition must
+      # not already contain it, or this component is buying nothing.
+      old_composition = GenWireTypes.generate() <> "\n" <> GenWireTypes.generate_schema()
+
+      assert String.contains?(text, views)
+      refute String.contains?(old_composition, views)
+    end
+
+    test "the #2037 count response is inside the digested text" do
+      views = WirePin.json_view_spec_text()
+
+      # The exact shape whose ADDITION this gate failed to see. Named rather
+      # than probed generically: if a refactor moves this response out of a
+      # spec the digest reads, the coverage is gone and this says so.
+      assert views =~ "GrappaWeb.MessagesJSON"
+      assert views =~ "messages: non_neg_integer()"
+      assert views =~ "events: non_neg_integer()"
+    end
+
+    test "discovery is DERIVED from the build output and finds every view" do
+      mods = WirePin.json_view_modules()
+
+      # Positive control: a set this small going empty is the failure mode
+      # the component raises on, and an assertion of ">= 1" would not notice
+      # eleven of twelve disappearing.
+      assert length(mods) >= 12
+      assert GrappaWeb.MessagesJSON in mods
+      assert GrappaWeb.UserSettingsJSON in mods
+      assert GrappaWeb.PushSubscriptionJSON in mods
+
+      # Sorted, so the digest cannot move on filesystem ordering alone.
+      assert mods == Enum.sort(mods)
+
+      # Nothing that is not a view. The glob is the whole membership rule and
+      # a widened one would quietly digest unrelated modules.
+      for mod <- mods do
+        name = inspect(mod)
+        assert String.starts_with?(name, "GrappaWeb.")
+        assert String.ends_with?(name, "JSON")
+      end
+    end
+
+    test "a private helper's spec is NOT digested, while its exported sibling is" do
+      views = WirePin.json_view_spec_text()
+
+      # `PushSubscriptionJSON` is the module that makes this testable rather
+      # than argued: it `@spec`s BOTH `device/1` (exported, a wire shape) and
+      # `summary/1` (`defp`, an internal helper). One pair, one module, so a
+      # filter that passed everything and a filter that passed nothing are
+      # both caught here.
+      assert {:device, 1} in GrappaWeb.PushSubscriptionJSON.__info__(:functions)
+      refute {:summary, 1} in GrappaWeb.PushSubscriptionJSON.__info__(:functions)
+
+      assert views =~ "@spec device("
+      refute views =~ "@spec summary("
+    end
+  end
+
   describe "no network, and it is enforced rather than promised" do
     # The orchestrator's second binding requirement: a gate that reaches for
     # `origin/main` or a tag breaks CI the moment CI is offline. The pin is in


### PR DESCRIPTION
# Union gate for PR #2047 and PR #2049

This PR exists to gate **once** what two open PRs would otherwise gate separately
against a base neither of them shares with the other. It adds no work of its own:
it is `origin/main` with both branches **merged** (never cherry-picked), so both
heads stay ancestors of `main` and both PRs keep their authorship and resolve
themselves at merge.

| branch | PR | subject |
|---|---|---|
| `w2/2037-unread-anchor` @ `2969986e6` | #2047 | issue 2037 — unread anchor, plus the `wire_pin` digest cure |
| `w2/1738-tail-rest` @ `c247e3cba` | #2049 | issue 1738 — characterization spec for send-at-tail rest position |

## Why a union and not two merges

The cheap argument is one `integration` run instead of two. The honest one is that
these two touch the **same surface** without sharing a file: #2047 makes four
pre-existing e2e specs opt IN to the events pill and rewrites the unread anchor,
while #2049 adds a *new* e2e spec that exercises where a plain send at the tail
comes to rest. Each PR's green attests to `branch + base`, never to
`branch + the other branch`. This run is the first thing that asks whether they
still hold together.

A correction worth recording, because a plan was built on the opposite: **#2049
does not touch `docs/DESIGN_NOTES.md` at all** — it is a single new file, 263
lines added, 0 deleted. Only #2047 appends to the decision log. The `merge=union`
hazard therefore applies to one side, not two.

## DESIGN_NOTES: arithmetic predicted before the merge, then measured

`merge=union` resolves silently, with `rc=0` and zero conflicts — which is exactly
the case where a green proves nothing. So the numbers were pinned **before** the
merge ran:

| quantity | predicted | measured |
|---|---|---|
| bytes | `2990290 + 23926 + 0` = **3014216** | **3014216** |
| lines | `51111 + 445 + 0` = **51556** | **51556** |

Companions, each with a live control rather than an assertion:

- **Prefix identity** — the first 2990290 bytes of the union's log are byte-identical
  to `origin/main`'s (`cmp` rc=0). Both boundary controls **fail** as they must
  (`N+1` rc=1, `N-1` rc=1), so the comparison is discriminating and not a tautology.
- **Pure append** — #2047's contribution was verified as an append against its own
  merge base before merging (prefix `cmp` rc=0, negative control at one byte short
  rc=1).
- **Marker uniqueness against the *current* tip** — `#2037a`, `#2037b`, `#2037c` are
  the three markers the union adds; zero duplicates across the whole file, positive
  control 342 markers already on `main`. A rebase is precisely when a marker stops
  being unique, so this was re-checked here rather than inherited.
- **Boundary shape read on the file**, not eyeballed from a diff: full stop, marker
  with no blank line ahead of it, blank, `---`, blank, `## ` heading.

The two-sided numstat is deliberately **not** cited as the load-bearing proof: on a
pure append its "deletions zero" half is a tautology, and its "additions unchanged"
half is blind to the tail mode this recipe exists to catch.

## What this run is expected to say

Both branches were green at their own heads before this union (#2047's residue was
a single red on shard 1/4, `issue1796`, sighting 15 of a registered flake that falls
on clean `main` too and whose reachability was measured at 0 hits from the branch).
That attribution assigns provenance, **not** cause: it clears the code paths, not the
load. This run is where the pair is asked the question neither PR was asked.

## Not closed here

No closing keyword is used for either issue, deliberately. The issues are closed by
hand at the merge, so that the parser cannot decide it for us.
