### PR TITLE
cic(2059): the repo's most frequent red is two product defects, not a flake

### DIFF
--- a/cicchetto/src/__tests__/reconnectBounceRedirect.test.ts
+++ b/cicchetto/src/__tests__/reconnectBounceRedirect.test.ts
@@ -1,0 +1,213 @@
+// issue 2059 — the `/reconnect` bounce loses the home redirect when the park
+// is shorter than the GET that would have shown it.
+//
+// `issue1796-reconnect-bounces-network.spec.ts` has been red 17 times since
+// 2026-08 across branches that do not touch this path, and was tracked as a
+// flake. It is not one: the spec asserts the operator ends on Home, and the
+// product genuinely fails to put them there.
+//
+// WHY THE STORES BELOW ARE REAL AND THE BENCH IS NOT IN `selection.test.ts`:
+// bucket D lives in `selection.ts` but is FED by `userTopic.ts`, and the
+// defect is precisely a disagreement between what the event says and what the
+// refetch it triggers ends up showing. A bench that calls `refetchNetworks()`
+// by hand — which is what the existing bucket-D suite does — cannot express
+// it, because the event never enters the picture. So this file mounts the
+// real `userTopic` dispatcher over the real `selection` + `networks` stores,
+// the way `userTopic-rotation.test.ts` does, and mocks only the two
+// boundaries: the socket (to inject events) and REST.
+//
+// THE RACE, stated as the mock encodes it: `/reconnect` parks and immediately
+// reconnects. Both legs emit `connection_state_changed` and each triggers a
+// `refetchNetworks()`. A GET issued at the park leg does not necessarily
+// OBSERVE the park — by the time the server answers it, the credential can
+// already read `connected` again. `listNetworks` therefore returns
+// `connected` on EVERY call here. That is not a contrived stub: it is what a
+// park shorter than one round-trip looks like from the client, and it is the
+// measured signature of the flake (the store never held `parked`).
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { warmGraph } from "./helpers/warmGraph";
+
+const channelMock = vi.hoisted(() => {
+  const handlers: Array<(payload: { kind: string; [k: string]: unknown }) => void> = [];
+  return {
+    handlers,
+    on: vi.fn((event: string, fn: (payload: { kind: string; [k: string]: unknown }) => void) => {
+      if (event === "event") handlers.push(fn);
+    }),
+    leave: vi.fn(),
+    fireEvent: (payload: { kind: string; [k: string]: unknown }) => {
+      for (const h of handlers) h(payload);
+    },
+    reset: () => {
+      handlers.length = 0;
+    },
+  };
+});
+
+// `onJoinOk` is deliberately NOT invoked: it hydrates highlights and
+// notification prefs over REST, which this bench does not stub and does not
+// assert on. Calling it only buys an unhandled `fetch() URL is invalid` in
+// the output — noise that would sit next to a real failure and be read as
+// part of it.
+vi.mock("../lib/socket", () => ({
+  joinUser: vi.fn(() => ({ on: channelMock.on, leave: channelMock.leave })),
+  joinChannel: vi.fn(() => ({ on: vi.fn(), leave: vi.fn() })),
+}));
+
+const NET_SLUG = "azzurra";
+const CHANNEL = "#italia";
+
+// Pass-through override rather than a full factory: the graph under test
+// pulls in `tagNetwork` / `ownNickForNetwork` / the kind predicates, and a
+// hand-written twin of those would be a second implementation to keep in
+// step. Only the three REST calls are stubbed.
+vi.mock(import("../lib/api"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    // ALWAYS connected — see "THE RACE" above. The park is never visible to
+    // a refetch, which is the whole point of the bench.
+    listNetworks: vi.fn().mockResolvedValue([
+      {
+        kind: "user",
+        id: 1,
+        slug: NET_SLUG,
+        nick: "vjt",
+        connection_state: "connected",
+        connection_state_reason: null,
+        connection_state_changed_at: null,
+        inserted_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ]),
+    listChannels: vi.fn().mockResolvedValue([]),
+    listMessages: vi.fn().mockResolvedValue([]),
+    sendMessage: vi.fn(),
+    postPart: vi.fn().mockResolvedValue(undefined),
+    me: vi.fn().mockResolvedValue({
+      kind: "user",
+      id: "u1",
+      name: "vjt",
+      is_admin: false,
+      inserted_at: "2026-01-01T00:00:00Z",
+      read_cursors: {},
+    }),
+    login: vi.fn(),
+    logout: vi.fn(),
+    setOn401Handler: vi.fn(),
+  };
+});
+
+// Same shape the server emits and `userTopic.test.ts` already pins.
+const connectionStateChanged = (from: string, to: "connected" | "parked" | "failed") => ({
+  kind: "connection_state_changed",
+  user_id: "u1",
+  network_id: 1,
+  network_slug: NET_SLUG,
+  from,
+  to,
+  reason: to === "connected" ? null : "rolling a fresh vhost",
+  at: "2026-09-10T00:00:00Z",
+  network: {
+    slug: NET_SLUG,
+    nick: "vjt",
+    connection_state: to,
+    connection_state_reason: to === "connected" ? null : "rolling a fresh vhost",
+    connection_state_changed_at: "2026-09-10T00:00:00Z",
+    recoverable: false,
+  },
+});
+
+// #781 — warm the graph outside the per-test budget. See helpers/warmGraph.ts.
+beforeAll(() => warmGraph(() => import("../lib/userTopic")));
+
+beforeEach(() => {
+  vi.resetModules();
+  localStorage.clear();
+  vi.clearAllMocks();
+  channelMock.reset();
+  channelMock.on.mockClear();
+});
+
+const seedIdentity = (token: string) => {
+  localStorage.setItem("grappa-token", token);
+  localStorage.setItem("grappa-subject", JSON.stringify({ kind: "user", id: "u1", name: "vjt" }));
+};
+
+// Bring the graph up with the operator sitting in a channel of the live
+// network, and the user-topic dispatcher installed. Returns the store handles
+// the arms assert on.
+const mountLookingAtChannel = async (token: string) => {
+  seedIdentity(token);
+  const auth = await import("../lib/auth");
+  const sel = await import("../lib/selection");
+  const networks = await import("../lib/networks");
+  await import("../lib/userTopic");
+  auth.setToken(token);
+
+  await vi.waitFor(() => {
+    const nets = networks.networks();
+    expect(nets?.length).toBe(1);
+    const n = nets?.[0];
+    expect(n?.kind).toBe("user");
+    if (n?.kind === "user") expect(n.connection_state).toBe("connected");
+  });
+  // The dispatcher has to be listening, or an arm would fire events into
+  // nothing and pass for the wrong reason.
+  await vi.waitFor(() => expect(channelMock.handlers.length).toBeGreaterThan(0));
+
+  sel.setSelectedChannel({ networkSlug: NET_SLUG, channelName: CHANNEL, kind: "channel" });
+  expect(sel.selectedChannel()?.networkSlug).toBe(NET_SLUG);
+  return { sel, networks };
+};
+
+describe("issue 2059 — /reconnect bounce keeps the home redirect", () => {
+  it("redirects to home when the park is only ever visible in the event", async () => {
+    const { sel } = await mountLookingAtChannel("tok2059-race");
+
+    // The bounce: both legs land while any GET they trigger still answers
+    // `connected`. This is the measured signature — the store never holds
+    // `parked`.
+    channelMock.fireEvent(connectionStateChanged("connected", "parked"));
+    channelMock.fireEvent(connectionStateChanged("parked", "connected"));
+
+    // The park HAPPENED — the server said so, twice, on the wire. The
+    // operator's compose box was torn down under them, so leaving them
+    // pointed at the channel is the defect the e2e spec catches as "no
+    // .home-pane".
+    await vi.waitFor(() => {
+      expect(sel.selectedChannel()?.networkSlug).toBe("$home");
+    });
+  });
+
+  it("does NOT redirect when the parking network is not the selected one", async () => {
+    // Negative control for the arm above: without it, a cure that redirects
+    // on ANY park event would pass the first arm while breaking every
+    // operator watching a second network.
+    const { sel } = await mountLookingAtChannel("tok2059-other");
+
+    channelMock.fireEvent({
+      ...connectionStateChanged("connected", "parked"),
+      network_slug: "freenode",
+      network: { ...connectionStateChanged("connected", "parked").network, slug: "freenode" },
+    });
+
+    await vi.waitFor(() => expect(channelMock.handlers.length).toBeGreaterThan(0));
+    expect(sel.selectedChannel()?.networkSlug).toBe(NET_SLUG);
+    expect(sel.selectedChannel()?.channelName).toBe(CHANNEL);
+  });
+
+  it("does NOT redirect on a connected → connected event", async () => {
+    // The second negative control, and the one that pins the cure's shape:
+    // reading the EVENT must not degrade into "any state change redirects".
+    // Only a transition INTO parked/failed may move the operator.
+    const { sel } = await mountLookingAtChannel("tok2059-noop");
+
+    channelMock.fireEvent(connectionStateChanged("connected", "connected"));
+
+    await vi.waitFor(() => expect(channelMock.handlers.length).toBeGreaterThan(0));
+    expect(sel.selectedChannel()?.networkSlug).toBe(NET_SLUG);
+    expect(sel.selectedChannel()?.channelName).toBe(CHANNEL);
+  });
+});

--- a/cicchetto/src/__tests__/reconnectBounceRedirect.test.ts
+++ b/cicchetto/src/__tests__/reconnectBounceRedirect.test.ts
@@ -56,6 +56,7 @@ vi.mock("../lib/socket", () => ({
 }));
 
 const NET_SLUG = "azzurra";
+const OTHER_SLUG = "freenode";
 const CHANNEL = "#italia";
 
 // Pass-through override rather than a full factory: the graph under test
@@ -68,11 +69,31 @@ vi.mock(import("../lib/api"), async (importOriginal) => {
     ...actual,
     // ALWAYS connected — see "THE RACE" above. The park is never visible to
     // a refetch, which is the whole point of the bench.
+    //
+    // BOTH networks are listed, and the second one is load-bearing rather
+    // than scenery: the observer ignores the FIRST state it ever sees for a
+    // slug (an operator opening the app on a parked network chose that
+    // window). A bench that fired the other-network arm at a slug absent
+    // from this list would be stopped by that first-sighting guard and pass
+    // without ever reaching the test it means to exercise — measured, on the
+    // first cut of this file: the mutation that deletes the slug test left
+    // the arm green.
     listNetworks: vi.fn().mockResolvedValue([
       {
         kind: "user",
         id: 1,
         slug: NET_SLUG,
+        nick: "vjt",
+        connection_state: "connected",
+        connection_state_reason: null,
+        connection_state_changed_at: null,
+        inserted_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        kind: "user",
+        id: 2,
+        slug: OTHER_SLUG,
         nick: "vjt",
         connection_state: "connected",
         connection_state_reason: null,
@@ -100,17 +121,21 @@ vi.mock(import("../lib/api"), async (importOriginal) => {
 });
 
 // Same shape the server emits and `userTopic.test.ts` already pins.
-const connectionStateChanged = (from: string, to: "connected" | "parked" | "failed") => ({
+// `failing` is in the closed set too (#1675: [connected, failing, parked,
+// failed]) and the arms below need it — it is the one transition that is
+// genuinely a CHANGE while not being a park.
+type Conn = "connected" | "failing" | "parked" | "failed";
+const connectionStateChanged = (from: Conn, to: Conn, slug: string = NET_SLUG) => ({
   kind: "connection_state_changed",
   user_id: "u1",
-  network_id: 1,
-  network_slug: NET_SLUG,
+  network_id: slug === NET_SLUG ? 1 : 2,
+  network_slug: slug,
   from,
   to,
   reason: to === "connected" ? null : "rolling a fresh vhost",
   at: "2026-09-10T00:00:00Z",
   network: {
-    slug: NET_SLUG,
+    slug,
     nick: "vjt",
     connection_state: to,
     connection_state_reason: to === "connected" ? null : "rolling a fresh vhost",
@@ -146,12 +171,16 @@ const mountLookingAtChannel = async (token: string) => {
   await import("../lib/userTopic");
   auth.setToken(token);
 
+  // Wait for BOTH slugs to be seen once. The observer ignores a slug's first
+  // state, so an arm that fired before this settled would be testing the
+  // first-sighting guard instead of what it claims to test.
   await vi.waitFor(() => {
     const nets = networks.networks();
-    expect(nets?.length).toBe(1);
-    const n = nets?.[0];
-    expect(n?.kind).toBe("user");
-    if (n?.kind === "user") expect(n.connection_state).toBe("connected");
+    expect(nets?.length).toBe(2);
+    for (const n of nets ?? []) {
+      expect(n.kind).toBe("user");
+      if (n.kind === "user") expect(n.connection_state).toBe("connected");
+    }
   });
   // The dispatcher has to be listening, or an arm would fire events into
   // nothing and pass for the wrong reason.
@@ -181,32 +210,32 @@ describe("issue 2059 — /reconnect bounce keeps the home redirect", () => {
     });
   });
 
-  it("does NOT redirect when the parking network is not the selected one", async () => {
-    // Negative control for the arm above: without it, a cure that redirects
-    // on ANY park event would pass the first arm while breaking every
-    // operator watching a second network.
+  it("does NOT redirect when a DIFFERENT network parks", async () => {
+    // Negative control: a cure that redirects on any park event passes the
+    // arm above while bouncing every operator who is watching a second
+    // network. `freenode` is in the network list and has been seen
+    // `connected` once, so this is a real transition reaching a real
+    // observer — not a first sighting being dropped on the floor.
     const { sel } = await mountLookingAtChannel("tok2059-other");
 
-    channelMock.fireEvent({
-      ...connectionStateChanged("connected", "parked"),
-      network_slug: "freenode",
-      network: { ...connectionStateChanged("connected", "parked").network, slug: "freenode" },
-    });
+    channelMock.fireEvent(connectionStateChanged("connected", "parked", OTHER_SLUG));
 
-    await vi.waitFor(() => expect(channelMock.handlers.length).toBeGreaterThan(0));
     expect(sel.selectedChannel()?.networkSlug).toBe(NET_SLUG);
     expect(sel.selectedChannel()?.channelName).toBe(CHANNEL);
   });
 
-  it("does NOT redirect on a connected → connected event", async () => {
+  it("does NOT redirect on a connected → failing transition of the selected network", async () => {
     // The second negative control, and the one that pins the cure's shape:
     // reading the EVENT must not degrade into "any state change redirects".
-    // Only a transition INTO parked/failed may move the operator.
-    const { sel } = await mountLookingAtChannel("tok2059-noop");
+    // `failing` (#1675) is the discriminating case — a genuine transition of
+    // the SELECTED network that is nonetheless not a park, so nothing but
+    // the parked/failed test can stop it. `connected` → `connected` would
+    // not do: the same-value test stops that one first, and the arm would
+    // pass whether or not the cure kept the park gate at all.
+    const { sel } = await mountLookingAtChannel("tok2059-failing");
 
-    channelMock.fireEvent(connectionStateChanged("connected", "connected"));
+    channelMock.fireEvent(connectionStateChanged("connected", "failing"));
 
-    await vi.waitFor(() => expect(channelMock.handlers.length).toBeGreaterThan(0));
     expect(sel.selectedChannel()?.networkSlug).toBe(NET_SLUG);
     expect(sel.selectedChannel()?.channelName).toBe(CHANNEL);
   });

--- a/cicchetto/src/__tests__/reconnectBounceRedirect.test.ts
+++ b/cicchetto/src/__tests__/reconnectBounceRedirect.test.ts
@@ -224,6 +224,46 @@ describe("issue 2059 — /reconnect bounce keeps the home redirect", () => {
     expect(sel.selectedChannel()?.channelName).toBe(CHANNEL);
   });
 
+  // ── the sibling defect, measured rather than inherited ──────────────────
+  //
+  // issue 2059 names a second failure on this path: two refetches issued in
+  // the same microtask collapse into a single GET, the second swallowed,
+  // leaving the UI stuck on `parked`. That is a DIFFERENT symptom from the
+  // lost redirect — and it reaches the SAME e2e spec, which also asserts the
+  // network section loses its greyed class. So a cure for the redirect alone
+  // could still leave that spec red. This arm exists to find out whether the
+  // collapse is real, stated as an outcome (does the store end on the truth?)
+  // rather than as a call count.
+  it("ends on the LAST state when park and unpark refetch back to back", async () => {
+    const api = await import("../lib/api");
+    const parked = {
+      kind: "user" as const,
+      id: 1,
+      slug: NET_SLUG,
+      nick: "vjt",
+      connection_state: "parked" as const,
+      connection_state_reason: "rolling a fresh vhost",
+      connection_state_changed_at: null,
+      inserted_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+    const { networks } = await mountLookingAtChannel("tok2059-collapse");
+
+    // Park answers first, unpark second — the ordering `/reconnect`
+    // produces when the GETs are NOT outrun. If the second refetch is
+    // swallowed, the store keeps the parked row and the sidebar stays grey.
+    vi.mocked(api.listNetworks).mockResolvedValueOnce([parked]);
+    const netModule = await import("../lib/networks");
+    netModule.refetchNetworks();
+    netModule.refetchNetworks();
+
+    await vi.waitFor(() => {
+      const n = networks.networks()?.find((x) => x.slug === NET_SLUG);
+      expect(n?.kind).toBe("user");
+      if (n?.kind === "user") expect(n.connection_state).toBe("connected");
+    });
+  });
+
   it("does NOT redirect on a connected → failing transition of the selected network", async () => {
     // The second negative control, and the one that pins the cure's shape:
     // reading the EVENT must not degrade into "any state change redirects".

--- a/cicchetto/src/__tests__/reconnectBounceRedirect.test.ts
+++ b/cicchetto/src/__tests__/reconnectBounceRedirect.test.ts
@@ -64,22 +64,22 @@ const CHANNEL = "#italia";
 // queued `once` implementations.
 const defaultNetworks = vi.hoisted(() => [
   {
-    kind: "user",
+    kind: "user" as const,
     id: 1,
     slug: "azzurra",
     nick: "vjt",
-    connection_state: "connected",
+    connection_state: "connected" as const,
     connection_state_reason: null,
     connection_state_changed_at: null,
     inserted_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
   },
   {
-    kind: "user",
+    kind: "user" as const,
     id: 2,
     slug: "freenode",
     nick: "vjt",
-    connection_state: "connected",
+    connection_state: "connected" as const,
     connection_state_reason: null,
     connection_state_changed_at: null,
     inserted_at: "2026-01-01T00:00:00Z",

--- a/cicchetto/src/__tests__/reconnectBounceRedirect.test.ts
+++ b/cicchetto/src/__tests__/reconnectBounceRedirect.test.ts
@@ -59,6 +59,34 @@ const NET_SLUG = "azzurra";
 const OTHER_SLUG = "freenode";
 const CHANNEL = "#italia";
 
+// `vi.hoisted` because the `vi.mock` factory below is hoisted above every
+// plain const, and `beforeEach` re-seeds the same value after resetting the
+// queued `once` implementations.
+const defaultNetworks = vi.hoisted(() => [
+  {
+    kind: "user",
+    id: 1,
+    slug: "azzurra",
+    nick: "vjt",
+    connection_state: "connected",
+    connection_state_reason: null,
+    connection_state_changed_at: null,
+    inserted_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    kind: "user",
+    id: 2,
+    slug: "freenode",
+    nick: "vjt",
+    connection_state: "connected",
+    connection_state_reason: null,
+    connection_state_changed_at: null,
+    inserted_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+]);
+
 // Pass-through override rather than a full factory: the graph under test
 // pulls in `tagNetwork` / `ownNickForNetwork` / the kind predicates, and a
 // hand-written twin of those would be a second implementation to keep in
@@ -78,30 +106,7 @@ vi.mock(import("../lib/api"), async (importOriginal) => {
     // without ever reaching the test it means to exercise — measured, on the
     // first cut of this file: the mutation that deletes the slug test left
     // the arm green.
-    listNetworks: vi.fn().mockResolvedValue([
-      {
-        kind: "user",
-        id: 1,
-        slug: NET_SLUG,
-        nick: "vjt",
-        connection_state: "connected",
-        connection_state_reason: null,
-        connection_state_changed_at: null,
-        inserted_at: "2026-01-01T00:00:00Z",
-        updated_at: "2026-01-01T00:00:00Z",
-      },
-      {
-        kind: "user",
-        id: 2,
-        slug: OTHER_SLUG,
-        nick: "vjt",
-        connection_state: "connected",
-        connection_state_reason: null,
-        connection_state_changed_at: null,
-        inserted_at: "2026-01-01T00:00:00Z",
-        updated_at: "2026-01-01T00:00:00Z",
-      },
-    ]),
+    listNetworks: vi.fn().mockResolvedValue(defaultNetworks),
     listChannels: vi.fn().mockResolvedValue([]),
     listMessages: vi.fn().mockResolvedValue([]),
     sendMessage: vi.fn(),
@@ -147,12 +152,21 @@ const connectionStateChanged = (from: Conn, to: Conn, slug: string = NET_SLUG) =
 // #781 — warm the graph outside the per-test budget. See helpers/warmGraph.ts.
 beforeAll(() => warmGraph(() => import("../lib/userTopic")));
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.resetModules();
   localStorage.clear();
   vi.clearAllMocks();
   channelMock.reset();
   channelMock.on.mockClear();
+  // `clearAllMocks` wipes call history but NOT queued `once` implementations.
+  // Measured: the back-to-back arm below leaves its second
+  // `mockResolvedValueOnce` UNCONSUMED (that is the defect it pins), and
+  // without this reset the next test received that one-network list and
+  // failed on `expect(1).toBe(2)` — a red belonging to the previous arm,
+  // landing on an innocent one.
+  const api = await import("../lib/api");
+  vi.mocked(api.listNetworks).mockReset();
+  vi.mocked(api.listNetworks).mockResolvedValue(defaultNetworks);
 });
 
 const seedIdentity = (token: string) => {
@@ -234,33 +248,44 @@ describe("issue 2059 — /reconnect bounce keeps the home redirect", () => {
   // could still leave that spec red. This arm exists to find out whether the
   // collapse is real, stated as an outcome (does the store end on the truth?)
   // rather than as a call count.
-  it("ends on the LAST state when park and unpark refetch back to back", async () => {
+  it("ends on the SECOND answer when two refetches are issued back to back", async () => {
+    // THREE distinct states on purpose. An earlier cut of this arm ran
+    // connected → (parked, connected) and asserted `connected`, which the
+    // store already read at mount: `waitFor` returned on its first tick
+    // without any GET having answered, and the arm stayed GREEN even when
+    // the swallow was fabricated. An assertion that holds BEFORE the action
+    // measures nothing.
+    //
+    // Here the terminal state (`failing`) is one the store has never held,
+    // so it can only be reached by the SECOND answer landing. If that
+    // refetch is swallowed the row stays `parked` and the arm fails.
+    //
+    // Driven on the OTHER network so the park does not also trip the home
+    // redirect — this arm is about the store, not about selection.
     const api = await import("../lib/api");
-    const parked = {
+    const row = (state: Conn) => ({
       kind: "user" as const,
-      id: 1,
-      slug: NET_SLUG,
+      id: 2,
+      slug: OTHER_SLUG,
       nick: "vjt",
-      connection_state: "parked" as const,
-      connection_state_reason: "rolling a fresh vhost",
+      connection_state: state,
+      connection_state_reason: state === "connected" ? null : "rolling a fresh vhost",
       connection_state_changed_at: null,
       inserted_at: "2026-01-01T00:00:00Z",
       updated_at: "2026-01-01T00:00:00Z",
-    };
+    });
     const { networks } = await mountLookingAtChannel("tok2059-collapse");
 
-    // Park answers first, unpark second — the ordering `/reconnect`
-    // produces when the GETs are NOT outrun. If the second refetch is
-    // swallowed, the store keeps the parked row and the sidebar stays grey.
-    vi.mocked(api.listNetworks).mockResolvedValueOnce([parked]);
+    vi.mocked(api.listNetworks).mockResolvedValueOnce([row("parked")]);
+    vi.mocked(api.listNetworks).mockResolvedValueOnce([row("failing")]);
     const netModule = await import("../lib/networks");
     netModule.refetchNetworks();
     netModule.refetchNetworks();
 
     await vi.waitFor(() => {
-      const n = networks.networks()?.find((x) => x.slug === NET_SLUG);
+      const n = networks.networks()?.find((x) => x.slug === OTHER_SLUG);
       expect(n?.kind).toBe("user");
-      if (n?.kind === "user") expect(n.connection_state).toBe("connected");
+      if (n?.kind === "user") expect(n.connection_state).toBe("failing");
     });
   });
 

--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -81,6 +81,12 @@ vi.mock("../lib/selection", () => ({
   selectedChannel: vi.fn(() => null),
   setSelectedChannel: vi.fn(),
   applySeedEnvelope: vi.fn(),
+  // issue 2059 — bucket D is fed from the event now, not only from the
+  // `networks()` sample. This file mocks selection wholesale, so a port
+  // missing here is a TypeError inside the dispatch arm rather than a
+  // missing assertion: the three `setReconnecting` arms below went red on
+  // it, two statements before the line they were testing.
+  noteConnectionState: vi.fn(),
 }));
 
 vi.mock("../lib/bundleHash", () => ({
@@ -1123,6 +1129,31 @@ describe("userTopic", () => {
       const rs = await import("../lib/reconnectingStatus");
       channelMock.fireEvent(connectionStateChanged("bahamut-test", "connected"));
       expect(rs.setReconnecting).not.toHaveBeenCalled();
+    });
+
+    // issue 2059 — the wiring half of the park-redirect cure. The behaviour
+    // half is measured over the real stores in
+    // `reconnectBounceRedirect.test.ts`; what can only be checked HERE, where
+    // selection is a mock, is that the dispatcher actually hands the
+    // transition over — and hands over the EVENT's `to`, not something
+    // re-read from a store that may not have caught up yet. Without this the
+    // cure could be silently unplugged and only an e2e run would notice.
+    it("hands connection_state_changed to selection with the event's own slug and target state", async () => {
+      const sel = await import("../lib/selection");
+      channelMock.fireEvent(connectionStateChanged("bahamut-test", "parked"));
+      expect(sel.noteConnectionState).toHaveBeenCalledWith("bahamut-test", "parked");
+    });
+
+    it("hands over the unpark leg too, so a bounce is two transitions and not one", async () => {
+      // The park leg alone would satisfy the arm above while still losing
+      // half of `/reconnect`: the observer needs the return to `connected`
+      // recorded, or the NEXT park of the same network reads `curr === prev`
+      // and is dropped.
+      const sel = await import("../lib/selection");
+      channelMock.fireEvent(connectionStateChanged("bahamut-test", "parked"));
+      channelMock.fireEvent(connectionStateChanged("bahamut-test", "connected"));
+      expect(sel.noteConnectionState).toHaveBeenNthCalledWith(1, "bahamut-test", "parked");
+      expect(sel.noteConnectionState).toHaveBeenNthCalledWith(2, "bahamut-test", "connected");
     });
 
     // #410 LOCK — an off-contract connection_state drops the whole

--- a/cicchetto/src/lib/networks.ts
+++ b/cicchetto/src/lib/networks.ts
@@ -195,8 +195,49 @@ const exports = identityScopedStore((onIdentityChange) => {
   // `userTopic.ts` can pull the updated `Credential.connection_state`
   // / reason / changed_at fields without duplicating wire shape into
   // the client.
+  //
+  // issue 2059 — QUEUE A TRAILING REFETCH INSTEAD OF DROPPING IT.
+  //
+  // Measured, not assumed: with two calls issued back to back, the SECOND
+  // GET never leaves. The bench answers the first call `parked` and the
+  // second `failing`; the store ends on `parked` and the second stubbed
+  // answer is still queued, unconsumed. `createResource.refetch()` does not
+  // start a second fetch while one is in flight, so the caller's second
+  // request is simply lost.
+  //
+  // That is not a cosmetic loss. `/reconnect` emits two
+  // `connection_state_changed` events in quick succession and each triggers
+  // a refetch: lose the unpark one and the store keeps the parked row —
+  // the sidebar section stays greyed and the Home parked card stays up,
+  // with nothing further scheduled to correct it. It is the second half of
+  // what `issue1796-reconnect-bounces-network.spec.ts` asserts, and it is a
+  // DIFFERENT defect from the lost home redirect, with a different cure.
+  //
+  // Trailing-coalesce rather than a full chain: any number of calls arriving
+  // during a flight collapse into exactly ONE follow-up, which starts after
+  // that flight ends. The invariant that matters is "a refetch requested
+  // after the last state change is answered after it", and one trailing run
+  // gives that without turning a burst of N events into N round-trips.
+  let refetchInFlight = false;
+  let refetchPending = false;
+  const runNetworksRefetch = async (): Promise<void> => {
+    refetchInFlight = true;
+    try {
+      await refetchNetworksResource();
+    } finally {
+      refetchInFlight = false;
+      if (refetchPending) {
+        refetchPending = false;
+        void runNetworksRefetch();
+      }
+    }
+  };
   const refetchNetworks = (): void => {
-    void refetchNetworksResource();
+    if (refetchInFlight) {
+      refetchPending = true;
+      return;
+    }
+    void runNetworksRefetch();
   };
 
   // #126 — re-fetch GET /me after a visitor disconnect/reconnect so the

--- a/cicchetto/src/lib/selection.ts
+++ b/cicchetto/src/lib/selection.ts
@@ -767,8 +767,72 @@ const exports = identityScopedStore((onIdentityChange) => {
   // Home and visitor windows have no network credential so
   // `networkBySlug` returns undefined → no entry in the map → no
   // redirect (correct: home is the redirect TARGET, never the source).
+  // issue 2059 — TWO FEEDS, ONE OBSERVER, ONE MEMORY.
+  //
+  // The Map below is the only record of "what state was this network in last
+  // time we heard". Both feeds write it through `observeConnectionState`, so
+  // there is no second structure to keep in step (CLAUDE.md: don't duplicate
+  // state — derive it).
+  //
+  //   FEED 1, the `networks()` sample (below). Load-bearing and NOT
+  //   removable: Phoenix PubSub does not replay, so after a WS gap the
+  //   refetch is the ONLY evidence that a park happened while we were
+  //   deaf.
+  //
+  //   FEED 2, the `connection_state_changed` event (`noteConnectionState`,
+  //   called from userTopic.ts). Load-bearing for the opposite reason: a
+  //   sample cannot see a transition shorter than the interval between
+  //   samples. `/reconnect` parks and reconnects immediately, and a GET
+  //   issued at the park leg can be answered after the credential already
+  //   reads `connected` again — so the sampled sequence is
+  //   ["connected", "connected"], `curr === prev`, and the redirect is
+  //   silently lost. That is issue 2059, and it is why
+  //   `issue1796-reconnect-bounces-network.spec.ts` went red 17 times and
+  //   was mistaken for a flake: the spec is honest, the product loses the
+  //   park.
+  //
+  // The event carries `to` directly, so it cannot be outrun by its own
+  // refetch. This is the same move `userTopic.ts` already makes three lines
+  // above that refetch — `patchHomeNetwork(payload.network)`, added by REV-J
+  // M15 to close "the temporal window where Sidebar saw the new state but
+  // HomePane hadn't yet". Bucket D was the last consumer still sampling.
   const lastConnectionState = new Map<string, string>();
   onIdentityChange(() => lastConnectionState.clear());
+
+  // The single transition test. `prev === undefined` (first sighting of a
+  // slug) is deliberately NOT a transition: the operator may open the app
+  // with a network already parked, and bouncing them off a window they chose
+  // to look at is not a redirect, it is a hijack.
+  const observeConnectionState = (slug: string, curr: string): void => {
+    const prev = lastConnectionState.get(slug);
+    lastConnectionState.set(slug, curr);
+    if (prev === undefined) return;
+    if (curr === prev) return;
+    if (curr !== "parked" && curr !== "failed") return;
+    untrack(() => {
+      const sel = selectedChannel();
+      if (!sel) return;
+      if (sel.networkSlug !== slug) return;
+      setSelectedChannel({
+        networkSlug: HOME_WINDOW_SLUG,
+        channelName: HOME_WINDOW_NAME,
+        kind: "home",
+      });
+    });
+  };
+
+  /**
+   * FEED 2 — a `connection_state_changed` event, straight from the wire.
+   *
+   * Called by `userTopic.ts` with `payload.network_slug` / `payload.to`
+   * BEFORE the refetch it also triggers, so a park shorter than one
+   * round-trip is still observed. Writes the same Map the sample does, so
+   * the sample that lands afterwards sees `curr === prev` and does not
+   * redirect a second time.
+   */
+  const noteConnectionState = (slug: string, to: string): void => {
+    observeConnectionState(slug, to);
+  };
 
   createEffect(() => {
     const nets = networks();
@@ -782,22 +846,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     }
     for (const net of nets) {
       if (net.kind !== "user") continue;
-      const prev = lastConnectionState.get(net.slug);
-      const curr = net.connection_state;
-      lastConnectionState.set(net.slug, curr);
-      if (prev === undefined) continue;
-      if (curr === prev) continue;
-      if (curr !== "parked" && curr !== "failed") continue;
-      untrack(() => {
-        const sel = selectedChannel();
-        if (!sel) return;
-        if (sel.networkSlug !== net.slug) return;
-        setSelectedChannel({
-          networkSlug: HOME_WINDOW_SLUG,
-          channelName: HOME_WINDOW_NAME,
-          kind: "home",
-        });
-      });
+      observeConnectionState(net.slug, net.connection_state);
     }
   });
 
@@ -973,6 +1022,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     applySeedEnvelope,
     setCursorIfAdvances,
     followQueryNick,
+    noteConnectionState,
   };
 });
 
@@ -989,3 +1039,4 @@ export const setServerSeedCount = exports.setServerSeedCount;
 export const applySeedEnvelope = exports.applySeedEnvelope;
 export const setCursorIfAdvances = exports.setCursorIfAdvances;
 export const followQueryNick = exports.followQueryNick;
+export const noteConnectionState = exports.noteConnectionState;

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -39,7 +39,7 @@ import { clearSeen } from "./reconnectBackfill";
 import { setReconnecting } from "./reconnectingStatus";
 import { applyRecoverProgress, applyRecoverResult } from "./recoverProgress";
 import { purgeScrollback } from "./scrollback";
-import { selectedChannel, setSelectedChannel } from "./selection";
+import { noteConnectionState, selectedChannel, setSelectedChannel } from "./selection";
 import { setServerReply } from "./serverReplyModal";
 import { applyServerSettings } from "./serverSettings";
 import { joinUser } from "./socket";
@@ -994,6 +994,16 @@ moduleRoot(() => {
           // its row from the same event, eliminating the temporal window
           // where Sidebar saw the new state but HomePane hadn't yet.
           patchHomeNetwork(payload.network);
+          // issue 2059 — hand selection.ts the transition from the EVENT,
+          // before the refetch below. Bucket D used to derive the transition
+          // by sampling `networks()`, i.e. the answer to that refetch, and a
+          // sample cannot see a park shorter than one round-trip: on
+          // `/reconnect` the GET issued here can be answered after the
+          // credential already reads `connected` again, so the sampled
+          // sequence is ["connected", "connected"] and the home redirect is
+          // silently lost. Same move as `patchHomeNetwork` on the line above,
+          // for the same reason and against the same window.
+          noteConnectionState(payload.network_slug, payload.to);
           refetchNetworks();
           // #100 — clear a stuck "reconnecting…" badge on a SETTLED state.
           // The badge is set on connection_progress "connecting" and cleared

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52354,3 +52354,124 @@ module's subject rather than this issue's.
 
 `GrappaWeb.Admin.SubjectLabelsTest`, the fourth file, is untouched here — it is
 issue 2065.
+<!-- entry #2059 -->
+
+---
+
+## 2026-09-10 — #2059: the most frequent red in the repo was not a flake, and it was two defects
+
+`cicchetto/e2e/tests/issue1796-reconnect-bounces-network.spec.ts` had gone
+red **17 times since 2026-08**, on branches with nothing to do with it. It
+was rerun past, attributed to branches, and tracked as a flake sixteen
+times. It is not a flake. The spec is honest on both of its assertions, and
+the product fails each of them by a different mechanism.
+
+Sighting 17 (2026-09-10, run `34497776963`) was the first on clean `main`,
+which settles that no branch is NECESSARY to reproduce it; the next run on
+main was green, which settles that it is intermittent rather than healed. A
+green does not acquit the mechanism any more than a red convicts the branch
+that happens to host it — the race is sensitive to main-thread latency, so
+a branch can move its probability without being its cause. Several past
+attributions did not clear that bar.
+
+### Defect A — a sampled transition cannot see a park shorter than the sample
+
+UX-4 bucket D (`selection.ts`) redirects the operator to Home when the
+network they are looking at goes INTO `:parked`. It derived that transition
+by SAMPLING `networks()` — the answer to a GET — against a per-slug Map of
+the previous value:
+
+```ts
+if (curr === prev) continue;                       // ← the redirect died here
+if (curr !== "parked" && curr !== "failed") continue;
+```
+
+`/reconnect` parks and reconnects immediately. Both legs emit
+`connection_state_changed` and each triggers a `refetchNetworks()`, but a
+GET issued at the park leg is not guaranteed to OBSERVE the park: by the
+time the server answers, the credential can already read `connected`
+again. The sampled sequence is then `["connected", "connected"]`,
+`curr === prev`, and the redirect is lost in silence. The measured
+signature at sighting 16 was exactly that — the store never held `parked`.
+
+The cure reads the EVENT, which carries `to` and cannot be outrun by the
+refetch it triggers. That is not a new pattern: `userTopic.ts` already
+makes the same move three lines above that refetch, with
+`patchHomeNetwork(payload.network)`, added by REV-J M15 to close "the
+temporal window where Sidebar saw the new state but HomePane hadn't yet".
+Bucket D was the last consumer still sampling.
+
+**Two feeds, one observer, one memory.** The sample is NOT removed, and
+deleting it would have been the smaller change and the wrong one: Phoenix
+PubSub does not replay, so after a WS gap the refetch is the only evidence
+that a park happened while the client was deaf. Both feeds are load-bearing
+for opposite reasons — the sample survives a lost event, the event survives
+a park shorter than a round-trip. Rather than a second observer with its
+own state to keep in step, both call ONE `observeConnectionState`, which
+owns the only Map: the event writes it first, so the sample that lands
+afterwards sees `curr === prev` and does not fire a second redirect.
+
+### Defect B — a second refetch in flight is dropped, not queued
+
+Measured on the same bench, and NOT the same defect: with two
+`refetchNetworks()` issued back to back, the second GET never leaves.
+`createResource.refetch()` does not start a second fetch while one is in
+flight, so the caller's request is simply lost. Driving the bench with
+three distinct states (`connected` → GET1 `parked` → GET2 `failing`) leaves
+the store on `parked` with the second stubbed answer still queued,
+unconsumed.
+
+It reaches the SAME spec from the other side. That spec asserts the
+operator lands on Home AND that the network section loses its greyed class;
+losing the unpark refetch keeps the parked row in the store, so the section
+stays grey and the Home parked card stays up with nothing scheduled to
+correct it. Curing only A could therefore have left the spec red and looked
+like the cure had failed.
+
+The cure queues a TRAILING refetch: any number of calls arriving during a
+flight collapse into exactly one follow-up, started when that flight ends.
+The invariant worth holding is "a refetch requested after the last state
+change is answered after it" — one trailing run buys that without turning a
+burst of N events into N round-trips.
+
+**The independence is measured, not argued:** unwiring A alone leaves B's
+arm green (mutation M5).
+
+### What the bench had to be taught, three times
+
+Every negative control in the first cut of this bench passed for the wrong
+reason, and the mutation bench is what found all three. This is recorded
+because the failure mode is generic, not specific to this file.
+
+1. The other-network arm fired at a slug absent from the mocked network
+   list, so the first-sighting guard (`prev === undefined`) stopped it
+   before the slug test was ever consulted. Deleting the slug test left it
+   GREEN.
+2. The no-op arm used `connected` → `connected`, which the same-value test
+   stops before the parked/failed gate. Deleting that gate left it GREEN.
+   It now uses `connected` → `failing` (#1675 put `:failing` in the closed
+   set) — a genuine transition of the selected network that is not a park,
+   so only the gate can stop it.
+3. The sibling-defect arm asserted a value the store ALREADY HELD at mount,
+   so `waitFor` returned on its first tick without any GET having answered.
+   Fabricating the swallow left it GREEN. It now ends on a third state the
+   store has never held.
+
+The general rule: **an assertion that holds before the action measures
+nothing, and a control nobody has mutated is a control nobody has tested.**
+
+### Not established, and not to be rounded off
+
+* That the run at sighting 16 took defect A's mode is INFERRED, not
+  measured — the HAR leaves 19 ms of margin. What is measured is that the
+  store never held `parked`, and that the bench reproduces the collapse.
+* Whether either defect is what produced any GIVEN one of the 17 sightings.
+  They are reproduced here store-level; attributing a specific historical
+  red to a specific mechanism is not something this work did.
+* `refetchChannels` and `refetchUser` have the same shape as `refetchNetworks`
+  and are therefore open to defect B. They are NOT changed here: nobody has
+  measured a caller that issues two of them back to back, and serialising a
+  refetch nobody has measured changes timing for callers this slice never
+  looked at.
+
+_cic only. No wire change, no protocol bump, no migration — cic bundle deploy._


### PR DESCRIPTION
`issue1796-reconnect-bounces-network.spec.ts` is the most frequent red in this repo — **17 sightings since 2026-08**, on branches with nothing to do with it, rerun past and tracked as a flake sixteen times. It is not a flake, and it is not one defect. This branch reproduces **two**, deterministically, at store level, and cures both. Work for issue 2059.

---

## Read this before the diff: three limits on what this branch proves

**1. The link to the 17 reds is INFERRED, not measured. The local environment does not reproduce them.**
Both defects are reproduced deterministically store-level and both cures are proven load-bearing by mutation. What is *not* established is that either defect caused any given one of the 17 CI reds. The issue itself already carries this posture for sighting 16 (the HAR leaves 19 ms of margin); nothing here narrows it. The e2e green in CI, if it comes, should not be read as attribution.

**2. The e2e two-arm comparison, stated restricted to what the arms have in common.**
> On the spec `issue1796-reconnect-bounces-network`, 3 executions per arm: **3/3 green with the cures and 3/3 green without**. The local environment does not reproduce the red, so the e2e green is not attributable to the cures. Over the rest of the `--grep` the two arms are not comparable, because different filters were used.

The pre-cure arm was built by reverting every cic file this branch touches to `origin/main` byte-exact (`BASE_IDENTICAL` verified per file) and deleting the one file absent there; `SPEC_UNCHANGED` was verified too, so both arms ran the identical spec. The extra spec in the other arm (`issue1796-cycle-part-rejoin`) is a different verb and has no pre-cure arm at all.

**3. What this branch refuses to claim.**
* That a given historical sighting took defect A's mode, or B's. Not measured; see (1).
* That the e2e spec is cured. It is green, and it was green before — see (2).
* **That `refetchChannels` and `refetchUser` are safe.** They have the SAME shape that makes defect B possible and are deliberately left alone: nobody has measured a caller that issues two of them back to back, and serialising a refetch nobody has measured changes timing for callers this slice never looked at. Named here rather than quietly fixed or quietly ignored.

---

## Defect A — a sampled transition cannot see a park shorter than the sample

UX-4 bucket D (`selection.ts`) redirects the operator to Home when the network they are looking at goes INTO `:parked`. It derived that transition by SAMPLING `networks()` — the answer to a GET — against a per-slug Map:

```ts
if (curr === prev) continue;                       // ← the redirect died here
```

`/reconnect` parks and reconnects immediately. Both legs emit `connection_state_changed` and each triggers a `refetchNetworks()`, but a GET issued at the park leg need not OBSERVE the park: by the time the server answers, the credential can already read `connected` again. The sampled sequence is `["connected", "connected"]` and the redirect is lost in silence — which matches the measured signature at sighting 16, where the store never held `parked`.

The cure reads the EVENT, which carries `to` and cannot be outrun by the refetch it triggers. Not a new pattern: `userTopic.ts` already makes the same move three lines above that refetch (`patchHomeNetwork`, REV-J M15, added to close "the temporal window where Sidebar saw the new state but HomePane hadn't yet"). Bucket D was the last consumer still sampling.

**Two feeds, one observer, one memory.** The sample is NOT removed — Phoenix PubSub does not replay, so after a WS gap the refetch is the only evidence a park happened while the client was deaf. Both feeds call one `observeConnectionState`, which owns the only Map, so the event writes it first and the later sample sees `curr === prev` rather than firing a second redirect.

## Defect B — a second refetch in flight is dropped, not queued

Measured, not inherited from the issue text: with two `refetchNetworks()` back to back the second GET never leaves. Driving the bench with three distinct states (`connected` → GET1 `parked` → GET2 `failing`) leaves the store on `parked`, second stubbed answer still queued, unconsumed.

It reaches the SAME spec from the other side — that spec asserts the operator lands on Home AND that the network section loses its greyed class, and losing the unpark refetch keeps the parked row in the store. Curing only A could have left it red for this reason and looked like the cure had failed.

Cure: a TRAILING refetch. Any number of calls during a flight collapse into exactly one follow-up started when that flight ends — "a refetch requested after the last state change is answered after it", without turning N events into N round-trips.

**Independence is measured, not argued:** unwiring A alone leaves B's arm green (mutation M5 below).

## Mutation bench — every assert is load-bearing

Run on the final tree with `node_modules` reconciled to the lockfile.

| Mutation | Red arm | Others |
|---|---|---|
| M0 — unmutated control | none | 4/4 green |
| M1 — unwire cure A | `redirects to home when the park is only ever visible in the event` | 3 green |
| M2 — drop the slug test | `does NOT redirect when a DIFFERENT network parks` | 3 green |
| M3 — drop the parked/failed gate | `does NOT redirect on a connected → failing transition` | 3 green |
| M4 — unwire cure B | `ends on the SECOND answer when two refetches are issued back to back` | 3 green |
| M5 — unwire A only | `redirects to home …` only; **B stays green** | 3 green |

### The bench had to be taught three times, and that is the transferable part

Every negative control in the first cut passed for the wrong reason; the mutation bench found all three.

1. The other-network arm fired at a slug absent from the mocked list, so the first-sighting guard (`prev === undefined`) stopped it before the slug test. Deleting the slug test left it GREEN.
2. The no-op arm used `connected` → `connected`, stopped by the same-value test before the park gate. Deleting the gate left it GREEN. It now uses `connected` → `failing` (#1675 put `:failing` in the closed set).
3. The sibling arm asserted a value the store ALREADY held at mount, so `waitFor` returned on its first tick with no GET having answered. Fabricating the swallow left it GREEN. It now ends on a third state the store has never held.

**An assertion that holds before the action measures nothing; a control nobody has mutated is a control nobody has tested.**

## Gates

| Gate | rc | Result |
|---|---|---|
| `bun.sh run test` | 0 | 346/346 files, **6985/6985 tests** |
| `bun.sh run check` | 0 | 5 stages, 0 failed |
| `design-notes-gate.sh` | 0 | `1 new entry heading(s), separator and marker present.` |
| e2e `#1796` ×3, with cures | — | `6 passed` (see limit 2 for how to read this) |
| e2e ×3, pre-cure tree | — | `3 passed` (see limit 2) |

The full `scripts/integration.sh` suite is running as this is opened; it is the ship gate and its result will be reported on the PR.

**One caveat on the earlier local runs, disclosed rather than buried:** the first measurements ran with 22 packages off-lock (inherited from a cloned `node_modules`), including `solid-js 1.9.14` instead of `1.9.15` — the very library whose `createResource` behaviour defect B describes. The lock-drift stage says outright that verdicts taken in that state are not attributable to the code, so those runs were **discarded** and everything above was re-measured after reconciling.

## Shape

cic only. No wire change, no protocol bump, no migration — cic bundle deploy.
