### PR TITLE
fix(2056): seed the identity account axis from 900 RPL_LOGGEDIN

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -341,7 +341,9 @@ the operator is identified to NickServ arrives as one user-topic event:
 
 `identified` is the verdict and the ONLY thing to gate on; the server folds
 every flavour's evidence behind it (bahamut's `+r` umode, OFTC's `+R`,
-IRCv3 `account-notify`, numeric 330 RPL_WHOISLOGGEDIN). `account` is the
+IRCv3 `account-notify`, numeric 330 RPL_WHOISLOGGEDIN, and numeric 900
+RPL_LOGGEDIN — which on a SASL login is the only one of the four that
+arrives at all). `account` is the
 services account name when the ircd exposes one and `null` otherwise —
 including while `identified` is `true`, which is the normal bahamut case.
 It is display data; absence of an account is not absence of identity.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51554,3 +51554,111 @@ down as an argument rather than dressed as a measurement.
 A spec that references a remote type is digested as the reference TEXT, so a
 change inside `Grappa.Scrollback.count_split()` moves nothing unless that type
 reaches the digest by another route.
+<!-- entry #2056 -->
+
+---
+
+## 2026-09-10 — #2056: SASL logs you in on solanum, and nothing on the wire told the session
+
+`IdentityState` (#388) ORs two axes, and on solanum/Libera only one of them
+exists: there is no registered umode in `user_modes[256]`, so the services
+account IS the verdict. It was seeded in exactly two places — the IRCv3
+`ACCOUNT` relay and a self-targeted 330 RPL_WHOISLOGGEDIN — and a SASL login
+reaches neither, so a session that authenticated successfully read
+`identified: false` until the operator happened to WHOIS themselves.
+
+**The issue said that, and said it was NOT measured.** Its analysis derives
+"no self `ACCOUNT` on a SASL login" from the absence of a seeding path plus
+the pre-registration timing. That is a reading of structure: structure says a
+path EXISTS or does not, never that it is the cause. So the first step here
+was a capture, not a clause.
+
+**The capture.** A stock solanum (upstream main @ `30f74b2c`) fronted by
+Atheme 7.3.0-rc2, in an isolated compose project on its own subnet. Stock
+matters: the #349 e2e conf loads an `umode_regd` extension that emits `+r` on
+services login, and that shim would have handed the bench a registered-umode
+axis solanum does not have — the exact axis under measurement. A client ACKed
+`account-notify extended-join multi-prefix sasl chghost server-time` and
+logged in with SASL PLAIN. What arrived:
+
+```
+<< CAP w2sasl ACK :account-notify extended-join multi-prefix sasl chghost server-time
+>> AUTHENTICATE AGNhcGFjY3QAY2FwYWNjdHBhc3MxMjM=
+<< 900 w2sasl w2sasl!w2sasl@172.31.99.1 capacct :You are now logged in as capacct
+<< 903 w2sasl :SASL authentication successful
+>> CAP END
+<< 001 … 376, :w2sasl MODE w2sasl :+i
+```
+
+From socket open through 001, a ten-second tail, and a JOIN: **zero `ACCOUNT`
+lines**. The premise holds.
+
+**The zero is only worth printing because the instrument answered a known
+question first.** Two positive controls, same tool, same transcript format: a
+`NickServ LOGOUT` on the SAME socket with the SAME caps produced
+`:w2sasl!~w2sasl@… ACCOUNT *` (plus `901`), and a `NickServ IDENTIFY` on a
+second socket produced `:w2ident!~w2ident@… ACCOUNT capacct` (plus `900`). The
+harness refuses to print the negative count unless both fire — and that refusal
+earned its keep on the first run: the line classifier skipped the `:` source
+prefix but not the `@time=` tag that `server-time` puts in front of it, so every
+tagged line was classified as the tag blob. It reported "INSTRUMENT BLIND"
+rather than "0 ACCOUNT lines". The answer would have been right for the wrong
+reason.
+
+**Why no ACCOUNT, now read WITH the measurement in hand.** solanum emits the
+relay in one place, `modules/m_services.c:148` (`me_su`), and
+`sendto_common_channels_local` does deliver it to the user themselves even
+with no channels in common (`ircd/send.c`, the trailing `MyConnect(user)`
+branch) — which is why the IDENTIFY control fires. SASL takes the other door:
+`me_svslogin` (`modules/m_signon.c:122`) sends the numeric and then, on the
+`IsUnknown(target_p)` pre-registration branch, merely stashes `suser` and the
+spoof fields. No ACCOUNT to anyone; `register_local_user` propagates
+`ENCAP * LOGIN` to SERVERS only; no `account_change` hook consumer emits one.
+
+**The cure** is a `do_route/2` clause for `{:numeric, 900}` mirroring the 330
+one — `normalize_account/1`, `identity_effects/2`, `identity_secret_effects/2`
+— and nothing else. Two details the issue's sketch did not carry, both from
+the capture and the source:
+
+  * **It must NOT be gated on the leading param matching our nick.** The 330
+    clause is, correctly. But SASL completes pre-registration and solanum
+    fills that param with `*` while the client has no nick
+    (`m_signon.c:218`, `EmptyString(target_p->name) ? "*"`). The numeric is
+    `sendto_one` to this link about this link; there is no third party it
+    could describe.
+  * **It does not fold into the WHOIS card.** 330 folds because 330 is a
+    WHOIS reply; 900 describes the connection, and folding it would write an
+    account into whatever WHOIS happened to be open.
+
+The vjt ruling of 2026-08-11 is untouched: the account counts as proof only
+where `account-notify` is ACKed. On solanum it is, which is precisely why the
+seeded axis is retractable — the `ACCOUNT *` in positive control 1 is the
+retraction, captured.
+
+**A correction to the issue text.** It says "900 has no logged-out form". True
+of 900; not true of the transition — solanum emits `901 RPL_LOGGEDOUT`, and
+the capture has it. The clause stays set-only anyway: where the account counts
+at all, the cap guarantees the `ACCOUNT *`, so 901 would be a second spelling
+of a retraction already handled. Recorded so the next reader does not
+rediscover it as a gap.
+
+**Reachability, checked because the fix depends on it.** The 900 lands
+mid-registration. `IRC.Client.process_line/2` forwards every parsed line to
+the session BEFORE stepping the auth FSM, and `Session.Server`'s numeric
+clause delegates to `EventRouter` after window routing — so the clause is
+reached. The `:acquired` transition also releases the deferred autojoin
+(#347); it cannot fire early here, because that latch is armed at 001
+(`maybe_autojoin_or_defer/1`) and is a no-op while nil.
+
+**What this does NOT establish.** The bench is stock solanum plus stock
+Atheme, not Libera's deployment: Libera runs its own solanum fork and its own
+services, and nothing here was captured against Libera itself (no account
+there was in scope). What the bench does establish is that the behaviour is
+solanum's DEFAULT, in the code path Libera runs, with the positive controls to
+show the tool would have seen the counter-example. Nor is it established that
+this is the only cause of a stuck `identified: false` on an atheme network —
+the capture shows the SASL arm carries no seed, not that no other arm is also
+broken. The `extended-join` echo of our OWN JOIN carries the account
+(`JOIN #capchan capacct :realname`), a third potential seeding path, left
+deliberately untouched: it is not the connection's login signal, it is a
+channel event that happens to mention it.

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -898,6 +898,56 @@ defmodule Grappa.Session.EventRouter do
     end
   end
 
+  # issue 2056 — 900 RPL_LOGGEDIN: the SASL login's ONLY identity signal.
+  #
+  #     :server 900 <nick|*> <nick>!<user>@<host> <account> :You are now
+  #     logged in as <account>
+  #
+  # (solanum `include/messages.h:245`; the account is the third param, and
+  # solanum passes it twice — middle AND trailing — so this reads the
+  # STRUCTURED one, never the English template.)
+  #
+  # Why this clause has to exist, MEASURED against a stock solanum @
+  # 30f74b2c fronted by Atheme 7.3.0-rc2: on a SASL login the wire carries
+  # NO self `ACCOUNT`. The IRCv3 relay above is emitted only by
+  # `modules/m_services.c:148` (`me_su`, services logging in an ALREADY
+  # REGISTERED client), while SASL goes through `me_svslogin`
+  # (`modules/m_signon.c:122`), which sends this numeric and then, on the
+  # `IsUnknown(target_p)` pre-registration branch, merely stashes the
+  # account — no ACCOUNT to anyone, and no `account_change` consumer emits
+  # one either. Nothing issues a self-WHOIS at connect, so no 330 arrives
+  # to seed the axis either. On solanum there is no registered umode at
+  # all, so before this clause `identified?/1` stayed false after a
+  # SUCCESSFUL SASL login until the operator happened to WHOIS themselves.
+  # The capture that establishes this carried its own positive controls: a
+  # `NickServ LOGOUT` on the same socket produced `ACCOUNT *` and a
+  # `NickServ IDENTIFY` on another produced `ACCOUNT <acct>`.
+  #
+  # Deliberately NOT gated on the leading param matching our nick, unlike
+  # the 330 clause: SASL completes pre-registration, and solanum fills that
+  # param with `*` while the client has no nick yet (`m_signon.c:218`,
+  # `EmptyString(target_p->name) ? "*"`). The numeric is `sendto_one` to
+  # THIS link about THIS link; there is no third party it could describe.
+  #
+  # Set-only, like the 330: 900 has no logged-out form, so absence must
+  # never be read as a logout. (solanum does emit `901 RPL_LOGGEDOUT` for
+  # the reverse, and where `account-notify` is ACKed the retraction already
+  # arrives as `ACCOUNT *` — the axis this seeds is retracted by the clause
+  # above, which is exactly what makes it proof under vjt's 2026-08-11
+  # ruling.) It does NOT fold into `whois_pending`: 330 folds because 330
+  # IS a WHOIS reply, whereas this describes the connection, and folding it
+  # would write an account into whatever WHOIS happened to be open.
+  defp do_route(
+         %Message{command: {:numeric, 900}, params: [_, _, account | _]},
+         state
+       )
+       when is_binary(account) do
+    next_state = Map.put(state, :account, IdentityState.normalize_account(account))
+    effects = identity_effects(state, next_state)
+
+    {:cont, next_state, identity_secret_effects(next_state, effects) ++ effects}
+  end
+
   # MODE on a 2+-param target. The leading param is either the session's
   # OWN nick (user-MODE-on-self, Task 15) or a channel — discriminated by
   # ASCII nick-equality (#121/#525), NOT an exact-match dispatch guard, so a

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -5501,6 +5501,87 @@ defmodule Grappa.Session.EventRouterTest do
     end
   end
 
+  # issue 2056 — the SASL login's ONLY identity signal is 900 RPL_LOGGEDIN.
+  #
+  # CAPTURED, not deduced. `@sasl_900` below is a verbatim line off a stock
+  # solanum (upstream main @ 30f74b2c) fronted by Atheme 7.3.0-rc2, taken by a
+  # client that ACKed `account-notify` and logged in with SASL PLAIN. Across
+  # that whole arm — socket open, through 001, a ten-second tail, and a JOIN —
+  # the wire carried ZERO `ACCOUNT` lines. The instrument was not blind: a
+  # `NickServ LOGOUT` on the SAME socket produced `ACCOUNT *`, and a
+  # `NickServ IDENTIFY` on a second one produced `ACCOUNT capacct`. So on a
+  # SASL login there is no `ACCOUNT` to seed the account axis and no WHOIS to
+  # answer with a 330 — this numeric is the whole of it, and it carries the
+  # account name (solanum `include/messages.h:245`, emitted by
+  # `modules/m_signon.c:218` from the pre-registration SVSLOGIN path).
+  @sasl_900 "@time=2026-09-10T16:16:05.727Z :solanum.capnet.test 900 w2sasl " <>
+              "w2sasl!w2sasl@172.31.99.1 capacct :You are now logged in as capacct"
+
+  describe "issue 2056 — 900 RPL_LOGGEDIN as the SASL identity confirmation" do
+    test "the captured solanum 900 emits :acquired and records the account" do
+      state = account_notify_state(%{nick: "w2sasl", umodes: [], services_flavor: :atheme})
+      {:ok, m} = Parser.parse(@sasl_900)
+
+      {:cont, next, effects} = EventRouter.route(m, state)
+
+      assert {:session_identity_changed, :acquired} in effects
+      assert next.account == "capacct"
+    end
+
+    test "a 900 addressed to `*` still seeds — the numeric is about this link" do
+      # solanum fills the target with `*` while the client has no nick yet
+      # (`m_signon.c:218`, `EmptyString(target_p->name) ? "*"`), and SASL
+      # completes pre-registration. Gating this numeric on nick equality the
+      # way the 330 clause does would therefore drop the login on any client
+      # that finishes SASL before NICK.
+      state = account_notify_state(%{nick: "w2sasl", umodes: [], services_flavor: :atheme})
+
+      m =
+        msg(
+          {:numeric, 900},
+          ["*", "w2sasl!w2sasl@172.31.99.1", "capacct", "You are now logged in as capacct"],
+          {:server, "solanum.capnet.test"}
+        )
+
+      {:cont, next, effects} = EventRouter.route(m, state)
+
+      assert {:session_identity_changed, :acquired} in effects
+      assert next.account == "capacct"
+    end
+
+    test "without account-notify the account is recorded but is not proof" do
+      # vjt's ruling of 2026-08-11 is untouched by this: an account counts
+      # only where the ircd promised to retract it. Same posture as the self
+      # 330 — folded onto the state, not part of the verdict.
+      state = base_state(%{nick: "w2sasl", umodes: [], services_flavor: :azzurra})
+      {:ok, m} = Parser.parse(@sasl_900)
+
+      {:cont, next, effects} = EventRouter.route(m, state)
+
+      refute Enum.any?(effects, &match?({:session_identity_changed, _}, &1))
+      assert next.account == "capacct"
+    end
+
+    test "a 900 does not fold into an in-flight WHOIS card" do
+      # The 330 clause folds because 330 IS a WHOIS reply. 900 is not: it
+      # describes this connection's login, and folding it would write an
+      # account into whatever WHOIS happened to be open at the time.
+      state =
+        account_notify_state(%{
+          nick: "w2sasl",
+          umodes: [],
+          services_flavor: :atheme,
+          whois_pending: %{"w2sasl" => %WhoisAccum{target_display: "w2sasl"}}
+        })
+
+      {:ok, m} = Parser.parse(@sasl_900)
+
+      {:cont, next, _} = EventRouter.route(m, state)
+
+      assert next.whois_pending == state.whois_pending
+    end
+  end
+
   describe "#388 — 221 RPL_UMODEIS is an identity source too" do
     test "a snapshot revealing the registered umode emits :acquired" do
       # Pre-#388 ONLY the self-MODE echo emitted a transition, so a session

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -444,6 +444,58 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    test "reports registered: true from a SASL 900, before 001 (issue 2056)" do
+      # The solanum/Libera case, end to end through the real intake path:
+      # `IRC.Client` forwards every parsed line to the session BEFORE the
+      # auth FSM steps, and the numeric clause delegates to `EventRouter`
+      # after window routing — so a 900 that lands mid-registration reaches
+      # the identity axis. This is the door the operator sees (`registered:`
+      # on the rail card), and the EventRouter unit test cannot reach it: a
+      # deny-list entry or an early return anywhere between the socket and
+      # the router would leave that test green and this one red.
+      #
+      # The ORDER is the captured one (stock solanum @ 30f74b2c + Atheme
+      # 7.3.0-rc2): the CAP ACK first, then the login numeric, then the
+      # welcome. It matters — the account axis counts only where
+      # `account-notify` is ACKed (vjt's ruling, 2026-08-11), so an ACK
+      # arriving after the 900 would move the verdict with no transition to
+      # broadcast. On that ircd there is no registered umode to fall back
+      # on, and no self `ACCOUNT` arrives on a SASL login at all.
+      handler = fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply,
+           ":irc.test.org CAP grappa-test ACK :account-notify\r\n" <>
+             ":irc.test.org 900 grappa-test grappa-test!u@h capacct " <>
+             ":You are now logged in as capacct\r\n" <>
+             ":irc 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = IRCServer.start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      pid = start_session_for(user, network)
+      :ok = IRCServer.await_handshake(server, 1_000)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :session_identity_changed,
+                         identified: true,
+                         account: "capacct"
+                       }
+                     },
+                     1_000
+
+      assert {:ok, %{registered: true}} =
+               Session.connection_info({:user, user.id}, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "carries connected_at — the instant THIS link came up (#897)" do
       # #897 — the rail card's "connected <duration>" must measure the LIVE
       # link, and the only anchor that resets with the link is per-process


### PR DESCRIPTION
Addresses issue 2056.

## The capture came first, because the issue said its premise was not measured

The issue derives "solanum sends no self-`ACCOUNT` on a SASL login" from the
absence of a seeding path. That is a reading of structure, so it was measured
before a line was written. It holds.

Bench: **stock solanum** (upstream main @ `30f74b2c`, built by the repo's own
`#221` e2e image) fronted by **Atheme 7.3.0-rc2**, in an isolated compose
project on its own subnet. Stock matters — the `#349` e2e conf loads an
`umode_regd` extension that emits `+r` on services login, and that shim would
have handed the bench the exact second identity axis whose absence is the
whole reason this bug exists.

**Negative arm** — SASL PLAIN, with `account-notify` ACKed:

```
<< CAP w2sasl ACK :account-notify extended-join multi-prefix sasl chghost server-time
>> AUTHENTICATE AGNhcGFjY3QAY2FwYWNjdHBhc3MxMjM=
<< 900 w2sasl w2sasl!w2sasl@172.31.99.1 capacct :You are now logged in as capacct
<< 903 w2sasl :SASL authentication successful
>> CAP END
<< 001 … 376, :w2sasl MODE w2sasl :+i
```

Socket open → 001 → +10s tail → a JOIN: **zero `ACCOUNT` lines**, and no
registered umode (`+i` only).

**Positive controls, same instrument.** `NickServ LOGOUT` on the SAME socket
with the SAME caps → `:w2sasl!~w2sasl@… ACCOUNT *` (+ `901`). `NickServ
IDENTIFY` on a second socket → `:w2ident!~w2ident@… ACCOUNT capacct` (+ `900`).
The harness refuses to print the negative count unless both fire — and that
refusal earned its keep: on the first run the line classifier skipped the `:`
source prefix but not the `@time=` tag that `server-time` puts in front of it,
so it answered `INSTRUMENT BLIND` instead of a zero that would have been right
for the wrong reason.

## The change

One `do_route/2` clause for `{:numeric, 900}`, mirroring the 330 one
(`normalize_account/1`, `identity_effects/2`, `identity_secret_effects/2`).
Two differences from 330, both from the measurement:

* **not gated on the leading param matching our nick** — SASL completes
  pre-registration and solanum fills that param with `*` while the client has
  no nick (`m_signon.c:218`);
* **no fold into the WHOIS card** — 330 folds because 330 IS a WHOIS reply.

Set-only. The 2026-08-11 ruling is untouched: the account counts as proof only
where `account-notify` is ACKed, which on solanum it is — the `ACCOUNT *` that
retracts it is in positive control 1.

**A correction to the issue text:** it says "900 has no logged-out form". True
of the numeric; solanum does emit `901 RPL_LOGGEDOUT`, and the capture has it.
The clause stays set-only anyway, since where the account counts at all the cap
guarantees the `ACCOUNT *`. Recorded in DESIGN_NOTES so it is not rediscovered
as a gap.

## Tests, both read failing first

* `event_router_test.exs` — 4 tests, feeding the captured line verbatim through
  the real parser. On the base: `4 tests, 3 failures`. The fourth (no WHOIS
  fold) passes without the clause and is a guard against the wrong
  implementation, not a red.
* `server_test.exs` — one end-to-end test through the fake ircd in the CAPTURED
  order (CAP ACK, then the login numeric, then 001), because the unit test
  cannot see a deny-list entry or an early return between the socket and the
  router. Proven red by stashing ONLY the production clause: `1 test, 1
  failure`.

No wire-shape change (`wireTypes.ts` / `wireSchema.ts` both in sync), so no
protocol bump; cic already consumes `session_identity_changed`.

`scripts/check.sh` green end to end (credo 0, sobelow, dialyzer `Total errors:
0`, `7258 tests, 0 failures`, bats, DESIGN_NOTES gate) — run pre-rebase; the
rebase pulled in one commit touching only `.claude/skills/orchestrate/SKILL.md`.

## What this does not establish

The bench is stock solanum plus stock atheme, not Libera's own fork and
services — no Libera account was in scope. It establishes solanum's DEFAULT
behaviour in the code path Libera runs, with controls showing the tool would
have seen the counter-example. It also shows the SASL arm carries no seed, not
that no other arm is broken.