### PR TITLE
test(2064): count the queries these three tests caused, not the whole VM

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52264,3 +52264,93 @@ icon badge and the `document.title` mirror; the in-app sidebar counters were
 not audited. `installNotificationDismiss` being non-idempotent is fine — the
 sibling `installPushTargetListener` is equally so, `main.tsx` calls each once,
 and the sweep is idempotent regardless.
+<!-- entry #2064 -->
+
+---
+
+## 2026-09-10 — issue 2064: three more blind windows, and the harness this log asked for is the wrong shape
+
+The entry above closed by naming four test files that attach to
+`[:grappa, :repo, :query]` with no filter at all, and by saying that "the shape
+they share argues for one test-support harness rather than four one-line
+patches." Three of those four are cured here — one line per attach site, no
+harness. This entry records why that sentence is withdrawn, and one thing both
+it and the issue got wrong about the mechanism.
+
+### The mechanism is the GLOBAL attach, not the shared sandbox
+
+The 2060 entry and issue 2064's body both attribute the leak to `async: false`
+putting the Ecto sandbox in SHARED mode, so a stranger's query runs on the
+test's own connection. That is true of two of the three files, and it is not
+the mechanism. `WindowCountsTest` is `async: true` — it owns its connection and
+no stranger can borrow it — and its counter is contaminated all the same,
+because `:telemetry.attach/4` is VM-global: the handler fires for every emitter
+in the node, whatever connection, whatever sandbox owner, whatever test the
+query belongs to. Shared mode decides who may USE the connection; it decides
+nothing about who is HEARD. Under `async: true` the strangers are just the
+other async tests running concurrently.
+
+That distinction is what a later reader needs. "Make the file `async: false`"
+is not a cure for this class, and an `async: true` file is not exempt from it.
+
+### Measured, two-sided
+
+The bench: one ambient stranger injected inside each helper, before the subject
+runs — a bare `spawn`ed process (so no `$callers`, the shape of a sweeper or a
+`Session.Server`), allowed on the sandbox, running
+`Repo.transaction(fn -> Repo.query!("SELECT 1") end)`. Built, measured, and
+removed; it is in no commit.
+
+| state | failures |
+|---|---|
+| before any change, no stranger | 0 / 232 tests |
+| blind counter + stranger | **8** — `WindowCountsTest` 2, `ScrollbackTest` 5, `NickMigrationTest` 1 |
+| `self() == test_pid` + stranger | 0 |
+| `self() == test_pid`, stranger removed | 0 / 232 tests |
+
+So each file still carries a live positive control inside its own asserts: the
+predicate keeps exactly the work the pinned numbers describe, and blinding it
+again turns eight of them red.
+
+Issue 2064's table reports `ScrollbackTest` at 6, not 5. Six tests reach that
+file's two helpers; the sixth is the `rename_dm_peer` plan test, which picks
+its statement out of the captured list by CONTENT (`Enum.find` on an
+`UPDATE ... "dm_with" =`) rather than by position, so an added stranger cannot
+displace it. Whether the earlier bench differed in shape or in injection point
+is unknown; 5 is what this instrument measures and it is not offered as a
+refutation of 6.
+
+### Why one line each, and not the harness
+
+Four attach sites, not three — `ScrollbackTest` has a plural twin
+(`capture_queries/1`) beside `capture_one_query/1`. What the four share is the
+PREDICATE, one expression. What they do not share is everything else: the
+payload is a bare tick, a `{sql, params}` pair, or a lowercased statement; the
+drain is a counter, an ordered list, or a reversed list; the handler id is a
+`{__MODULE__, ref}` tuple in two files and an interpolated string in the third.
+A harness would have to be parameterised on payload and on drain, which is the
+entire body — it would share the twelve lines that differ in order to share the
+one that does not. Lightweight over heavyweight (CLAUDE.md design discipline
+(4)): the mechanism would be heavier than the problem, so the mechanism would
+BE the problem. The measured cure is four guarded handler bodies.
+
+### What is not claimed
+
+`capture_queries/1` is cured for CONSISTENCY, not on a measured red — its one
+caller is content-addressed, as above. Leaving one blind attach beside a cured
+one in the same file would leave two patterns for the next caller to copy, and
+the next caller may well index by position.
+
+`NickMigrationTest`'s second oracle (`refute transaction_statements(...) == []`,
+the complement that stops the fix degrading into "never transact") asserts
+PRESENCE, so a stranger's savepoint can only mask a regression there, never
+manufacture one. The blind-counter red on its sibling proves the stranger's
+savepoint does enter the list; that the masking direction is therefore reachable
+is an inference from that measurement, not a separate measurement. It was not
+probed, deliberately: `Grappa.NickMigration`'s own moduledoc already records
+that no test can kill a mutant deleting `immediate_transaction/1` today, for a
+reason independent of this one, and the strength of that oracle is that
+module's subject rather than this issue's.
+
+`GrappaWeb.Admin.SubjectLabelsTest`, the fourth file, is untouched here — it is
+issue 2065.

--- a/test/grappa/nick_migration_test.exs
+++ b/test/grappa/nick_migration_test.exs
@@ -26,9 +26,17 @@ defmodule Grappa.NickMigrationTest do
   alias Grappa.IRC.Identifier
   alias Grappa.{NickMigration, QueryWindows, Scrollback, UserSettings}
 
-  # Every SQL statement Ecto reports while `fun` runs, lowercased. `async:
-  # false` because the handler is global: a concurrent test's queries would
-  # land in this list and the counts below would stop meaning anything.
+  # Every SQL statement THIS TEST CAUSED while `fun` runs, lowercased.
+  #
+  # `async: false` keeps concurrent tests out of the window, but it is not
+  # sufficient and never was (issue 2064): `:telemetry.attach/4` is VM-global,
+  # so an ambient process — a sweeper, a `Session.Server` — emits into this
+  # list too, and shared mode means it does so on this very connection. One
+  # stray transaction is enough to invert the oracle below, because a
+  # savepoint this test did not cause reads exactly like the write lock it
+  # exists to forbid. A handler runs INSIDE the emitting process, so
+  # `self() == test` is the attribution; `$callers` is not consulted because
+  # `peer_renamed/5` runs in the test process.
   defp capture_sql(fun) do
     ref = make_ref()
     test = self()
@@ -36,7 +44,9 @@ defmodule Grappa.NickMigrationTest do
     :telemetry.attach(
       "nm-sql-#{inspect(ref)}",
       [:grappa, :repo, :query],
-      fn _, _, %{query: query}, _ -> send(test, {ref, String.downcase(query)}) end,
+      fn _, _, %{query: query}, _ ->
+        if self() == test, do: send(test, {ref, String.downcase(query)})
+      end,
       nil
     )
 

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -167,11 +167,20 @@ defmodule Grappa.ScrollbackTest do
     rows |> List.flatten() |> Enum.map_join("\n", &to_string/1)
   end
 
-  # Returns the single `{sql, params}` Ecto emitted while `fun` ran. Ecto
+  # Returns the single `{sql, params}` THIS TEST CAUSED while `fun` ran. Ecto
   # publishes `[:grappa, :repo, :query]` synchronously in the caller process,
   # so the capture needs no synchronisation. Matching on ONE query is part of
   # the contract: if `count_after_split/6` ever becomes multi-statement, this
   # raises instead of silently pinning whichever statement came last.
+  #
+  # Which is exactly why the attribution is load-bearing here (issue 2064).
+  # `:telemetry.attach/4` is VM-global and hears every emitter in the node;
+  # this file is `async: false`, so the sandbox is SHARED and a stranger's
+  # statement runs on this test's own connection. A handler runs INSIDE the
+  # emitting process, so `self() == test_pid` keeps only what this test
+  # caused — without it a single ambient query turns the one-query contract
+  # into a `MatchError` that names the wrong culprit. `$callers` is
+  # deliberately not consulted: the subject runs in the test process.
   defp capture_one_query(fun) do
     ref = make_ref()
     test_pid = self()
@@ -179,7 +188,9 @@ defmodule Grappa.ScrollbackTest do
     :telemetry.attach(
       {__MODULE__, ref},
       [:grappa, :repo, :query],
-      fn _, _, meta, _ -> send(test_pid, {ref, meta.query, meta.params}) end,
+      fn _, _, meta, _ ->
+        if self() == test_pid, do: send(test_pid, {ref, meta.query, meta.params})
+      end,
       nil
     )
 
@@ -197,6 +208,13 @@ defmodule Grappa.ScrollbackTest do
   # is deliberately MULTI-statement (`rename_dm_peer/4` emits a count plus two
   # `update_all`s). Returns them in emission order, so a test can pick the one
   # whose plan it means to pin instead of pinning whichever came last.
+  #
+  # Carries the same `self() == test_pid` attribution as its singular twin,
+  # and for consistency rather than on a measured red: its one caller picks
+  # its statement by CONTENT (`Enum.find` on an `UPDATE ... "dm_with" =`), so
+  # an ambient stranger cannot displace it today. Leaving one blind attach
+  # beside a cured one would leave two patterns in one file for the next
+  # caller to copy from, and the next caller may well index by position.
   defp capture_queries(fun) do
     ref = make_ref()
     test_pid = self()
@@ -204,7 +222,9 @@ defmodule Grappa.ScrollbackTest do
     :telemetry.attach(
       {__MODULE__, ref},
       [:grappa, :repo, :query],
-      fn _, _, meta, _ -> send(test_pid, {ref, meta.query, meta.params}) end,
+      fn _, _, meta, _ ->
+        if self() == test_pid, do: send(test_pid, {ref, meta.query, meta.params})
+      end,
       nil
     )
 

--- a/test/grappa/window_counts_test.exs
+++ b/test/grappa/window_counts_test.exs
@@ -833,8 +833,18 @@ defmodule Grappa.WindowCountsTest do
     subject
   end
 
-  # Counts `[:grappa, :repo, :query]` telemetry events emitted while `fun`
+  # Counts the `[:grappa, :repo, :query]` events THIS TEST CAUSED while `fun`
   # runs (Ecto emits one per statement, synchronously in the caller process).
+  #
+  # The attribution is the point (issue 2064). `:telemetry.attach/4` is
+  # VM-global: it hears every emitter in the node, and no sandbox mode gates
+  # that — under `async: true` the strangers are the other async tests running
+  # concurrently on their own connections. A handler runs INSIDE the emitting
+  # process, so `self()` here IS the emitter and `self() == test_pid` keeps
+  # exactly the statements this test is paying for. `$callers` is deliberately
+  # NOT consulted: `bulk_snapshot/4` runs in the test process, so `self()`
+  # suffices, and widening the predicate would start counting work spawned by
+  # the test that the pinned number does not describe.
   defp count_repo_queries(fun) do
     ref = make_ref()
     test_pid = self()
@@ -842,7 +852,7 @@ defmodule Grappa.WindowCountsTest do
     :telemetry.attach(
       {__MODULE__, ref},
       [:grappa, :repo, :query],
-      fn _, _, _, _ -> send(test_pid, {ref, :q}) end,
+      fn _, _, _, _ -> if self() == test_pid, do: send(test_pid, {ref, :q}) end,
       nil
     )
 


### PR DESCRIPTION
Refs issue 2064.

Four attach sites across three test files listened to
`[:grappa, :repo, :query]` with no filter and then pinned something on the
result: a constant-2 query count, a one-query match that raises on the second,
and a transaction-statement list read as "did this path take the write lock".
Anything the node emitted inside the window landed in all three.

The cure is `self() == test_pid`, evaluated in the handler — telemetry runs it
INSIDE the emitting process, so `self()` there IS the emitter. `$callers` is
deliberately not consulted: all three subjects run in the test process.

## Four cures, three measured reds — read this before the diff

There are four attach sites and only three of them have an observed defect.
The fourth, `ScrollbackTest.capture_queries/1`, **has no measured red: it is
cured for consistency, not for an observed defect.** Its one caller picks its
statement out of the captured list by CONTENT (`Enum.find` on an
`UPDATE ... "dm_with" =`) rather than by position, so an ambient stranger
cannot displace it today.

It is cured anyway because it is the plural twin of `capture_one_query/1` in
the SAME FILE, and CLAUDE.md is explicit: "Total consistency or nothing.
Half-migrated creates two patterns — Claude copies whichever is closer." A
blind attach left standing beside a cured one is a pattern the next caller
copies, and the next caller may well index by position.

## This PR retracts a sentence in a DESIGN_NOTES entry that is already on main

The entry for issue 2060 closed by saying the blind-window files "argue for one
test-support harness rather than four one-line patches". That is withdrawn
here, by the person who wrote it, on the strength of a measurement taken after
it (below).

**The entry for issue 2060 is NOT edited.** A dated entry is history and stays
put; the cure for a claim in the log is a NEW entry that names the retraction
and carries the measurement, never a find-and-replace on the past. So the
DESIGN_NOTES diff here is append-only and the two entries are meant to be read
in order — the second withdraws the first's closing sentence, and says so. If
you read them as contradicting each other, that is the retraction working, not
a merge accident.

## A premise of the issue is wrong, and it matters

The issue (and the DESIGN_NOTES entry for issue 2060) attribute the leak to
`async: false` putting the sandbox in SHARED mode. Measured: `WindowCountsTest`
is `async: true` — it owns its connection, no stranger can borrow it — and it
is contaminated all the same, because `:telemetry.attach/4` is VM-global. It
fires for every emitter in the node, whatever connection the query ran on.
Shared mode decides who may USE the connection; it decides nothing about who is
HEARD.

Consequence for the next reader: "make the file `async: false`" is not a cure
for this class, and an `async: true` file is not exempt from it.

## Measured, two-sided

Bench: one ambient stranger injected in each helper before the subject runs — a
bare `spawn`ed process (no `$callers`, the shape of a sweeper or a
`Session.Server`), allowed on the sandbox, running
`Repo.transaction(fn -> Repo.query!("SELECT 1") end)`. Built, measured,
removed; it is in no commit.

| state | failures |
|---|---|
| before any change, no stranger | 0 / 232 tests |
| blind counter + stranger | **8** — WindowCounts 2, Scrollback 5, NickMigration 1 |
| `self() == test_pid` + stranger | 0 |
| `self() == test_pid`, stranger removed | 0 / 232 tests |

So each file keeps a live positive control inside its own asserts.

Full gate green on this sha from the worktree: `CHECK_RC=0`, 7260 tests /
0 failures, bats 764 ok / 0 not ok.

## Where this disagrees with the issue's table

Issue 2064 reports Scrollback at 6, this instrument measures 5. The sixth is
the content-addressed test described above. The earlier bench was removed and
its injection point is unknown, so 5 is reported as this instrument's number,
not as a refutation of 6 — two instruments that count different things do not
correct each other.

## No shared harness, on purpose

Four sites, not three. What they share is one expression; the payload (bare
tick / `{sql, params}` / lowercased statement), the drain (counter / ordered
list / reversed list) and the handler id (tuple in two files, interpolated
string in the third) all differ. A harness would be parameterised on everything
that differs in order to share the one thing that does not — heavier than the
problem it solves.

## Also not claimed

`NickMigrationTest`'s second oracle asserts PRESENCE, so a stranger's savepoint
can only mask a regression there, never manufacture one. That the stranger's
savepoint enters the list is measured (the sibling's red); that the masking
direction is reachable is inferred from it, not separately measured. Not probed
on purpose: `Grappa.NickMigration`'s moduledoc already records that the
`immediate_transaction/1` mutant is unkillable today for an independent reason.

`GrappaWeb.Admin.SubjectLabelsTest` is untouched — that is issue 2065.

No production file is touched: three test files plus DESIGN_NOTES.