### PR TITLE
freeze the OTP app vsn so a VERSION bump can hot-reload (issue 2057)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -912,22 +912,33 @@ is due. Don't just look at todo.md.
    because `Grappa.Version`'s git facts are a compile-time snapshot: build
    first and prod reports the unreleased form `X.Y.Z-<sha>` instead of the
    bare `X.Y.Z` that #391's tag-≡-CTCP-VERSION contract promises.
-   🔴 **A `VERSION`-only bump is COLD, not HOT — measured on m42 2026-08-10,
-   correcting what #652 claimed here.** `Version.base/0` is a compile-time
-   constant baked from `VERSION` (an `@external_resource`), and `mix.exs`
-   reads the same file to stamp the OTP application vsn — so the bump moves
-   the release's lib directory to `lib/grappa-<new>/ebin`, while
-   `Grappa.HotReload.reload_modified/0` walks `:code.lib_dir(:grappa)`, which
-   the RUNNING node resolves to its BOOT directory `lib/grappa-<old>/ebin`.
-   Nothing in the old directory changed, so `/admin/reload` answers
-   `{"failed":[],"reloaded":[]}` and the node keeps serving the old number
-   with the new code on disk. Plan a restart for any release bump —
-   `Preflight` enforces it since #1287 (reason `version`), on the two
-   substrates that boot a `mix release`; docker stays HOT because its
-   bind-mounted `mix phx.server` layout puts no vsn in the lib-dir path.
-   Do NOT re-hardcode `@version` in `mix.exs`: it reads `VERSION` at build
-   time, and re-inlining a literal silently reinstates the COLD (guarded by
-   `version_single_source_test.exs`). Invoke deploy scripts by ABSOLUTE
+   🔴 **A `VERSION`-only bump is HOT on every substrate (issue 2057,
+   2026-09-10) — reversing what this file said from 2026-08-10, which was
+   true of the code as it then stood.** It WAS cold, and the reason was one
+   coupling: `mix.exs` read `VERSION` to stamp the OTP application vsn, and
+   that vsn is the only thing that puts a number into a release's code path,
+   so a bump wrote the fresh beams to `lib/grappa-<new>/ebin` while
+   `Grappa.HotReload.reload_modified/0` kept walking `:code.lib_dir(:grappa)`
+   — the RUNNING node's BOOT directory `lib/grappa-<old>/ebin`. Nothing there
+   changed, `/admin/reload` answered `{"failed":[],"reloaded":[]}`, and prod
+   served the old number under new code for ~6.5h on 2026-08-13.
+   **The app vsn is now the frozen `@otp_vsn` constant in `mix.exs`**: the lib
+   directory never moves, the beams land where the node already looks, and the
+   round trip is measured end to end on a real `mix release` with a live node
+   (bump → `/admin/reload` 200 reloading `Elixir.Grappa.Version` →
+   `/api/config` on the new number, no restart). `Preflight`'s `version`
+   class (#1287) is GONE with its cause.
+   🔴 **Two constraints survive the freeze, and both are silent when broken.**
+   (1) Do NOT re-hardcode `@version` in `mix.exs` — it must keep reading
+   `VERSION` at build time; re-inlining a literal makes the bump edit
+   `mix.exs`, which is COLD via `mix_deps?`. (2) Do NOT give the release a
+   `version:` of its own under `releases:` — it MUST inherit the frozen app
+   vsn, because `HotReload.audit_code_path/1` compares the booted app vsn
+   against the release vsn in `start_erl.data`, and a frozen one beside a
+   tracking one diverges forever: measured as a permanent
+   `409 {"booted":"0.0.0","built":"1.5.6"}`, the cure inverted into a total
+   silent refusal of every hot deploy. Both are pinned by
+   `version_single_source_test.exs`. Invoke deploy scripts by ABSOLUTE
    path (`/srv/grappa/scripts/…`) — cwd drift runs another
    checkout's copy. `scripts/deploy.sh` (Docker) drives the LOCAL
    dev stack only; nothing production runs on the pi.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51876,3 +51876,103 @@ driven through its published verb rather than by scrolling, and nothing here
 asserts the fix reaches a rendered badge in a browser.
 
 _cic only. No wire change, no protocol bump, no migration — cic bundle deploy._
+<!-- entry #2057 -->
+
+---
+
+## 2026-09-10 — issue 2057: the OTP app vsn was never a version, it was a path
+
+A `VERSION`-only bump was COLD on `:jail` and `:linux`, and #1287 had already
+established WHY: the bump moves the release's lib directory to
+`lib/grappa-<new>/ebin` while the running node keeps resolving
+`:code.lib_dir(:grappa)` to its BOOT directory, so `reload_modified/0` diffs a
+stale tree against itself and answers `{"failed":[],"reloaded":[]}`. Production
+served the old BEAM under new git history for ~6.5 hours on 2026-08-13 that way.
+
+What had never been named is that this is not a property of deploying, or of
+releases, or of the version number. It is one line of `mix.exs`. The repo-root
+`VERSION` was read to stamp the **OTP application vsn**, and the app vsn is the
+only thing that puts a number into a release's code path. Freeze it and the
+class disappears: `@otp_vsn "0.0.0"`, a constant that never moves, with
+`@version` left deriving from `VERSION` exactly as #652 built it.
+
+### The bench, three arms, one live node
+
+Measured on a real `mix release` (not the docker dev stack, whose bind-mounted
+`mix phx.server` layout has no vsn in the lib path and would have passed for
+the wrong reason), in an isolated tree, booting the release and asking the
+**live** node rather than reading the disk:
+
+| arm | live `:code.lib_dir(:grappa)` | `start_erl.data` after bump | `POST /admin/reload` | `/api/config` after |
+|---|---|---|---|---|
+| app vsn tracks `VERSION` (before) | `lib/grappa-1.5.5` | `1.5.6` | **409** `stale_code_path` | **1.5.5** — stuck |
+| app vsn frozen, release vsn inherits | `lib/grappa-0.0.0` | `0.0.0` | **200** `reloaded:["Elixir.Grappa.Version"]` | **1.5.6** |
+| app vsn frozen, release vsn tracks | `lib/grappa-0.0.0` | `1.5.6` | **409** `booted 0.0.0 / built 1.5.6` | **1.5.5** — stuck |
+
+The first arm is the negative control and it reproduced the production 409
+exactly, so the bench can see the defect it claims to cure. A side effect worth
+recording: under the freeze the second `mix release --overwrite` left **one**
+lib directory, where the tracking arm accumulated `grappa-1.5.5` beside
+`grappa-1.5.6`. Stale sibling directories stop piling up forever.
+
+### The third arm is the whole reason this entry is long
+
+Freezing the app vsn while letting the release keep `version: @version` is the
+obvious half-measure — it preserves an honest number in the tarball name — and
+it is **catastrophic and silent**. `HotReload.audit_code_path/1` compares the
+app vsn it reads off the booted code path against the RELEASE vsn in
+`start_erl.data`. Frozen beside tracking, those two diverge on every bump and
+never reconverge, so the audit refuses **every hot deploy, permanently**. The
+cure becomes its own exact opposite and says nothing while doing it.
+
+So the constraint is: the release vsn MUST inherit the freeze, i.e. the release
+must have no `version:` key of its own. That is not enforceable by reading the
+value — an inheriting release and a re-coupled one both produce a plausible
+number — so the pin asserts the KEY IS ABSENT
+(`version_single_source_test.exs`). This was predicted from the source and then
+measured rather than shipped as a reasoned-about hazard.
+
+### What was in the way, and it was a false zero
+
+The proposal rested on "`Application.spec(:grappa, :vsn)` has zero consumers;
+the only matches are prose". Re-measured, that is false in the way this repo
+fails most often: the census had stopped at `lib/`.
+`test/grappa/version_single_source_test.exs:67` asserted
+`Application.spec(:grappa, :vsn) == @canonical_version` — not a stale test but
+the #538/#652 PIN on the exact coupling being removed, with its rationale in
+the comment above it: *"If they disagree the running node's .app would report a
+version the source never declared."*
+
+That is now true and deliberate, which is a thing a worker does not get to
+decide. vjt ruled it (**relayed via the ircbot, not observed first-hand**): the
+number in the source stays one — the `VERSION` file — and the second place is
+the app vsn, which is a path component and not a carrier. The pin is
+**rewritten as the pin of the DECOUPLING, not deleted**, because an accidental
+re-coupling is silent and the inverted assertion is what catches it. Both
+mutants were run and each kills exactly one assertion.
+
+Two `Application.spec(:grappa, …)` readers do remain — `:modules`, a different
+key — which also falsifies `Grappa.Version`'s own moduledoc claim to be the
+only consumer. Corrected in place.
+
+### What deliberately did NOT change
+
+`stale_code_path` (#1850) stays. It is fair to observe that with both vsns
+frozen it can no longer fire for the class it was written against, and that is
+the correct outcome rather than an argument to delete it: prevention moved to
+the ROOT, detection did not move at all. It never named `VERSION` — it compares
+what the node booted against what the build wrote, whatever drove them apart,
+and the third arm above is a live example of a route that has nothing to do
+with a bump.
+
+Also not taken: vjt floated running the jail the way docker runs, `mix
+phx.server` over a bind-mount, hot by construction. The price is the whole
+release — no `bin/grappa`, so no `rpc`, no boot script, no operator CLI — and
+he did not pursue it. The decision here is to freeze a constant, not to change
+substrate.
+
+The price paid, in full: paths and the release tarball on the box read `0.0.0`.
+Nothing consumes them — measured across `infra/`, `scripts/`, `.github/` and
+`Dockerfile*`, every one of which names the unversioned
+`_build/prod/rel/grappa`. The number an operator reads is `Grappa.Version`,
+still baked from `VERSION`, still declared exactly once.

--- a/lib/grappa/deploy/preflight.ex
+++ b/lib/grappa/deploy/preflight.ex
@@ -40,10 +40,9 @@ defmodule Grappa.Deploy.Preflight do
   `infra/linux/nginx.conf` plus the shared `infra/snippets/*` proxy
   surface — is HOT on `:jail`, which since the jail-nginx removal
   runs no proxy of its own at all (#923 scoping, widened). The repo-root
-  `VERSION` file spans TWO substrates rather than one: it is COLD on
-  `:jail` and `:linux`, which boot a `mix release` whose lib directory
-  carries the vsn in its path, and HOT on `:docker`, which does not —
-  see `version?/1`. The 2026-06-10 metadata-strip
+  `VERSION` file is HOT on every substrate since issue 2057 froze the
+  OTP application vsn — the release lib directory no longer carries the
+  number, so a bump has nowhere to hide. The 2026-06-10 metadata-strip
   deploy cold-restarted prod (ALL IRC sessions dropped) for a
   Dockerfile diff the jail never reads — on an always-on bouncer
   every needless restart is incident-grade, so the substrate is an
@@ -77,7 +76,6 @@ defmodule Grappa.Deploy.Preflight do
           | {:migration, [String.t()]}
           | {:nginx, [String.t()]}
           | {:config, [String.t()]}
-          | {:version, [String.t()]}
           | {:state_shape, [String.t()]}
 
   @type verdict :: {:hot, []} | {:cold, [reason()]}
@@ -93,10 +91,6 @@ defmodule Grappa.Deploy.Preflight do
   @type migration_class :: :hot | :cold
 
   @substrates [:docker, :jail, :linux]
-  # The substrates that boot from a `mix release` artifact, whose lib
-  # directory carries the OTP application vsn in its PATH. Docker is
-  # absent by construction, not by omission — see `version?/1`.
-  @release_substrates [:jail, :linux]
   # CLI-boundary mirror of @substrates — derived, not hand-kept, so a
   # third substrate can't be accepted by classify_paths/2 yet rejected
   # at the cli/1 guard (or vice versa).
@@ -142,7 +136,6 @@ defmodule Grappa.Deploy.Preflight do
       |> add_reason(:migration, contract_migrations(paths, migration_source_fn))
       |> add_reason(:nginx, filter_on([:linux], substrate, paths, &nginx?/1))
       |> add_reason(:config, Enum.filter(paths, &config?/1))
-      |> add_reason(:version, filter_on(@release_substrates, substrate, paths, &version?/1))
       |> Enum.reverse()
 
     case reasons do
@@ -685,40 +678,30 @@ defmodule Grappa.Deploy.Preflight do
     String.starts_with?(path, "config/") and String.ends_with?(path, ".exs")
   end
 
-  # Class 8 (#1287): the repo-root VERSION file — the SSOT for the OTP
-  # application vsn, which `mix.exs` reads at build time. COLD on the
-  # substrates that boot a `mix release`, and ONLY those.
+  # Class 8 (#1287) is GONE, and this comment is its headstone (issue 2057).
   #
-  # The bump does not merely change a string: it moves every artifact to
-  # `lib/grappa-<new>/ebin`, while the running node keeps resolving
-  # `:code.lib_dir(:grappa)` — the directory `HotReload.reload_modified/0`
-  # walks, and the root `Ecto.Migrator` reaches through
-  # `Application.app_dir/1,2` — to the BOOT directory `lib/grappa-<old>/ebin`.
-  # The new artifacts land in a SIBLING the node never looks at, so the
-  # reload diffs the stale tree against itself and answers
-  # `{"failed":[],"reloaded":[],"migrated":[]}`. That is indistinguishable
-  # from "nothing to do": the miss cannot be reported, only prevented here.
-  # Repro'd in production 2026-08-13 on a self-hosted `:linux` install
-  # deploying v1.0.0 → v1.1.0 — ~6.5 hours serving the old BEAM under the
-  # new git history. Before #652 the number lived in `mix.exs` and
-  # `mix_deps?/1` caught the bump by accident; moving it to VERSION removed
-  # the accident without replacing the rule.
+  # The repo-root VERSION file was COLD on `:jail` and `:linux` because the
+  # bump moved every artifact to `lib/grappa-<new>/ebin` while the running node
+  # kept resolving `:code.lib_dir(:grappa)` to its BOOT directory — so the
+  # reload diffed a stale tree against itself and answered
+  # `{"failed":[],"reloaded":[],"migrated":[]}`, indistinguishable from
+  # "nothing to do". Repro'd in production 2026-08-13 on a `:linux` install:
+  # ~6.5 hours serving the old BEAM under the new git history.
   #
-  # Docker is excluded by MEASUREMENT, not by omission: the container execs
-  # `mix phx.server` over a bind-mounted tree (`bin/start.sh:76`), where
-  # `:code.lib_dir(:grappa)` is `/app/_build/<env>/lib/grappa` — no vsn in
-  # the path, so the fresh beams land where the node is already looking.
-  # The two release substrates say the opposite in their own words:
-  # `infra/freebsd/deploy.sh:116` names `lib/grappa-X.Y/ebin` as the
-  # daemon's code path. COLDing docker for a file its boot layout is immune
-  # to would be the needless-restart class the substrate argument exists to
-  # prevent (moduledoc: 2026-06-10, #923) — on an always-on bouncer every
-  # restart drops every IRC session.
+  # That class no longer exists because its CAUSE no longer exists. The OTP
+  # application vsn is now the frozen `@otp_vsn` constant in `mix.exs`, not the
+  # VERSION file, so the lib directory never moves and the fresh beams land
+  # where the node is already looking — measured end to end on a real
+  # `mix release` with a live node: bump, `POST /admin/reload` 200 reloading
+  # `Elixir.Grappa.Version`, `/api/config` on the new number, no restart.
   #
-  # Exact repo-root match: a sibling `VERSION` elsewhere in the tree (e.g.
-  # `cicchetto/VERSION`) is a different file with no bearing on the OTP vsn.
-  defp version?("VERSION"), do: true
-  defp version?(_), do: false
+  # Do NOT reinstate a VERSION rule here without first re-measuring `mix.exs`:
+  # a COLD class for a file whose boot layout is immune to it is exactly the
+  # needless-restart failure the substrate argument exists to prevent
+  # (moduledoc: 2026-06-10, #923), and on an always-on bouncer every restart
+  # drops every IRC session. `Grappa.HotReload.audit_code_path/1` remains the
+  # DETECTION for a lib directory going stale by any other route; prevention
+  # moved to the root, detection did not move at all.
 
   # Walk the AST collecting nodes that match any of:
   #   * `@type t :: %{...}`     — bare-map state typespec

--- a/lib/grappa/hot_reload.ex
+++ b/lib/grappa/hot_reload.ex
@@ -237,17 +237,29 @@ defmodule Grappa.HotReload do
 
   On the two `mix release` substrates the code path is
   `lib/grappa-<vsn>/ebin`, and `:code.lib_dir/1` resolves it to the **boot**
-  directory forever. A `VERSION`-only bump moves the build's output to
-  `lib/grappa-<new>/ebin`, so `reload_modified/0` walks the stale tree,
-  diffs it against itself and answers `%{reloaded: [], failed: []}` — a
-  shape indistinguishable from "nothing to do". `Grappa.Deploy.Preflight`
-  PREVENTS that by classifying a `VERSION` diff COLD, but prevention is
-  not detection: `--force-hot` skips preflight entirely, and a diff range
-  that misses the bump has nothing to classify. Production served the old
-  BEAM under the new git history for ~6.5 hours on 2026-08-13 that way,
-  and the deploy printed success. Same posture as
-  `migrate_and_reload/2`'s pending-migration gate: the last line of
-  defence belongs HERE, where the code path is actually observable.
+  directory forever. If the build writes its beams under a DIFFERENT vsn,
+  `reload_modified/0` walks the stale tree, diffs it against itself and
+  answers `%{reloaded: [], failed: []}` — a shape indistinguishable from
+  "nothing to do". Production served the old BEAM under the new git history
+  for ~6.5 hours on 2026-08-13 that way, and the deploy printed success.
+
+  The specific mover then was the `VERSION` file, because the OTP
+  application vsn tracked it. That is over: issue 2057 froze the app vsn to
+  a constant, so a bump no longer moves the directory and
+  `Grappa.Deploy.Preflight` no longer has a `VERSION` class at all.
+
+  **This audit stays, and is not now dead code.** It never named `VERSION`;
+  it compares what the node BOOTED against what the build WROTE, whatever
+  moved them apart — an operator or packager overriding the release vsn,
+  a release assembled into a root the node did not boot from, a
+  hand-edited `mix.exs`. Prevention moved to the root; detection is a
+  different job and belongs HERE, where the code path is actually
+  observable, exactly like `migrate_and_reload/2`'s pending-migration gate.
+  Note the standing constraint the freeze creates: the release vsn must
+  keep INHERITING the frozen app vsn, since giving the release a `version:`
+  of its own makes these two values diverge permanently and turns this
+  audit into a refusal of every hot deploy. `mix.exs` says so at the
+  constant, and `version_single_source_test.exs` pins it.
 
   ## Why the release metadata, and not the sibling directories
 

--- a/lib/grappa/version.ex
+++ b/lib/grappa/version.ex
@@ -16,13 +16,11 @@ defmodule Grappa.Version do
   mix release --overwrite → POST /admin/reload`; `/admin/reload`
   (`Grappa.HotReload.reload_modified/0`) reloads only the `.beam` files
   whose on-disk md5 changed — it never re-reads `.app`. So after a
-  **hot-deployed** version bump, `Application.spec/2` would keep reporting
-  the boot-time value while the operator expects the new one. Sourcing
-  `base/0` from a compiled constant instead keeps the number inside the
-  artifact, with no runtime filesystem access and no way to drift from the
-  string `mix.exs` stamps (#652). What it does NOT buy is the payoff #652
-  claimed — the new number arriving on a hot reload — because a `VERSION`
-  bump is itself a cold deploy; see "The declared price" below.
+  hot-deployed version bump, `Application.spec/2` would keep reporting the
+  boot-time value while the operator expects the new one. Sourcing `base/0`
+  from a compiled constant instead keeps the number inside the artifact,
+  with no runtime filesystem access and no way to drift from the string
+  `mix.exs` stamps (#652).
   This is also NOT the #391 defect: that was a **runtime** read of
   a **build** file (`mix.exs`), which a package lacks — it *raised* and
   crashed the `CTCP VERSION` reply. Here the read is at compile time,
@@ -30,30 +28,38 @@ defmodule Grappa.Version do
   release tarball), and the artifact carries a plain string — no runtime
   filesystem access, so no fallback to design and no packaging failure.
 
-  ## The declared price (#652), and what it turned out to be
+  ## The payoff #652 claimed, delayed a year (issue 2057)
 
-  #652 declared the price as a divergence: after a **hot** bump the running
-  node's `.app` vsn would stay at its boot value while `base/0` reported the
-  new number, reconverging at the next cold restart. `Grappa.Version` is the
-  ONLY `Application.spec(:grappa, …)` consumer in the tree, so nothing else
-  would observe it.
+  #652 expected a `VERSION` bump to arrive on a HOT deploy: the file is an
+  `@external_resource`, so a bump dirties this module, `mix compile`
+  rebuilds `version.beam`, and `reload_modified/0` swaps it in by md5.
+  Every step of that was true, and the result still did not happen.
 
-  Measured on m42 on 2026-08-10, the real price is a different one: that
-  divergence never opens, because **a bump that changes only `VERSION` is a
-  COLD deploy**, not the HOT one #652 expected. `mix.exs` reads the same file
-  to stamp the OTP application vsn, so under `mix release` the bump moves the
-  artifact to `lib/grappa-<new>/ebin` while the running node still resolves
-  `:code.lib_dir(:grappa)` — the directory `Grappa.HotReload.reload_modified/0`
-  walks — to its boot directory `lib/grappa-<old>/ebin`. Nothing in there
-  changed, so `/admin/reload` answers `{"failed":[],"reloaded":[]}`: neither
-  the `.app` vsn NOR `base/0` moves, and the node serves the old number with
-  the new code already on disk until it is restarted. (In a source checkout
-  `:code.lib_dir/1` is the unversioned `_build/<env>/lib/grappa`, which is why
-  development never showed this.)
+  What defeated it, measured on m42 on 2026-08-10, was a coupling one file
+  away: `mix.exs` read the same `VERSION` to stamp the **OTP application
+  vsn**, and that vsn is what puts a number into a release's code path.
+  So the rebuilt beam landed in `lib/grappa-<new>/ebin` while the running
+  node still resolved `:code.lib_dir(:grappa)` — the directory
+  `reload_modified/0` walks — to its boot directory `lib/grappa-<old>/ebin`.
+  Nothing in there changed, `/admin/reload` answered
+  `{"failed":[],"reloaded":[]}`, and the node served the old number with the
+  new code already on disk. (In a source checkout `:code.lib_dir/1` is the
+  unversioned `_build/<env>/lib/grappa`, which is why development never
+  showed this.)
 
-  `Grappa.Deploy.Preflight` still classifies such a bump HOT. That
-  misclassification is a behaviour defect with an issue of its own; what is
-  corrected here is only the claim this moduledoc made about it.
+  Issue 2057 cut that coupling: the OTP application vsn is now a frozen
+  constant in `mix.exs` (`@otp_vsn`), unrelated to `VERSION`. The code path
+  stops moving, the fresh beam lands where the node is already looking, and
+  the bump hot-reloads — measured end to end on a real `mix release` with a
+  live node. `Grappa.Deploy.Preflight` classifies such a bump HOT
+  accordingly, and that is now correct rather than a misclassification.
+
+  The `.app` vsn and `base/0` are therefore expected to DISAGREE, on every
+  substrate and permanently — the `.app` carries the frozen path component,
+  `base/0` carries the release number. Nothing reads the `.app` vsn but the
+  pin that asserts the split (`version_single_source_test.exs`); the two
+  other `Application.spec(:grappa, …)` readers in the tree ask for
+  `:modules`, a different key.
 
   ## Suffix — git tag ≡ CTCP VERSION (#391)
 
@@ -109,11 +115,11 @@ defmodule Grappa.Version do
   # #652 — the base version is the repo-root `VERSION` file, read at COMPILE
   # time and baked into a module attribute. Registered as an
   # `@external_resource` so a bump dirties this module and `mix compile` on the
-  # deploy path recompiles it. That much still holds; what #652 claimed next —
-  # that `reload_modified/0` then picks the new beam up by md5 and the reported
-  # version updates WITHOUT a cold restart — does not, because in a release the
-  # recompiled beam lands under `lib/grappa-<new>/ebin` and the running node
-  # never looks there (moduledoc, "The declared price"). The read is
+  # deploy path recompiles it; `reload_modified/0` then picks the new beam up
+  # by md5 and the reported version updates WITHOUT a cold restart. That last
+  # step only started working with issue 2057, which froze the OTP application
+  # vsn so the recompiled beam stops landing in a lib directory the running
+  # node never reads (moduledoc, "The payoff #652 claimed"). The read is
   # compile-time, inside the build tree where `VERSION` always exists, so —
   # unlike the #391 runtime `mix.exs` read — a package build cannot raise.
   @version_path Path.join(@repo_root, "VERSION")
@@ -147,10 +153,11 @@ defmodule Grappa.Version do
   @doc """
   The canonical base version — the repo-root `VERSION` file, read at compile
   time and baked into `@base_version` (#652). NOT `Application.spec(:grappa,
-  :vsn)`: the `.app` resource is read once at boot and never re-read, and the
-  constant needs no runtime filesystem access while being the same string
-  `mix.exs` stamps. It does not, however, make a bump land on a hot deploy —
-  a `VERSION`-only bump is COLD (moduledoc, "The declared price").
+  :vsn)`, which is a frozen path component since issue 2057 and no longer
+  a version at all; the `.app` resource is also read once at boot and never
+  re-read, while this constant needs no runtime filesystem access. Since
+  issue 2057 a `VERSION`-only bump lands on a HOT deploy and this value moves
+  with it (moduledoc, "The payoff #652 claimed").
   """
   @spec base() :: String.t()
   def base, do: @base_version

--- a/lib/grappa_web/controllers/admin_controller.ex
+++ b/lib/grappa_web/controllers/admin_controller.ex
@@ -27,10 +27,13 @@ defmodule GrappaWeb.AdminController do
       directory this node does not read (#1850); nothing ran. A cold
       deploy is the fix, as with the contract arm. This one is checked
       BEFORE the migration audit, and it is a DETECTION rather than a
-      prevention: `Grappa.Deploy.Preflight` already classifies a `VERSION`
-      diff COLD, but `--force-hot` skips preflight and a reload that walks
-      the stale tree answers `{"reloaded":[],"failed":[]}` — the silence
-      that served old code for ~6.5h on 2026-08-13.
+      prevention: a reload that walks the stale tree answers
+      `{"reloaded":[],"failed":[]}` — the silence that served old code for
+      ~6.5h on 2026-08-13. The mover THEN was a `VERSION` bump, which
+      `Grappa.Deploy.Preflight` classified COLD; since issue 2057 froze the
+      OTP app vsn a bump no longer moves the lib directory and that class is
+      gone, so what remains here is the general case the audit always
+      covered — any other way the built and booted vsns come apart.
     * a raising migration is NOT rescued: it 5xxes, the transaction
       rolls back, and no module is reloaded.
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,26 +8,49 @@ defmodule Grappa.MixProject do
   # the SAME file into a module attribute, so the number an operator reads can
   # never drift from the one stamped into the package metadata.
   #
-  # A `VERSION`-only bump is nonetheless a COLD deploy — measured on m42
-  # 2026-08-10, correcting what #652 claimed here. Its reasoning was sound in
-  # the abstract (a bump no longer edits `mix.exs`, so `Grappa.Deploy.Preflight`
-  # stops classifying it COLD through `mix_deps?`), but it is defeated by the
-  # coupling the line below introduces: that read stamps the OTP application
-  # vsn, so under `mix release` — how production ships — the bump moves the
-  # artifact to `lib/grappa-<new>/ebin`, while the RUNNING node keeps resolving
-  # `:code.lib_dir(:grappa)` to its boot directory `lib/grappa-<old>/ebin`.
-  # That is the directory `Grappa.HotReload.reload_modified/0` walks; nothing in
-  # it changed, so `/admin/reload` answers `{"failed":[],"reloaded":[]}` and the
-  # node serves the old number with the new code already on disk. Plan a restart
-  # for any release bump. Preflight still calls such a bump HOT — that
-  # misclassification is a behaviour defect and belongs to an issue of its own,
-  # not to a comment.
+  # #652's payoff — a bump that hot-reloads — was defeated for a year by ONE
+  # coupling: this same string used to be passed as the project's `version:`,
+  # i.e. the OTP application vsn, which is the ONLY thing that puts a number
+  # into a release's code path (`lib/grappa-<vsn>/ebin`). Issue 2057 cut that
+  # coupling; see `@otp_vsn` below. `@version` stays the honest number and is
+  # still read from `VERSION` at BUILD time.
   @version File.read!(Path.join(__DIR__, "VERSION")) |> String.trim()
+
+  # The OTP application vsn — FROZEN, and deliberately NOT `@version`
+  # (issue 2057). It is not a version carrier; it is a path component, and the
+  # only consumer that cares is the code path a running node resolves.
+  #
+  # MEASURED on a real `mix release` with a live node, three arms, one bench:
+  #
+  #   * tracking `VERSION` (what this used to do): bumping 1.5.5 → 1.5.6 wrote
+  #     the fresh beams to `lib/grappa-1.5.6/ebin` while the live node kept
+  #     resolving `:code.lib_dir(:grappa)` to `lib/grappa-1.5.5` — its BOOT
+  #     directory. `POST /admin/reload` answered `409 stale_code_path`
+  #     (`booted 1.5.5`, `built 1.5.6`) and `/api/config` stayed on 1.5.5.
+  #   * frozen (this): one lib dir, ever. The same bump reloaded
+  #     `Elixir.Grappa.Version` and `/api/config` reported 1.5.6 with no
+  #     restart — and no stale sibling directory accumulated on disk.
+  #
+  # 🔴 THE RELEASE VSN MUST INHERIT THIS FREEZE. Do NOT give the release a
+  # `version:` of its own below: `Grappa.HotReload.audit_code_path/1` compares
+  # the app vsn in the booted code path against the RELEASE vsn in
+  # `releases/start_erl.data`, so a frozen app vsn beside a tracking release
+  # vsn makes those two diverge FOREVER — measured as a permanent
+  # `409 {"booted":"0.0.0","built":"1.5.6"}`, i.e. this cure inverted into a
+  # total silent refusal of every hot deploy. Pinned by
+  # `test/grappa/version_single_source_test.exs`.
+  #
+  # The price, and it is only cosmetic: paths and the release tarball on the
+  # box carry this constant instead of the real number. The number an operator
+  # reads — `/api/config`, `CTCP VERSION`, the `.deb`/AUR metadata — is
+  # `Grappa.Version`, which is still baked from `VERSION`.
+  @otp_vsn "0.0.0"
 
   def project do
     [
       app: @app,
-      version: @version,
+      # The FROZEN vsn, not @version — see @otp_vsn (issue 2057).
+      version: @otp_vsn,
       elixir: "~> 1.19",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:boundary] ++ Mix.compilers(),
@@ -204,13 +227,16 @@ defmodule Grappa.MixProject do
 
       {:skip, :no_git} ->
         # Log-honesty: a fast path states what it OBSERVED, never a silent no-op.
-        # Report the bare version from `release.version` (the %Mix.Release{}
-        # field) — NOT `Grappa.Version.base/0`, which returns "" unless `:grappa`
-        # is loaded into the mix VM, and would emit an empty version on this very
+        # Report `@version` — the VERSION-file string, which is precisely what
+        # `Grappa.Version.current/0` returns for a no-git build. NOT
+        # `release.version`: since issue 2057 that is the frozen `@otp_vsn` and
+        # would print `0.0.0`, a number no artifact ever reports. And not
+        # `Grappa.Version.base/0`, which returns "" unless `:grappa` is loaded
+        # into the mix VM and would emit an empty version on this very
         # honesty-logging path (the AUR-tarball substrate exercises it).
         Mix.shell().info(
           "version guard (#542): no .git at build — artifact reports the bare " <>
-            "#{release.version} (package/tarball); no HEAD to verify against"
+            "#{@version} (package/tarball); no HEAD to verify against"
         )
 
         release

--- a/test/grappa/deploy/preflight_test.exs
+++ b/test/grappa/deploy/preflight_test.exs
@@ -275,41 +275,45 @@ defmodule Grappa.Deploy.PreflightTest do
     end
   end
 
-  describe "classify_paths/2 — Class 8: VERSION (COLD on the release substrates)" do
-    # #1287, repro'd in production 2026-08-13 on a v1.0.0 → v1.1.0 deploy:
-    # the bump moves the release's lib directory to `lib/grappa-<new>/ebin`
-    # while the running node keeps resolving `:code.lib_dir(:grappa)` to its
-    # BOOT directory, so the hot reload diffs a stale tree against itself and
-    # answers `{"reloaded":[]}` — a success shape it has no way to distinguish
-    # from "nothing to do". REVERSES the #652 pin that used to live in the HOT
-    # describe below.
-    test "VERSION → cold (:version) on jail (mix release, versioned lib dir)" do
-      assert {:cold, reasons} = Preflight.classify_paths(["VERSION"], :jail)
-      assert {:version, ["VERSION"]} in reasons
+  describe "classify_paths/2 — VERSION is HOT on every substrate (issue 2057)" do
+    # This describe used to assert the exact opposite on `:jail` and `:linux`
+    # (#1287's Class 8), and the reversal is not a relaxation of the
+    # conservative bias — the CAUSE was removed. The bump was COLD because the
+    # OTP application vsn tracked the VERSION file and put its number into the
+    # release code path `lib/grappa-<vsn>/ebin`, so the fresh beams landed in a
+    # sibling the running node never reads. `mix.exs` now freezes that vsn to a
+    # constant (`@otp_vsn`), the directory never moves, and the round trip was
+    # measured end to end on a real `mix release` with a live node: bump,
+    # `POST /admin/reload` 200 reloading `Elixir.Grappa.Version`,
+    # `/api/config` on the new number, no restart.
+    #
+    # A COLD class kept past its cause is not free: on an always-on bouncer
+    # every needless restart drops every IRC session.
+    test "VERSION → hot on jail (the frozen vsn keeps the lib dir still)" do
+      assert {:hot, []} = Preflight.classify_paths(["VERSION"], :jail)
     end
 
-    test "VERSION → cold (:version) on linux (mix release, versioned lib dir)" do
-      assert {:cold, reasons} = Preflight.classify_paths(["VERSION"], :linux)
-      assert {:version, ["VERSION"]} in reasons
+    test "VERSION → hot on linux (the frozen vsn keeps the lib dir still)" do
+      assert {:hot, []} = Preflight.classify_paths(["VERSION"], :linux)
     end
 
     test "VERSION → hot on docker (mix phx.server, unversioned _build lib dir)" do
-      # The container execs `mix phx.server` over a bind-mounted tree
+      # Docker was always hot here, for a different reason that still holds:
+      # the container execs `mix phx.server` over a bind-mounted tree
       # (bin/start.sh), so `:code.lib_dir(:grappa)` is `_build/<env>/lib/grappa`
-      # — no vsn in the path, and the reload sees the fresh beams. COLDing
-      # docker for a file its boot layout is immune to is the needless-restart
-      # class the substrate argument exists to prevent (moduledoc, 2026-06-10).
+      # — no vsn in the path at all. Kept as its own case so a future change
+      # that re-COLDs the release substrates cannot quietly take docker with it.
       assert {:hot, []} = Preflight.classify_paths(["VERSION"], :docker)
     end
 
-    test "the real bump-commit shape (VERSION + version.ex) → cold on linux" do
-      assert {:cold, reasons} =
-               Preflight.classify_paths(["VERSION", "lib/grappa/version.ex"], :linux)
-
-      assert {:version, ["VERSION"]} in reasons
+    test "the real bump-commit shape (VERSION + version.ex) → hot on every substrate" do
+      for substrate <- @substrates do
+        assert {:hot, []} =
+                 Preflight.classify_paths(["VERSION", "lib/grappa/version.ex"], substrate)
+      end
     end
 
-    test "a VERSION-named file elsewhere in the tree → hot (exact repo-root match)" do
+    test "a VERSION-named file elsewhere in the tree → hot (it never mattered)" do
       for substrate <- @substrates do
         assert {:hot, []} = Preflight.classify_paths(["cicchetto/VERSION"], substrate)
       end

--- a/test/grappa/version_single_source_test.exs
+++ b/test/grappa/version_single_source_test.exs
@@ -8,7 +8,10 @@ defmodule Grappa.VersionSingleSourceTest do
 
     * `mix.exs` `@version` + `lib/grappa/version.ex` `@base_version` — both
       read the SAME `VERSION` file at COMPILE time (no hardcoded literal to
-      drift; the beam-baked constant is what a hot deploy reloads);
+      drift; the beam-baked constant is what a hot deploy reloads). NOT the
+      OTP application vsn, which since issue 2057 is a frozen constant on
+      purpose — it is a code-PATH component (`lib/grappa-<vsn>/ebin`), not a
+      version carrier, and the two assertions below pin that split;
     * the `.deb`/nfpm version — `infra/packaging/build.sh` exports
       `GRAPPA_VERSION` from `infra/packaging/version.sh` (which reads
       `VERSION`), and `nfpm.yaml` interpolates `${GRAPPA_VERSION}`;
@@ -53,24 +56,68 @@ defmodule Grappa.VersionSingleSourceTest do
   # release workflow read it — a build↔source cross-check, not a runtime read.
   @canonical_version "VERSION" |> File.read!() |> String.trim()
 
+  # The frozen OTP application vsn (issue 2057). A LITERAL, deliberately
+  # duplicated from `mix.exs` rather than derived from it: deriving would make
+  # the assertion tautological and blind to the one regression that matters —
+  # someone putting `version: @version` back and re-coupling the release code
+  # path to the VERSION file. This constant never moves; that is its job.
+  @frozen_otp_vsn "0.0.0"
+
   describe "the single canonical declaration (repo-root VERSION file)" do
     test "is a well-formed semver" do
       assert @canonical_version =~ ~r/^\d+\.\d+\.\d+/
     end
 
-    test "is what OTP compiled into the .app resource (origin wired to runtime)" do
-      # Application.spec/2 returns the vsn OTP baked into the .app from mix.exs
-      # @version at build — which #652 has mix.exs read from VERSION. If they
-      # disagree the running node's .app would report a version the source
-      # never declared. (Note base/0 no longer routes through .app — #652 — but
-      # the .app vsn must still be stamped from the same VERSION at build.)
-      assert to_string(Application.spec(:grappa, :vsn)) == @canonical_version
+    test "is DECOUPLED from the OTP app vsn, which is frozen (issue 2057)" do
+      # This assertion used to be its own opposite: `Application.spec(:grappa,
+      # :vsn) == @canonical_version`, pinning the .app vsn to the VERSION file
+      # so "the running node's .app would report a version the source never
+      # declared" could not happen. That coupling is now deliberately BROKEN,
+      # and the pin is kept — inverted — rather than deleted, because the
+      # decoupling is the load-bearing property and an accidental re-coupling
+      # is silent (vjt's ruling, relayed 2026-09-10).
+      #
+      # WHY, measured on a real `mix release` + a live node (issue 2057):
+      # the app vsn is the ONLY thing that puts a number into the release's
+      # code path, `lib/grappa-<vsn>/ebin`. While it tracked VERSION, a bump
+      # moved the fresh beams to `lib/grappa-<new>` while the running node
+      # kept resolving `:code.lib_dir(:grappa)` to its BOOT directory — so
+      # `POST /admin/reload` answered 409 stale_code_path and `/api/config`
+      # stayed on the old number. Frozen, the path never moves, the beams land
+      # where the node is already looking, and the bump hot-reloads.
+      #
+      # The reported version does NOT regress: `Grappa.Version.base/0` is the
+      # compile-time constant baked from this same VERSION file, so the number
+      # an operator reads still has exactly one declaration.
+      assert to_string(Application.spec(:grappa, :vsn)) == @frozen_otp_vsn
+    end
+
+    test "the RELEASE vsn inherits the freeze — never its own version: key (issue 2057)" do
+      # The constraint that makes the freeze work, and the one way to undo it
+      # silently. `Grappa.HotReload.audit_code_path/1` compares the app vsn it
+      # reads off the booted code path (`lib/grappa-<app vsn>`) against the
+      # RELEASE vsn in `releases/start_erl.data`. They agree today only because
+      # a release with no `version:` of its own inherits the app's.
+      #
+      # MEASURED on the bench, not reasoned: freezing the app vsn while leaving
+      # `releases: [grappa: [version: @version]]` produced
+      # `409 {"booted":"0.0.0","built":"1.5.6"}` — and since the frozen side
+      # never moves while the other tracks VERSION, that 409 is PERMANENT. The
+      # cure would have become a total, silent refusal of every hot deploy.
+      release_opts = Keyword.fetch!(Mix.Project.config()[:releases], :grappa)
+
+      refute Keyword.has_key?(release_opts, :version),
+             "the grappa release must inherit the frozen app vsn; giving it a " <>
+               "version: of its own makes audit_code_path/1 refuse every hot deploy"
     end
 
     test "mix.exs @version DERIVES from VERSION — never a re-hardcoded literal (#652)" do
       # The core #652 guarantee: mix.exs stopped being the hand-edited carrier.
-      # If someone re-inlines `@version \"X.Y.Z\"` the bump silently forces COLD
-      # again (Preflight mix_deps?) — catch that regression at the bump commit.
+      # If someone re-inlines `@version \"X.Y.Z\"` the bump starts editing
+      # mix.exs again, which Preflight classifies COLD (mix_deps?) — catch that
+      # regression at the bump commit. Note this is about the BUMP CARRIER and
+      # is untouched by issue 2057, which froze a DIFFERENT attribute
+      # (`@otp_vsn`, the OTP app vsn) while leaving `@version` deriving.
       mix = File.read!("mix.exs")
       refute mix =~ ~r/@version\s+"\d/
       assert mix =~ "File.read!(Path.join(__DIR__, \"VERSION\"))"


### PR DESCRIPTION
Addresses issue 2057.

A `VERSION`-only bump was COLD on `:jail` and `:linux`. It did not have to
be: the reason was one line of `mix.exs`, not anything about deploying, or
releases, or the number itself.

The repo-root `VERSION` was read to stamp the **OTP application vsn**, and
the app vsn is the only thing that puts a number into a release's code path
(`lib/grappa-<vsn>/ebin`). So a bump wrote the fresh beams into a sibling
directory the running node never reads — `:code.lib_dir(:grappa)` resolves
to the BOOT directory forever — and `reload_modified/0` diffed a stale tree
against itself, answering `{"failed":[],"reloaded":[]}`. Production served
the old BEAM under new git history for ~6.5 hours on 2026-08-13 that way.

This freezes the app vsn to a constant (`@otp_vsn "0.0.0"`) and leaves
`@version` deriving from `VERSION` exactly as #652 built it. The directory
stops moving, the beams land where the node is already looking, and the
bump hot-reloads.

## Measured, on a real `mix release` with a live node

Not on the docker dev stack, which would have passed for the wrong reason:
its bind-mounted `mix phx.server` layout has no vsn in the lib path at all.
Isolated tree, release booted, `:code.lib_dir(:grappa)` asked of the **live
node** via `bin/grappa rpc` rather than read off the disk.

| arm | live `:code.lib_dir` | `start_erl.data` after bump | `POST /admin/reload` | `/api/config` after |
|---|---|---|---|---|
| app vsn tracks `VERSION` (before) | `lib/grappa-1.5.5` | `1.5.6` | **409** `stale_code_path` | **1.5.5** — stuck |
| app vsn frozen, release vsn inherits | `lib/grappa-0.0.0` | `0.0.0` | **200** `reloaded:["Elixir.Grappa.Version"]` | **1.5.6** |
| app vsn frozen, release vsn tracks | `lib/grappa-0.0.0` | `1.5.6` | **409** `booted 0.0.0 / built 1.5.6` | **1.5.5** — stuck |

The first arm is the negative control: it reproduces the production 409
exactly, so the bench can see the defect it claims to cure. Side effect
worth knowing: under the freeze the second `mix release --overwrite` leaves
**one** lib directory, where the tracking arm accumulates `grappa-1.5.5`
beside `grappa-1.5.6`. Stale siblings stop piling up.

## 🔴 The constraint the third arm buys

Freezing the app vsn while giving the release its own `version:` is the
obvious half-measure — it keeps an honest number in the tarball — and it is
catastrophic and silent. `HotReload.audit_code_path/1` compares the app vsn
in the booted code path against the RELEASE vsn in `start_erl.data`. Frozen
beside tracking, those diverge on every bump and never reconverge: the
audit then refuses **every hot deploy, permanently**, and the cure becomes
its exact opposite while saying nothing.

So the release vsn MUST inherit the freeze, i.e. the release must carry no
`version:` key of its own. That is not checkable by reading the value — an
inheriting release and a re-coupled one both yield a plausible number — so
the pin asserts the **key is absent**. This was predicted from the source
and then measured, rather than shipped as a reasoned-about hazard.

## What was in the way: a false zero

The proposal rested on "`Application.spec(:grappa, :vsn)` has zero
consumers; the only matches are prose". Re-measured, that is false — the
census had stopped at `lib/`.
`test/grappa/version_single_source_test.exs:67` asserted
`Application.spec(:grappa, :vsn) == @canonical_version`: not a stale test
but the #538/#652 pin on the exact coupling being removed, carrying its
rationale in the comment above it — *"If they disagree the running node's
.app would report a version the source never declared."*

That is now true and deliberate. The pin is **rewritten as the pin of the
decoupling, not deleted**, because an accidental re-coupling is silent and
the inverted assertion is what catches it. Both mutants were run and each
kills exactly one assertion.

Two `Application.spec(:grappa, …)` readers remain — `:modules`, a different
key — which also falsifies `Grappa.Version`'s moduledoc claim to be the only
consumer. Corrected in place.

⚠️ **Provenance:** vjt's ruling authorising the freeze, the rewrite of that
pin, and the CLAUDE.md paragraph arrived **relayed via the ircbot and was
not observed first-hand.** Stated here so a mis-relay is cheap to catch in
review.

## What deliberately did not change

`stale_code_path` (#1850) stays. Stated plainly: with both vsns frozen it
can no longer fire for the class it was written against — that is the
correct outcome, not grounds to delete it. Prevention moved to the ROOT;
detection did not move at all. The audit never named `VERSION`; it compares
booted-vs-built whatever drove them apart, and the third arm above is a live
example of a route that has nothing to do with a bump.

Also not taken: running the jail the way docker runs (`mix phx.server` over
a bind-mount, hot by construction). The price is the whole release — no
`bin/grappa`, so no `rpc`, no boot script, no operator CLI — and it was not
pursued. This freezes a constant; it does not change substrate.

## The price, in full

Paths and the release tarball on the box read `0.0.0`. Nothing consumes
them: measured across `infra/`, `scripts/`, `.github/` and `Dockerfile*`,
every one of which names the unversioned `_build/prod/rel/grappa`. The
number an operator reads — `/api/config`, `CTCP VERSION`, the `.deb`/AUR
metadata — is `Grappa.Version`, still baked from `VERSION`, still declared
exactly once. `@version` keeps a real consumer: the #542 guard's no-git log
line, which would otherwise have started printing the frozen `0.0.0`, a
number no artifact ever reports.

## Gates

`scripts/check.sh` green on the rebased tip: 8 doctests, 65 properties,
7259 tests, 0 failures; 764 bats ok / 0 not ok; Sobelow 0 errors.
This diff touches `mix.exs`, so it is COLD by classification and needs a
restart to take effect — after which a `VERSION`-only bump is HOT.
