### PR TITLE
cic(2050): retire the far-behind record when the cursor catches up

### DIFF
--- a/cicchetto/src/__tests__/unreadBadgeFarBehindStale.test.ts
+++ b/cicchetto/src/__tests__/unreadBadgeFarBehindStale.test.ts
@@ -341,4 +341,70 @@ describe("issue 2050 — a far-behind badge the cursor has already retired", () 
     // unfreeze the far-behind apparatus exists to refuse.
     expect(selection.messagesUnread()[KEY]).toBe(5003);
   });
+
+  it("keeps the record when an in-flight loadMore page lands after the pane re-anchored", async () => {
+    await wireServer();
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    const { getReadCursor } = await import("../lib/readCursor");
+
+    // The e2e (#1062) found this and it is a RACE, so it is pinned here where
+    // the order is decided rather than raced: 3 reds in 5 runs there, 3/3
+    // green with the guard, and every red rendering the SAME pane — rows
+    // 1..22 and 212..260, a 189-row hole, with the "jump back" bar gone.
+    //
+    // `loadMore` computes its page as "older than the current head" and the
+    // page only abuts the pane while that row IS still the head. `anchorAtTail`
+    // (#693) replaces the whole window mid-flight, so the late page splices two
+    // non-adjacent regions — the silent hole `anchorAtTail` refuses to create
+    // and #1538 made an invariant of every path. The far-behind record is then
+    // read off a pane whose `rows[0]` is BELOW the cursor with the region still
+    // missing, which is exactly the false premise the bound cannot detect from
+    // the inside.
+    //
+    // Hold the older page on the wire until the re-anchor has happened.
+    let releaseOlder: (() => void) | null = null;
+    vi.mocked(api.listMessages).mockImplementation(async (_t, _s, _c, before) => {
+      if (before === undefined) return server.listMessages(undefined);
+      return new Promise((resolve) => {
+        releaseOlder = () => resolve(server.listMessages(before));
+      });
+    });
+
+    // A window that is behind but NOT far behind: the resume drains it, so the
+    // pane holds a contiguous region above the cursor and no record is armed.
+    server.tip = CAUGHT_UP_AT + 250;
+    await joinChannelTopic();
+    await scrollback.refreshScrollback(SLUG, CHANNEL);
+    expect(scrollback.farBehindByChannel()[KEY]).toBeUndefined();
+    const headBefore = scrollback.scrollbackByChannel()[KEY]?.[0]?.id;
+    expect(headBefore).toBe(CAUGHT_UP_AT + 1);
+
+    // The operator scrolls up: the request goes out against THAT head.
+    const older = scrollback.loadMore(SLUG, CHANNEL, noSeam);
+    expect(releaseOlder).not.toBeNull();
+
+    // While it is on the wire the channel floods and the next resume gives up
+    // on contiguity: the window is replaced by the tail page and armed.
+    server.tip = 6000;
+    await scrollback.refreshScrollback(SLUG, CHANNEL);
+    expect(scrollback.farBehindByChannel()[KEY]).toBeDefined();
+
+    // Now the older page lands. It describes a window the pane has left.
+    (releaseOlder as unknown as () => void)();
+    await older;
+
+    // The record stands — nothing has been recovered, and the operator still
+    // has the only affordance that leads back to the region.
+    expect(scrollback.farBehindByChannel()[KEY]).toBeDefined();
+    expect(getReadCursor(SLUG, CHANNEL)).toBe(CAUGHT_UP_AT);
+
+    // And the reason it stands: the pane was never holed. Asserted as the
+    // general invariant rather than as "the page was dropped" — a future verb
+    // that re-pages the region properly must be allowed to pass this.
+    const ids = (scrollback.scrollbackByChannel()[KEY] ?? []).map((m) => m.id);
+    expect(ids.length).toBeGreaterThan(0);
+    const gaps = ids.filter((id, i) => i > 0 && id !== (ids[i - 1] ?? 0) + 1);
+    expect(gaps).toEqual([]);
+  });
 });

--- a/cicchetto/src/__tests__/unreadBadgeFarBehindStale.test.ts
+++ b/cicchetto/src/__tests__/unreadBadgeFarBehindStale.test.ts
@@ -34,10 +34,17 @@ import { channelKey } from "../lib/channelKey";
 // moves; a server that ignored its arguments would arm and clear far-behind for
 // reasons of its own.
 //
-// Deliberately threshold-agnostic: every arm leaves the cursor at the channel
-// TIP, where every candidate invalidation rule agrees. The rule itself (which
-// bound retires the record) is a separate decision and no assertion here
-// depends on it.
+// Deliberately threshold-agnostic: every arm that moves the CURSOR leaves it at
+// the channel TIP, where every candidate invalidation rule agrees. The rule
+// itself (which bound retires the record) is a separate decision and no
+// assertion in those arms depends on it.
+//
+// The last arm moves the WINDOW instead, with the cursor standing still, and it
+// is the one place a bound is asserted at all — but on the record's own terms
+// ("the unread region is not in this pane") rather than on any arithmetic:
+// page the whole region back in and the record must be gone, page part of it
+// and the record must stand. That is the caveat the chosen bound was accepted
+// with, measured instead of argued.
 //
 // What these tests do NOT cover: the browser. This is store-level — jsdom gives
 // the pane no geometry, so the read-at-the-tail door is driven through its
@@ -73,6 +80,15 @@ const CHANNEL = "#grappa";
 const KEY = channelKey(SLUG, CHANNEL);
 const DEFAULT_PAGE = 50;
 const CAUGHT_UP_AT = 1000;
+// #1094's prepend seam is the pane's scroll-geometry compensation. A store-level
+// test has no geometry to preserve, and `loadMore` documents `undefined` as a
+// legitimate answer, so the seam opens onto nothing here. Same spelling as
+// `scrollback.test.ts` / `scrollbackIngestCost.test.ts`.
+const noSeam = (): undefined => undefined;
+// A bound on the scroll-up loop below: the fake log is 6000 rows, so 120 pages
+// covers all of it. Reaching this means paging stopped making progress — a red
+// with a stack, not a five-second hang.
+const PAGE_BUDGET = 200;
 
 const row = (id: number, sender: string): ScrollbackMessage => ({
   id,
@@ -244,5 +260,70 @@ describe("issue 2050 — a far-behind badge the cursor has already retired", () 
 
     expect(scrollback.farBehindByChannel()[KEY]).toBeDefined();
     expect(selection.messagesUnread()[KEY]).toBe(5000);
+  });
+
+  it("retires the record when scroll-up re-pages the region, and thaws without marking it read", async () => {
+    await wireServer();
+    const scrollback = await import("../lib/scrollback");
+    const selection = await import("../lib/selection");
+    const { getReadCursor } = await import("../lib/readCursor");
+    await absenceThenReconnect();
+
+    // The other axis. Every arm above moves the CURSOR up to the region; this
+    // one leaves the cursor exactly where the absence left it and moves the
+    // WINDOW down to the region instead — the operator scrolls up. `loadMore`
+    // prepends OLDER rows, so it lowers the oldest loaded id, and paging far
+    // enough back therefore satisfies the invalidation bound with nothing
+    // having been read. That is the caveat the bound was accepted with, and
+    // this arm is the measurement it was accepted WITHOUT.
+    //
+    // Three rows land live while the operator is still away from the tail —
+    // the channel does not stop talking because someone is scrolling. They
+    // are also what makes the badge's two candidate readings separable: the
+    // seed is a join-time snapshot and cannot move (5000), local truth is
+    // 5003. Safe under the #1229 ceiling: the pane holds one tail page, so the
+    // unread it HOLDS is ~50, an order of magnitude under the cap that would
+    // collapse the window.
+    for (let id = 6001; id <= 6003; id++) {
+      server.tip = id;
+      scrollback.appendToScrollback(KEY, row(id, "bob"));
+    }
+    // Still the frozen seed, and now demonstrably frozen: 5003 rows are unread
+    // and the badge says 5000.
+    expect(selection.messagesUnread()[KEY]).toBe(5000);
+
+    // One page up is not enough and must not be — the pane still starts
+    // thousands of rows above the read position, so the region is still
+    // elsewhere. Without this step the arm cannot tell "retires when the hole
+    // closes" from "retires as soon as you scroll".
+    await scrollback.loadMore(SLUG, CHANNEL, noSeam);
+    expect(scrollback.farBehindByChannel()[KEY]).toBeDefined();
+    expect(selection.messagesUnread()[KEY]).toBe(5000);
+
+    // Keep scrolling until the record lets go. The loop asserts no arithmetic
+    // — the exit is the record's own state — so it holds for any bound that
+    // honours what the record claims.
+    let pages = 1;
+    while (scrollback.farBehindByChannel()[KEY] !== undefined) {
+      expect(pages).toBeLessThan(PAGE_BUDGET);
+      await scrollback.loadMore(SLUG, CHANNEL, noSeam);
+      pages++;
+    }
+
+    // Nothing was read: the cursor sits where the absence left it, on both
+    // sides. Retiring the record THAWS — it stops the badge publishing the
+    // frozen seed and hands the count back to local truth — it does not mark
+    // anything read, and an implementation that "cleared the unread" by moving
+    // the cursor would fail here rather than in some later session.
+    expect(getReadCursor(SLUG, CHANNEL)).toBe(CAUGHT_UP_AT);
+    expect(server.cursor).toBe(CAUGHT_UP_AT);
+
+    // And local truth is the WHOLE region, not a slice of it. 5003 says two
+    // things at once: the badge is no longer the seed (5000) and no longer
+    // frozen, AND the record held until every unread row was back in the pane.
+    // A bound that fired early would leave the pane holed, local truth would
+    // be short, and the badge would UNDER-report — which is the destructive
+    // unfreeze the far-behind apparatus exists to refuse.
+    expect(selection.messagesUnread()[KEY]).toBe(5003);
   });
 });

--- a/cicchetto/src/__tests__/unreadBadgeFarBehindStale.test.ts
+++ b/cicchetto/src/__tests__/unreadBadgeFarBehindStale.test.ts
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScrollbackMessage } from "../lib/api";
+import { channelKey } from "../lib/channelKey";
+
+// issue 2050 — a badge that no in-session gesture can clear, clean again after
+// an app restart.
+//
+// The #693 far-behind record says "the unread region is NOT in this pane". Two
+// consumers act on it: `selection.ts`'s `perChannelUnread` discards local truth
+// and publishes `serverSeedCounts[key]` instead, and `setCursorIfAdvances`
+// FREEZES the read cursor. Both are right only while the cursor is still where
+// it was when the record was written.
+//
+// It does not stay there. Two doors move the cursor without passing through the
+// frozen one, and neither tells the far-behind record:
+//
+//   * `scrollback.sendMessage` — a DIRECT `setReadCursor`, deliberately not
+//     routed through `setCursorIfAdvances` (import cycle; see its comment). So
+//     it inherits neither the freeze nor any far-behind exit. Talking in the
+//     window is enough, on ONE device.
+//   * `applyReadCursorSet` — the cross-device echo, unconditional by contract.
+//     A peer device reading the channel moves this device's cursor.
+//
+// Once either fires, the cursor is at the tip and nothing is unread — but the
+// record still stands, so the badge keeps publishing the seed, which is written
+// ONLY by a per-channel join reply or a `/me` fetch and therefore cannot move
+// while the socket stays up. Hence: unclearable in-session, clean after a
+// restart (both stores are in-memory).
+//
+// These tests assert the OUTCOME — the badge, and whether the pane still offers
+// a "jump back" bar — not the sequence of calls that produces it. They run the
+// REAL scrollback + readCursor + selection stores against a fake server that
+// honours `after` / `before` / `limit` and whose cursor the POST actually
+// moves; a server that ignored its arguments would arm and clear far-behind for
+// reasons of its own.
+//
+// Deliberately threshold-agnostic: every arm leaves the cursor at the channel
+// TIP, where every candidate invalidation rule agrees. The rule itself (which
+// bound retires the record) is a separate decision and no assertion here
+// depends on it.
+//
+// What these tests do NOT cover: the browser. This is store-level — jsdom gives
+// the pane no geometry, so the read-at-the-tail door is driven through its
+// published verb rather than by scrolling, and no assertion here says the fix
+// reaches a rendered badge.
+
+vi.mock(import("../lib/api"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    listNetworks: vi.fn().mockResolvedValue([]),
+    listChannels: vi.fn().mockResolvedValue([]),
+    listMessages: vi.fn(),
+    listMessagesAfter: vi.fn(),
+    countMessagesAfter: vi.fn(),
+    sendMessage: vi.fn(),
+    me: vi.fn().mockResolvedValue({
+      kind: "user",
+      id: "u-test",
+      name: "vjt",
+      is_admin: false,
+      inserted_at: "2026-01-01T00:00:00Z",
+      read_cursors: {},
+    }),
+    login: vi.fn(),
+    logout: vi.fn(),
+    setOn401Handler: vi.fn(),
+  };
+});
+
+const SLUG = "azzurra";
+const CHANNEL = "#grappa";
+const KEY = channelKey(SLUG, CHANNEL);
+const DEFAULT_PAGE = 50;
+const CAUGHT_UP_AT = 1000;
+
+const row = (id: number, sender: string): ScrollbackMessage => ({
+  id,
+  network: SLUG,
+  channel: CHANNEL,
+  server_time: id,
+  kind: "privmsg",
+  sender,
+  body: `m${id}`,
+  meta: {},
+});
+
+/** Rows 1..tip, plus the server-side read cursor the POST moves. */
+class FakeServer {
+  constructor(
+    public tip: number,
+    public cursor: number,
+  ) {}
+
+  listMessages(before?: number): ScrollbackMessage[] {
+    const hi = before === undefined ? this.tip : Math.min(this.tip, before - 1);
+    const lo = Math.max(1, hi - DEFAULT_PAGE + 1);
+    const out: ScrollbackMessage[] = [];
+    for (let i = hi; i >= lo; i--) out.push(row(i, "bob"));
+    return out;
+  }
+
+  listMessagesAfter(after: number, limit: number): ScrollbackMessage[] {
+    const out: ScrollbackMessage[] = [];
+    for (let i = after + 1; i <= this.tip && out.length < limit; i++) out.push(row(i, "bob"));
+    return out;
+  }
+
+  countMessagesAfter(after: number): number {
+    return Math.max(0, this.tip - after);
+  }
+}
+
+let server: FakeServer;
+
+const wireServer = async (): Promise<void> => {
+  const api = await import("../lib/api");
+  vi.mocked(api.listMessages).mockImplementation(async (_t, _s, _c, before) =>
+    server.listMessages(before),
+  );
+  vi.mocked(api.listMessagesAfter).mockImplementation(async (_t, _s, _c, after, limit) =>
+    server.listMessagesAfter(after, limit ?? DEFAULT_PAGE),
+  );
+  vi.mocked(api.countMessagesAfter).mockImplementation(async (_t, _s, _c, after) =>
+    server.countMessagesAfter(after),
+  );
+  // `readCursor.setReadCursor` POSTs through raw `fetch`. Stub the transport,
+  // not the module: the optimistic local advance under test lives inside it.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockImplementation(async (_url: string, init: { body: string }) => {
+      const id = JSON.parse(init.body).message_id as number;
+      if (id > server.cursor) server.cursor = id;
+      return { ok: true, status: 200, json: async () => ({}) };
+    }),
+  );
+};
+
+/** What `subscribe.ts` does on every per-channel join, initial AND rejoin. */
+const joinChannelTopic = async (): Promise<void> => {
+  const { applyJoinReply } = await import("../lib/readCursor");
+  const { setServerSeedCount } = await import("../lib/selection");
+  applyJoinReply(SLUG, CHANNEL, server.cursor);
+  setServerSeedCount(KEY, { messages: server.countMessagesAfter(server.cursor), events: 0 });
+};
+
+/**
+ * The reported setup: a long absence has left thousands of rows behind, the
+ * socket comes back, and `refreshScrollback` drives the window into #693's
+ * far-behind state. Returns once the state is armed.
+ */
+const absenceThenReconnect = async (): Promise<void> => {
+  const { refreshScrollback, farBehindByChannel } = await import("../lib/scrollback");
+  await joinChannelTopic();
+  await refreshScrollback(SLUG, CHANNEL);
+  // The arm is the premise of every assertion below, not a claim of its own.
+  expect(farBehindByChannel()[KEY]).toBeDefined();
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  localStorage.clear();
+  vi.clearAllMocks();
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => "visible",
+  });
+  localStorage.setItem("grappa-token", "tok");
+  server = new FakeServer(6000, CAUGHT_UP_AT);
+});
+
+describe("issue 2050 — a far-behind badge the cursor has already retired", () => {
+  it("drops the badge once the operator's own send carries the cursor to the tip", async () => {
+    await wireServer();
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    const selection = await import("../lib/selection");
+    const { getReadCursor } = await import("../lib/readCursor");
+    await absenceThenReconnect();
+    expect(selection.messagesUnread()[KEY]).toBe(5000);
+
+    // The operator says something in the window. `sendMessage` advances the
+    // cursor with a direct `setReadCursor`, so the #693 freeze does not apply.
+    server.tip = 6001;
+    vi.mocked(api.sendMessage).mockResolvedValue(row(6001, "vjt"));
+    await scrollback.sendMessage(SLUG, CHANNEL, "ciao");
+
+    // Both sides agree the channel is read to the tip...
+    expect(getReadCursor(SLUG, CHANNEL)).toBe(6001);
+    expect(server.cursor).toBe(6001);
+    expect(server.countMessagesAfter(server.cursor)).toBe(0);
+    // ...so there is nothing left to badge.
+    expect(selection.messagesUnread()[KEY]).toBeUndefined();
+  });
+
+  it("drops the badge when a PEER DEVICE reads the channel to the tip", async () => {
+    await wireServer();
+    const selection = await import("../lib/selection");
+    const { applyReadCursorSet, getReadCursor } = await import("../lib/readCursor");
+    await absenceThenReconnect();
+    expect(selection.messagesUnread()[KEY]).toBe(5000);
+
+    // The laptop reads it all; the server fans `read_cursor_set` to the phone.
+    // This is the arm that makes routing the SEND through the far-behind exit
+    // insufficient on its own — no gesture happened on this device at all.
+    server.cursor = 6000;
+    applyReadCursorSet(SLUG, CHANNEL, 6000);
+
+    expect(getReadCursor(SLUG, CHANNEL)).toBe(6000);
+    expect(selection.messagesUnread()[KEY]).toBeUndefined();
+  });
+
+  it("stops offering 'jump back' once the cursor has consumed the region", async () => {
+    await wireServer();
+    const scrollback = await import("../lib/scrollback");
+    const { applyReadCursorSet } = await import("../lib/readCursor");
+    await absenceThenReconnect();
+
+    server.cursor = 6000;
+    applyReadCursorSet(SLUG, CHANNEL, 6000);
+
+    // A test that watches only the badge lets this through: the record can be
+    // hidden from the count and still stand, which leaves the pane showing a
+    // "5000 unread — jump back" bar over a fully-read window AND keeps the
+    // cursor frozen for every writer that goes through `setCursorIfAdvances`.
+    expect(scrollback.farBehindByChannel()[KEY]).toBeUndefined();
+  });
+
+  it("keeps the badge and the bar while the cursor is still behind the region", async () => {
+    await wireServer();
+    const scrollback = await import("../lib/scrollback");
+    const selection = await import("../lib/selection");
+    const { applyReadCursorSet } = await import("../lib/readCursor");
+    await absenceThenReconnect();
+
+    // A cursor that moved but is still deep inside the abandoned region. The
+    // operator is thousands behind and the affordance is the only way back:
+    // retiring the record here is the destructive move #693 exists to refuse.
+    // The id is far below every candidate invalidation bound, so this arm
+    // does not take a side in that choice.
+    server.cursor = CAUGHT_UP_AT + 1;
+    applyReadCursorSet(SLUG, CHANNEL, CAUGHT_UP_AT + 1);
+
+    expect(scrollback.farBehindByChannel()[KEY]).toBeDefined();
+    expect(selection.messagesUnread()[KEY]).toBe(5000);
+  });
+});

--- a/cicchetto/src/__tests__/unreadBadgeFarBehindStale.test.ts
+++ b/cicchetto/src/__tests__/unreadBadgeFarBehindStale.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ScrollbackMessage } from "../lib/api";
+import type { GapProbe, ScrollbackMessage } from "../lib/api";
 import { channelKey } from "../lib/channelKey";
 
 // issue 2050 — a badge that no in-session gesture can clear, clean again after
@@ -7,9 +7,16 @@ import { channelKey } from "../lib/channelKey";
 //
 // The #693 far-behind record says "the unread region is NOT in this pane". Two
 // consumers act on it: `selection.ts`'s `perChannelUnread` discards local truth
-// and publishes `serverSeedCounts[key]` instead, and `setCursorIfAdvances`
+// and publishes a frozen server-side number instead, and `setCursorIfAdvances`
 // FREEZES the read cursor. Both are right only while the cursor is still where
 // it was when the record was written.
+//
+// WHICH frozen number moved under this file while it was being written. Until
+// #2037 (landed 2026-09-10) the badge published `serverSeedCounts[key]`; it now
+// publishes the far-behind record's OWN `missed`, so the record is not merely
+// the gate on a frozen figure, it CARRIES it. Same defect, and the same cure —
+// retiring the record releases both readings — which is why nothing here had to
+// change but the wording and the fake's probe shape.
 //
 // It does not stay there. Two doors move the cursor without passing through the
 // frozen one, and neither tells the far-behind record:
@@ -22,10 +29,11 @@ import { channelKey } from "../lib/channelKey";
 //     A peer device reading the channel moves this device's cursor.
 //
 // Once either fires, the cursor is at the tip and nothing is unread — but the
-// record still stands, so the badge keeps publishing the seed, which is written
-// ONLY by a per-channel join reply or a `/me` fetch and therefore cannot move
-// while the socket stays up. Hence: unclearable in-session, clean after a
-// restart (both stores are in-memory).
+// record still stands, so the badge keeps publishing a number taken at the
+// moment of the decision, which nothing moves while the socket stays up (the
+// seed is written only by a join reply or a `/me`; `missed` only by a ring-cap
+// bite). Hence: unclearable in-session, clean after a restart (both stores are
+// in-memory).
 //
 // These tests assert the OUTCOME — the badge, and whether the pane still offers
 // a "jump back" bar — not the sequence of calls that produces it. They run the
@@ -122,8 +130,14 @@ class FakeServer {
     return out;
   }
 
-  countMessagesAfter(after: number): number {
-    return Math.max(0, this.tip - after);
+  // #2037 — the probe answers THREE numbers, not one: `gap` (raw rows, what
+  // decides far-behind) and the `messages`/`events` split (what gets rendered).
+  // Every row this log serves is a privmsg, so the split is degenerate here by
+  // construction — which is the honest fake for THIS log, not a shortcut: an
+  // events figure would have to come from rows the fake never produces.
+  countMessagesAfter(after: number): GapProbe {
+    const gap = Math.max(0, this.tip - after);
+    return { gap, messages: gap, events: 0 };
   }
 }
 
@@ -157,7 +171,8 @@ const joinChannelTopic = async (): Promise<void> => {
   const { applyJoinReply } = await import("../lib/readCursor");
   const { setServerSeedCount } = await import("../lib/selection");
   applyJoinReply(SLUG, CHANNEL, server.cursor);
-  setServerSeedCount(KEY, { messages: server.countMessagesAfter(server.cursor), events: 0 });
+  const probe = server.countMessagesAfter(server.cursor);
+  setServerSeedCount(KEY, { messages: probe.messages, events: probe.events });
 };
 
 /**
@@ -205,7 +220,7 @@ describe("issue 2050 — a far-behind badge the cursor has already retired", () 
     // Both sides agree the channel is read to the tip...
     expect(getReadCursor(SLUG, CHANNEL)).toBe(6001);
     expect(server.cursor).toBe(6001);
-    expect(server.countMessagesAfter(server.cursor)).toBe(0);
+    expect(server.countMessagesAfter(server.cursor).gap).toBe(0);
     // ...so there is nothing left to badge.
     expect(selection.messagesUnread()[KEY]).toBeUndefined();
   });

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -1287,6 +1287,18 @@ const exports = identityScopedStore((onIdentityChange) => {
     // releasing here would unlock a fetch belonging to whoever replaced us.
     if (identityMoved(t)) return;
     try {
+      // issue 2050 — the WINDOW moved under the fetch. This page was computed
+      // as "older than `oldest.id`", and it only abuts the pane while that row
+      // is still the head. `anchorAtTail` (#693) replaces the whole window
+      // mid-flight and the ring cap can evict the head, so prepending here
+      // splices two non-adjacent regions — the silent hole `anchorAtTail`
+      // refuses to create and #1538 made an invariant of every path. Same
+      // sentence `loadInitialScrollback` already applies to its own two pages:
+      // the loser drops them, they describe a window the pane has left.
+      //
+      // Before the empty-page latch on purpose: a window that moved says
+      // nothing about whether the NEW head has older rows.
+      if (scrollbackByChannel()[key]?.[0]?.id !== oldest.id) return;
       // A transient failure does NOT latch as exhausted: the operator can
       // retry by scrolling again, and the in-flight guard releases below.
       if (page === null) return;

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -973,6 +973,12 @@ const exports = identityScopedStore((onIdentityChange) => {
   // What T1 would have done is the opposite: unfreeze while the pane was
   // still holed, leaving local truth incomplete and the count under-reported.
   //
+  // That was an ARGUMENT when this shipped and is now a measurement: the last
+  // arm of `unreadBadgeFarBehindStale.test.ts` scrolls the window down to a
+  // cursor that never moves and pins the badge to local truth (5003) rather
+  // than to zero, to the frozen seed, or to a short count. A bound that
+  // retired one page into the scroll passed every other arm in that file.
+  //
   // `measuredUnreadByChannel` (#947) is deliberately NOT cleared alongside:
   // the pane spends it only while `measured.at === cursor`, so a cursor that
   // moved has already expired it.

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -1,4 +1,4 @@
-import { batch, createSignal } from "solid-js";
+import { batch, createEffect, createSignal } from "solid-js";
 import {
   sendMessage as apiSendMessage,
   countMessagesAfter,
@@ -921,6 +921,83 @@ const exports = identityScopedStore((onIdentityChange) => {
       return rest;
     });
   };
+
+  // issue 2050 — the record retires itself when the read cursor catches up.
+  //
+  // Before this, the three exits above were the whole list (`jumpToUnread`,
+  // `dismissFarBehind`, `purgeScrollback`) and NONE of them was keyed on the
+  // cursor. That is the hole: both consumers of the record — the badge memo,
+  // which discards local truth for the frozen `serverSeedCounts` value
+  // (`selection.ts` `perChannelUnread`), and `setCursorIfAdvances`, which
+  // freezes the cursor — are sound only while the cursor sits where it did
+  // when the record was written, and it does not stay there. Measured: one
+  // `sendMessage` puts the cursor at the tip with nothing unread while the
+  // badge holds 5000 across a visit, a read at the tail, a reopen and the
+  // activation refetch, clearing only on the next app restart.
+  //
+  // An EFFECT rather than a call at the doors that move it, because the doors
+  // are not a closed set. Two bypass the frozen one today — `sendMessage`'s
+  // direct `setReadCursor` (deliberately not routed through
+  // `setCursorIfAdvances`; see its comment) and `applyReadCursorSet`, the
+  // unconditional cross-device echo — and the hydration paths (`/me`, the
+  // join reply) are two more. Patching the known ones cures the instances and
+  // leaves the next one to be found in production. Watching the cursor cures
+  // the class: whatever moves it, the record is re-examined.
+  //
+  // THE BOUND is "the loaded window already reaches down to the read
+  // position", i.e. nothing is missing between the cursor and what the pane
+  // holds. That is the record's own claim — "the unread region is NOT in this
+  // pane" — stated rather than approximated. The two alternatives were
+  // measured and rejected:
+  //
+  //   * `cursor >= resumeFrom + missed` adds an ID to a per-channel row
+  //     COUNT. `messages.id` is one global autoincrement across every network
+  //     and channel (a single `messages` table), so the sum is not an id at
+  //     all: with two channels interleaved on that sequence it fires at HALF
+  //     the region, and the error scales to ~1/N with N busy channels — worst
+  //     exactly when the absence was longest. Measured retiring the record
+  //     with 2500 rows still unread, which is the destructive unfreeze #693
+  //     exists to refuse.
+  //   * `cursor >= newest loaded` is not wrong, it says less: it closes only
+  //     at the very newest row, so an operator who has scrolled INTO the
+  //     loaded window keeps a "jump back" bar over a pane with no hole left.
+  //
+  // CAVEAT, named rather than discovered later: `loadMore` prepends older
+  // rows and LOWERS the oldest loaded id, so scrolling up far enough
+  // satisfies this bound. That is correct, and the reason is that clearing
+  // here THAWS — it does not mark anything read. The badge stops publishing
+  // the frozen seed and goes back to LOCAL truth, which is still N if N rows
+  // follow the cursor; the difference is that it is now a live number the
+  // operator retires by reading. Re-paging the region back into the pane IS
+  // closing the hole, so the far-behind apparatus has nothing left to do.
+  // What T1 would have done is the opposite: unfreeze while the pane was
+  // still holed, leaving local truth incomplete and the count under-reported.
+  //
+  // `measuredUnreadByChannel` (#947) is deliberately NOT cleared alongside:
+  // the pane spends it only while `measured.at === cursor`, so a cursor that
+  // moved has already expired it.
+  createEffect(() => {
+    const far = farBehindByChannel();
+    const sb = scrollbackByChannel();
+    batch(() => {
+      for (const rawKey of Object.keys(far)) {
+        const key = rawKey as ChannelKey;
+        // No rows loaded says nothing about where the region is — keep the
+        // record. Same for an unreadable key and for a channel with no read
+        // position at all: absence of evidence, not evidence of catching up.
+        const oldestLoaded = sb[key]?.[0]?.id;
+        if (oldestLoaded === undefined) continue;
+        const decoded = decodeChannelKey(key);
+        if (decoded === null) continue;
+        const cursor = getReadCursor(decoded.slug, decoded.name);
+        if (cursor === null) continue;
+        // `oldestLoaded - 1` and not `oldestLoaded`: the boundary case is a
+        // cursor sitting exactly one row below the oldest loaded, where the
+        // first unread row IS `rows[0]` and the pane is already contiguous.
+        if (cursor >= oldestLoaded - 1) clearFarBehind(key);
+      }
+    });
+  });
 
   // #693 — the operator took the "N unread — jump back" affordance. Swap the
   // tail window for the one anchored at their read position: exactly the fetch

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51662,3 +51662,105 @@ broken. The `extended-join` echo of our OWN JOIN carries the account
 (`JOIN #capchan capacct :realname`), a third potential seeding path, left
 deliberately untouched: it is not the connection's login signal, it is a
 channel event that happens to mention it.
+<!-- entry #2050 -->
+
+---
+
+## 2026-09-10 — #2050: the far-behind record had no way to notice the cursor had caught up
+
+vjt: *"hai rotto i badge e di conseguenza il bottone alt+a, adesso ho tre badge
+su tre canali che non riesco a marcare read"*, then *"dopo un restart dell'app
+problema sparito"*, and the repro: *"l'app ha passato un periodo di tempo senza
+connessione e poi si è riconnessa"*.
+
+Alt+A was never the defect — `keybindings.ts` dispatches `nextUnread`, so the
+chord kept landing on the same three windows because their badges would not
+fall. One thing was broken, not two.
+
+### What the record promises, and where the promise lapses
+
+#693's `farBehindByChannel[key]` says "the unread region is NOT in this pane".
+Two consumers act on it: `perChannelUnread` (`selection.ts`) discards local
+truth and publishes `serverSeedCounts[key]` instead, and `setCursorIfAdvances`
+FREEZES the read cursor. Both are sound only while the cursor sits where it did
+when the record was written.
+
+It does not stay there. The record had exactly three exits — `jumpToUnread`,
+`dismissFarBehind`, `purgeScrollback` — and not one of them was keyed on the
+cursor, while at least four paths move it: `sendMessage`'s DIRECT
+`setReadCursor` (deliberately not routed through the frozen door, to avoid an
+import cycle), `applyReadCursorSet` (the unconditional cross-device echo), and
+the two hydration paths. Once any of them fires, the cursor is at the tip with
+nothing unread and the record still stands — so the badge keeps publishing a
+seed that only a per-channel join reply or a `/me` fetch can rewrite, neither of
+which happens again while the socket stays up.
+
+That is the report exactly: unclearable in session, clean after a restart,
+because both stores are in-memory. Measured against the real stores and a fake
+server whose cursor the POST actually moves: one send takes both cursors to 6001
+with zero rows unread while the badge holds 5000 across a visit, a read at the
+tail, a reopen and the activation refetch. The single-device path needs no
+second client — talking in the window is enough.
+
+### Why an effect, and why this bound
+
+An EFFECT on the cursor rather than a call at each door, because the doors are
+not a closed set: patching the two known ones cures the instances and leaves the
+next to be found in production.
+
+The bound is `cursor >= oldestLoaded - 1` — "the loaded window already reaches
+down to the read position". It states the record's own claim instead of
+approximating it. Two alternatives were measured and rejected:
+
+* `cursor >= resumeFrom + missed` adds an ID to a per-channel row COUNT.
+  `messages.id` is one global autoincrement across every network and channel (a
+  single `messages` table, `20260425000000_init.exs`), so the sum is not an id.
+  With two channels interleaved on that sequence it fires at HALF the region,
+  and the error scales to ~1/N with N busy channels — worst exactly when the
+  absence was longest. Measured retiring the record with 2500 rows still unread,
+  which is the destructive unfreeze #693 exists to refuse.
+* `cursor >= newest loaded` is not wrong, it says less: it closes only at the
+  very newest row, so an operator who has scrolled INTO the loaded window keeps
+  a "jump back" bar over a pane with no hole left. The objection raised against
+  it — that live traffic keeps raising the newest id so the record would never
+  close — was measured false: under far-behind the only doors that move the
+  cursor land ON the row that just arrived, so cursor and newest rise together.
+
+### The caveat, named rather than discovered later
+
+`loadMore` prepends older rows and LOWERS the oldest loaded id, so scrolling up
+far enough satisfies the bound. That is correct, and the reason is that clearing
+**thaws; it does not mark anything read**. The badge stops publishing the frozen
+seed and returns to LOCAL truth — still N if N rows follow the cursor, but now a
+live number the operator retires by reading. Re-paging the region back into the
+pane IS closing the hole. The destructive move would have been the opposite:
+unfreezing while the pane was still holed, leaving local truth incomplete and
+the count under-reported.
+
+`measuredUnreadByChannel` (#947) is deliberately not cleared alongside: the pane
+spends it only while `measured.at === cursor`, so a cursor that moved has
+already expired it.
+
+### Two siblings named, not folded in
+
+Measured on the way and filed separately, because each fails differently and one
+fix does not obviously cover them:
+
+* issue 2052 — `applyJoinReply` lands the reply's cursor unconditionally, so
+  after a POST that failed offline a rejoin moves the local cursor BACKWARDS to
+  the server's stale value and the badge resurrects. It self-heals on the next
+  successful forward write; the asymmetry is that forward-only holds on the
+  write path and not on the join-reply path.
+* issue 2053 — the INVERSE defect on the same branch: a window driven far behind
+  by the #1229 ring cap, whose seed is a truthful zero from join time, shows NO
+  badge while hundreds of rows are unread. There the seed is stale LOW and
+  cannot rise; retiring the record on cursor catch-up does nothing for it,
+  because the cursor is frozen and never catches up.
+
+### Scope, declared
+
+Store-level. jsdom gives the pane no geometry, so the read-at-the-tail door is
+driven through its published verb rather than by scrolling, and nothing here
+asserts the fix reaches a rendered badge in a browser.
+
+_cic only. No wire change, no protocol bump, no migration — cic bundle deploy._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51774,6 +51774,60 @@ where every candidate bound agrees; this one is about the bound by construction
 pane"), not the arithmetic, so it survives any bound that honours what the
 record says.
 
+### What the e2e found: the bound was reading a HOLED pane
+
+The first contact with a browser turned the slice red — `#1062`'s spec, which
+asserts the "jump back" bar is attached on a freshly-opened far-behind window.
+It was not a flake and it was not the threshold being greedy. Measured:
+
+| tree | runs | verdict |
+| --- | --- | --- |
+| this branch | 5 (1 cold stack, 4 warm) | **3 red**, 2 green |
+| `9c1c9ecff` with `scrollback.ts` byte-identical to the base | 4 (1 cold, 3 warm) | 4 green |
+| this branch + the guard below | 3 | 3 green |
+
+Every red rendered the SAME pane, read off the DOM in three independent
+artefacts (one Playwright trace snapshot, two `error-context.md`): rows
+`seed line #1..#22` and `#212..#260` — **71 rows with a 189-row hole** — and
+the sidebar badge at 49 rather than the frozen 240.
+
+The chain, from the trace's own request order. `refreshScrollback` fills the
+pane with the region after the cursor; the pane scrolls up and `loadMore` puts
+`?before=<head>` on the wire; `loadInitialScrollback` probes, decides the gap
+is undrainable and `anchorAtTail` REPLACES the window with the tail page and
+arms the record; and THEN the older page lands and is prepended into a window
+it no longer abuts.
+
+So the far-behind bound was not wrong about its own claim — it was reading a
+pane that lied. `rows[0]` is the bottom of the unread region ONLY while the
+window is contiguous, and a late `loadMore` had spliced rows from BELOW the
+cursor onto a tail-anchored pane. `cursor >= oldestLoaded - 1` was then TRUE
+with the whole region still missing.
+
+**Fixed at the root, not at the threshold.** `loadMore` now drops a page whose
+window moved under it — `scrollbackByChannel()[key]?.[0]?.id !== oldest.id` —
+which is the same sentence `loadInitialScrollback` already applies to its own
+two pages ("the loser drops its pages: they describe a window the pane has
+deliberately left"). Narrowing the bound instead would have papered over a
+PRE-EXISTING defect: without this cure the same race still splices the hole,
+silently, and the pane renders two non-adjacent regions as if they were
+consecutive — precisely what `anchorAtTail` says it refuses to create and what
+#1538 calls an invariant of every path. The cure did not create the hole; it
+made it visible by reading it.
+
+The guard sits BEFORE the empty-page exhausted latch on purpose: a window that
+moved says nothing about whether the NEW head has older rows. It is not
+far-behind-specific — the ring cap evicting the head produces the same stale
+page, and `purgeScrollback` and `jumpToUnread` replace the window too.
+
+The e2e is a race and races are bad evidence, so the invariant is pinned where
+the order is decided rather than raced: a sixth arm in
+`unreadBadgeFarBehindStale.test.ts` holds the older page on the wire until the
+re-anchor has happened, then releases it and asserts BOTH that the record
+stands and that the pane carries no id gap. With the guard disabled it fails on
+the record; the other five arms stay green, which is the same coverage gap the
+e2e had.
+
 ### A send retires the affordance, and that is the ruling
 
 Writing in a far-behind window clears the record, so the "N unread — jump back"

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51726,7 +51726,7 @@ approximating it. Two alternatives were measured and rejected:
   close — was measured false: under far-behind the only doors that move the
   cursor land ON the row that just arrived, so cursor and newest rise together.
 
-### The caveat, named rather than discovered later
+### The caveat, named rather than discovered later — and then measured
 
 `loadMore` prepends older rows and LOWERS the oldest loaded id, so scrolling up
 far enough satisfies the bound. That is correct, and the reason is that clearing
@@ -51736,6 +51736,51 @@ live number the operator retires by reading. Re-paging the region back into the
 pane IS closing the hole. The destructive move would have been the opposite:
 unfreezing while the pane was still holed, leaving local truth incomplete and
 the count under-reported.
+
+That paragraph shipped as an ARGUMENT, labelled as one in the code comment and
+in the PR: the bound was measured on the cursor axis only, and everything above
+about the window axis was reasoning. It is now measured too, by a fifth arm on
+the other axis — the cursor never moves, the WINDOW does, page by page up to
+the read position. Three rows land live mid-scroll, which is what makes the
+badge's two readings separable: the seed is a join-time snapshot stuck at 5000,
+local truth is 5003. So the closing number is neither zero (thaw ≡ mark read),
+nor 5000 (still frozen), nor short (a bound firing over a holed pane).
+
+Its evidence is a mutation bench, because a green arm on a shipped cure proves
+nothing on its own. Bound deleted (= `origin/main`): red at the arm's page
+budget. **Bound fires one page into the scroll: all FOUR pre-existing arms stay
+GREEN and only the new one goes red** — that gap is the arm's whole reason to
+exist, since "retires when the hole closes" and "retires as soon as you scroll"
+were indistinguishable before it. Clear-and-also-advance-the-cursor: again only
+the new arm, on the cursor assertion.
+
+The price is the file's blanket threshold-agnosticism, and the header note is
+amended rather than left to rot. Four arms park the cursor at the channel tip
+where every candidate bound agrees; this one is about the bound by construction
+— but it asserts the record's own claim ("the unread region is not in this
+pane"), not the arithmetic, so it survives any bound that honours what the
+record says.
+
+### A send retires the affordance, and that is the ruling
+
+Writing in a far-behind window clears the record, so the "N unread — jump back"
+bar disappears after your own message. That reads like a loss — the operator
+never asked to give up the way back to the region — so it is worth saying that
+it is a DECISION and not a side effect nobody looked at.
+
+vjt ruled on 2026-09-10 (relayed by the orchestrator, whose session it reached):
+writing in a far-behind window counts as having caught up; the bar going away
+after a send is wanted. So the cure is NOT narrowed — `sendMessage` gets no
+special case and the record is not held armed for it.
+
+Why it holds, beyond the ruling: the SERVER already thought so. A send takes its
+read cursor to the tip, so before this the client was publishing a "you are
+thousands behind" affordance over a channel the server considered read. The
+change removes a disagreement rather than creating one.
+
+The cross-device echo (`applyReadCursorSet`) was NOT put to him and carries no
+ruling. It needs none — the bound covers it by construction, since the cursor
+lands at the tip whoever moved it.
 
 `measuredUnreadByChannel` (#947) is deliberately not cleared alongside: the pane
 spends it only while `measured.at === cursor`, so a cursor that moved has

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51681,9 +51681,22 @@ fall. One thing was broken, not two.
 
 #693's `farBehindByChannel[key]` says "the unread region is NOT in this pane".
 Two consumers act on it: `perChannelUnread` (`selection.ts`) discards local
-truth and publishes `serverSeedCounts[key]` instead, and `setCursorIfAdvances`
-FREEZES the read cursor. Both are sound only while the cursor sits where it did
-when the record was written.
+truth and publishes a frozen server-side number instead, and
+`setCursorIfAdvances` FREEZES the read cursor. Both are sound only while the
+cursor sits where it did when the record was written.
+
+WHICH frozen number moved while this was in flight, and the note is here so the
+next reader does not think the entry describes code that no longer exists.
+Until #2037 (landed 2026-09-10, hours before this) the published figure was
+`serverSeedCounts[key]`; it is now the far-behind record's OWN `missed`, so the
+record no longer merely GATES a frozen number, it CARRIES one. That makes the
+defect sharper rather than different — and the cure identical, because retiring
+the record is what releases either reading. Re-measured on the new base with
+the bound removed: the same three reds, the third now printing
+`{ missed: 5000, events: +0, … }` where it printed `{ missed: 5000,
+resumeFrom: 1000 }`. Nothing in the tests moved but the fake's probe shape
+(#2037 turned `countMessagesAfter` into a three-field `GapProbe`) — no
+assertion was touched, which is the only reason the reds are comparable at all.
 
 It does not stay there. The record had exactly three exits — `jumpToUnread`,
 `dismissFarBehind`, `purgeScrollback` — and not one of them was keyed on the


### PR DESCRIPTION
For issue 2050 — badges that no in-session gesture clears, clean again after an app restart.

## What was wrong

#693's `farBehindByChannel[key]` says *"the unread region is NOT in this pane"*. Two consumers act on it: `perChannelUnread` (`selection.ts`) discards local truth and publishes a **frozen server-side number** instead, and `setCursorIfAdvances` **freezes** the read cursor. Both are sound only while the cursor sits where it did when the record was written.

> **Which frozen number moved under this branch.** Until #2037 (landed in the union on 2026-09-10, hours before this rebase) the published figure was `serverSeedCounts[key]`; it is now the far-behind record's own `missed`. The record no longer merely **gates** a frozen number — it **carries** one. That makes the defect sharper rather than different, and leaves the cure identical: retiring the record releases either reading. Re-measured, not assumed — see *Rebase* below.

The record had no way to learn otherwise. Its three exits — `jumpToUnread`, `dismissFarBehind`, `purgeScrollback` — are all gestures, and **not one was keyed on the cursor**, while at least four paths move it:

- `scrollback.sendMessage` → a **direct** `setReadCursor`, deliberately not routed through the frozen door (import cycle; see its comment), so it inherits neither the freeze nor any far-behind exit;
- `applyReadCursorSet` → the cross-device echo, unconditional by contract;
- the `/me` and join-reply hydration paths.

Once any fires, the cursor is at the tip with nothing unread and the record still stands — so the badge keeps publishing a figure taken at the moment of the decision, which nothing moves while the socket stays up (the seed is rewritten only by a join reply or a `/me`; `missed` only by a ring-cap bite). Unclearable in session; clean after a restart, because both stores are in-memory.

Alt+A was never a second defect: `keybindings.ts` dispatches `nextUnread`, so the chord kept landing on the same three windows because their badges would not fall.

## Measured

Real `scrollback` + `readCursor` + `selection` stores against a fake server that honours `after`/`before`/`limit` and whose cursor the POST actually moves. Single-device — no second client needed:

| step | badge | local cursor | server cursor | far-behind |
|---|---|---|---|---|
| reconnect after the absence | 5000 | 1000 | 1000 | armed |
| operator sends one message | **5000** | 6001 | 6001 | still armed |
| visit + read at the tail | **5000** | 6001 | 6001 | still armed |
| reopen (activation refetch) | **5000** | 6001 | 6001 | still armed |
| restart | 0 | — | — | gone |

## The bound, and the two that were rejected

`cursor >= oldestLoaded - 1` — "the loaded window already reaches down to the read position". It states the record's own claim rather than approximating it.

- `cursor >= resumeFrom + missed` adds an **id** to a per-channel row **count**. `messages.id` is one global autoincrement across every network and channel (a single `messages` table, `20260425000000_init.exs`), so the sum is not an id. Measured on two channels interleaved on that sequence: it fires at **half** the region, retiring the record with **2500 rows still unread** — the destructive unfreeze #693 exists to refuse. The error scales to ~1/N with N busy channels, i.e. worst exactly when the absence was longest.
- `cursor >= newest loaded` is not wrong, it says less: it closes only at the very newest row, leaving a "jump back" bar over a pane the operator has scrolled into and which has no hole left. The objection that live traffic would keep it open forever was measured false — under far-behind the only doors that move the cursor land **on** the row that just arrived, so cursor and newest rise together.

An **effect** on the cursor rather than a call at each door, because the doors are not a closed set: patching the known ones cures the instances and leaves the next to be found in production.

## The caveat, named rather than discovered later — and now MEASURED

`loadMore` prepends older rows and **lowers** the oldest loaded id, so scrolling up far enough satisfies the bound.

That is correct, and the reason is the distinction worth keeping: **clearing THAWS — it does not mark anything read.** The badge stops publishing the frozen seed and returns to LOCAL truth, which is still N if N rows follow the cursor; the difference is that it is now a live number the operator retires by reading. Re-paging the region back into the pane IS closing the hole. The destructive move would have been the opposite — unfreezing while the pane was still holed, leaving local truth incomplete and the count under-reported.

**This paragraph was an argument when the branch first said it, and it said so.** It is now a measurement — a fifth arm on the other axis: the cursor never moves, the WINDOW does, page by page up to the read position. Three rows land live mid-scroll, which is what makes the badge's two readings separable — the frozen figure is stuck at 5000 (`far.missed` post-#2037; `serverSeedCounts` before it — neither moves without a rejoin or a ring-cap bite), local truth is 5003 — so the closing number is neither zero (thaw ≡ mark read), nor 5000 (still frozen), nor short (a bound firing over a still-holed pane).

A green arm on an already-shipped cure proves nothing by itself, so its evidence is a **mutation bench** (in this worktree, reverted after each run):

| mutation | result |
|---|---|
| bound deleted (= `origin/main`) | new arm RED at its page budget (`expected 200 to be less than 200`); the three cursor arms RED with their recorded messages; negative control green |
| **bound fires one page into the scroll** (`cursor >= oldestLoaded - 4920`) | **all FOUR pre-existing arms GREEN, only the new arm RED** (`expected undefined to be defined`) |
| the clear also advances the cursor ("thaw marks read") | only the new arm RED, on the cursor assertion (`expected 6003 to be 1000`) |
| `\|\| true` — clear unconditionally | degenerate: kills every arm including this one's own premise. Recorded so it is not mistaken for an isolating result |

The second row is the arm's whole reason to exist: before it, *"retires when the hole closes"* and *"retires as soon as you scroll"* were the same green.

`measuredUnreadByChannel` (#947) is deliberately not cleared alongside: the pane spends it only while `measured.at === cursor`, so a cursor that moved has already expired it.

## The e2e caught something the store-level tests could not, and it was not the threshold

`#1062`'s spec — the "jump back" bar attached on a freshly-opened far-behind window — went red on this branch. Measured before touching anything:

| tree | runs | verdict |
|---|---|---|
| this branch | 5 (1 cold stack, 4 warm) | **3 red**, 2 green |
| base: `scrollback.ts` byte-identical to `9c1c9ecff` | 4 (1 cold, 3 warm) | **4 green** |
| this branch + the guard | 3 | **3 green** |

So the cure is the cause, and it is a **race**, not a rule. Every red rendered the SAME pane, read off the DOM in three independent artefacts (one Playwright trace snapshot, two `error-context.md`): rows `seed line #1..#22` and `#212..#260` — **71 rows with a 189-row hole** — and the sidebar badge at **49** instead of the frozen 240.

The chain, from the trace's own request order: `refreshScrollback` fills the pane with the region after the cursor → the pane scrolls up and `loadMore` puts `?before=<head>` on the wire → the resume decides the gap is undrainable and `anchorAtTail` **replaces** the window with the tail page and arms the record → and only THEN the older page lands, prepended into a window it no longer abuts.

**The bound was not greedy; it was reading a pane that lied.** `rows[0]` is the bottom of the unread region only while the window is CONTIGUOUS. So the fix is at the root: `loadMore` drops a page whose head moved under it — the same sentence `loadInitialScrollback` already applies to its own two pages. Narrowing the threshold would have papered over a **pre-existing** defect: without this branch the same race still splices the same hole, silently, rendering two non-adjacent regions as consecutive — what `anchorAtTail` says it refuses to create and #1538 calls an invariant of every path. This branch did not open the hole; it read it.

A race is bad evidence, so the invariant is pinned where the order is decided: a sixth store-level arm holds the older page on the wire until the re-anchor has happened, releases it, and asserts both that the record stands and that the pane carries **no id gap**. Guard disabled → it fails on the record, the other five stay green. **No assertion in the e2e spec was touched.**

### The second sighting is the same cure, measured

`#1765`'s spec (»N on a far-behind window) was the other red, on the pre-rebase head. Same discriminating configuration, same stack:

| tree | runs | verdict |
|---|---|---|
| cure on, guard **off** | 3 | **2 red**, 1 green — both reds on `far-behind-bar` / `Expected: attached`, the same locator as #1062 |
| cure on, guard **on** | 3 | **3 green** |

Same locator, same failure shape, same fix: one cure, not two.

### Answering the two readings that were put to me

- **Not "the spec's premise is stale w.r.t. vjt's ruling."** Shown on the fixture's bytes: `setReadCursorToId` runs BEFORE login (it is what creates the far-behind precondition), `selectChannel` is called without `ownNick` so it only clicks, and there is no send and no cursor advance anywhere between login and the assertion. The ruling is about WRITING in a far-behind window; this spec writes nothing.
- **Not "the threshold is too wide" either** — see above. Its premise was false, not its bound.

## Scope, declared and not rounded up

**Store-level, plus one e2e contact.** jsdom gives the pane no geometry, so the read-at-the-tail door is driven through its published verb rather than by scrolling. The `#1062` spec above is the only browser evidence in this slice and it covers ONE window shape; no real device, no iOS.

## Tests

`unreadBadgeFarBehindStale.test.ts`, committed **red first** and proven red on `origin/main` (branch HEAD and `origin/main` both at `8a56fff15` at the time of the run), failing for the right reason — `expected 5000 to be undefined` ×2, `expected { missed: 5000, resumeFrom: 1000 } to be undefined`:

- the **send** arm (single device) — the load-bearing case;
- the **peer-device** arm — the one that shows routing only `sendMessage` through the far-behind exit would not have been enough, since no gesture happens on this device at all;
- the **bar** arm, which watches the record and not the count: a fix that only hides the number leaves a "jump back" bar over a fully-read window and the cursor still frozen;
- the **negative control** — a cursor that moved but is still deep in the abandoned region must keep both the badge and the bar. Green before and after; without it a "cure" that simply deletes the feature would pass the other three.

Added since: the **scroll-up** arm above, the only one that moves the window instead of the cursor.

The first four are deliberately **threshold-agnostic**: each leaves the cursor at the tip, where all three candidate bounds agree, and the negative control sits far below every one of them. The fifth is about the bound by construction — that is what measuring the caveat means — but it asserts the record's own claim (*"the unread region is not in this pane"*), never the arithmetic, so it survives any bound that honours what the record says. The file header now says this instead of claiming the property for all five.

Gates on the final tree: `bun.sh run check` 5/5 ok (`CHECK_GUARD_RC=0`, lock drift included), `bun.sh run test` **345** files / **6979** tests green (`TEST_GUARD_FULL_RC=0`), `design-notes-gate.sh` ok (`DNGATE3_RC=0`). (An earlier `check` run on this branch was red on *lock drift* — a cloned `node_modules` — and that stage says the verdicts below it are not attributable, so the tree was reconciled and the gate re-run; every green reported here is post-reconcile.)

## Two siblings, named and not folded in

Measured on the way, filed separately because each fails differently:

- issue 2052 — `applyJoinReply` lands the reply's cursor unconditionally, so after a POST that failed offline a rejoin moves the local cursor **backwards** and the badge resurrects. Self-heals on the next successful forward write.
- issue 2053 — the **inverse** defect on the same branch: a window driven far behind by the #1229 ring cap, whose seed is a truthful zero from join time, shows **no badge** while hundreds of rows are unread. This change does nothing for it — there the cursor is frozen and never catches up.

## Rebase onto the union — and the re-measurement, because a clean rebase proves nothing

Rebased onto `origin/main` at `9c1c9ecff` (the union carrying #2047, i.e. issue 2037, which touches **both** files this slice touches). **Zero conflicts** — which is exactly the case where green means nothing, because what changed is the BODY the test hooks into, not the lines around it:

- `countMessagesAfter` no longer answers a number. It answers a three-field `GapProbe` (`gap` decides far-behind, `messages`/`events` get rendered). The fake server was still answering a row count, so `probe.gap` read `undefined`, far-behind never armed, and **all five arms died on the premise** rather than on anything they assert. Measured, not predicted: `POSTREBASE_ASIS_RC=1`, five × `expected undefined to be defined`.
- the frozen figure moved from the seed to `far.missed` (the box at the top).

Fixed by making the fake track the contract — its return shape, the seed wiring, one `.gap` accessor. **No assertion was touched**, which is the only reason the reds below are comparable to the ones recorded before the rebase.

**The premise is alive, measured on the new base.** With the bound removed there:

| arm | red on the new base |
|---|---|
| send | `expected 5000 to be undefined` |
| peer device | `expected 5000 to be undefined` |
| jump-back bar | `expected { missed: 5000, events: +0, … } to be undefined` (was `{ missed: 5000, resumeFrom: 1000 }` — the record's shape moved, the red did not) |
| scroll-up | `expected 200 to be less than 200` (the page budget) |
| negative control | green, as it must be |

`DESIGN_NOTES.md` went through `scripts/union-rebase.sh` (it is `merge=union`; a bare rebase can rewrite it silently at `rc=0`). Arithmetic **predicted before the rebase and matched after**: `51556 + 147 = 51703` lines, `3014216 + 8274 = 3022490` bytes; the first 51556 lines are byte-identical to main's file (`cmp` rc=0) with both boundary controls failing (51555 and 51557 → rc=1), so the comparison discriminates. The two-sided numstat is honestly half-vacuous here — this contribution is a pure tail append, so *"deletions zero"* is a tautology and only the additions side carries information. Marker `<!-- entry #2050 -->`: 1 in the file, **0** on main's tip (which now carries `#2037a/b/c`).

## The open question is closed — a ruling, not a judgement call in the slice

Whether **sending** in a far-behind window counts as "I have caught up" was left open here. It is now decided: **yes** — a ruling from vjt on 2026-09-10, relayed by the orchestrator (it arrived in her session, not on this PR). So the "N unread — jump back" bar disappearing after your own message is the WANTED behaviour, and the cure is **not** narrowed: `sendMessage` gets no special case, the record is not held armed for it, and the shape stays exactly as reviewed.

Recorded in the DESIGN_NOTES entry with the reason it holds independently of the ruling: the **server already agreed**. A send takes its read cursor to the tip, so before this the client was publishing a "you are thousands behind" affordance over a channel the server considered read — the change removes a disagreement rather than creating one.

The cross-device echo (`applyReadCursorSet`) was **not** put to him and carries no ruling; the entry says so. It needs none — the bound covers it by construction, since the cursor lands at the tip whoever moved it.


