### PR TITLE
push: make the delivered send and the withheld one observable (issue 2067)

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52503,14 +52503,23 @@ needed three RPCs into a running node.
 `config/prod.exs` pins `:info` and `config/runtime.exs` defaults `LOG_LEVEL`
 to the same — so a `debug` line answers the operator's question exactly as
 badly as the silence did for anyone who has not already reconfigured their
-logger, which is everyone at the moment they need it. The counter-argument
-is volume, and it does not survive contact with the trigger conditions: a
-delivery happens only when a message passes `should_notify?/5` AND no device
-of that subject has the PWA on-screen, so `push.send delivered` is one line
-per notification per registered device, not one per IRC message. A
-suppression is bounded the same way from the other side. The sibling
+logger, which is everyone at the moment they need it. The sibling
 `push.send subscription gone — deleted` has sat at `info` since B2 for the
 same class of event, so `info` is also what the module already does.
+
+The counter-argument is volume, and the first draft of this entry answered
+it wrongly. It claimed the lines are "one per notification, not one per IRC
+message", which holds only for the DEFAULT prefs. `channel_messages_all` is
+a real pref and `channel_match?/4` returns `true` unconditionally when it is
+set, so an operator who turns it on has asked for a notification per channel
+message and gets a log line per channel message to match — `push.send
+delivered` while their devices are backgrounded, `push.trigger suppressed`
+while the PWA is on-screen. The honest statement is that the PREFS set the
+rate: the defaults (`channel_messages_all: false`, `channel_mentions: true`,
+`private_messages_all: true`) need a DM or a mention and are rare,
+`channel_messages_all` needs nothing and is not, and `LOG_LEVEL` is the knob
+for anyone who does not want the consequence of their own pref. Stated
+rather than bounded away, because the level decision above rests on it.
 
 ### What was NOT added, and why
 
@@ -52522,12 +52531,36 @@ rate belongs. A per-subscription success counter would restate a number the
 aggregate already has, which is design-discipline (1): derive, do not
 duplicate. Only the LOG half of that half of the issue was missing.
 
-No new Logger metadata key. `:reason`, `:subject_kind`, `:user_id`,
-`:visitor_id` and `:endpoint` are all already in the `config/config.exs`
-`:metadata` allowlist, so this slice edits no config file at all. That
-matters twice: an undeclared key is dropped at FORMAT time (the call site
-compiles, the line fires, the operator reads it bare), and any touch of
-`config/*.exs` turns a hot deploy cold. Reusing declared keys buys both.
+No new Logger metadata key. `:reason`, `:network`, `:subject_kind`,
+`:user_id`, `:visitor_id` and `:endpoint` are all already in the
+`config/config.exs` `:metadata` allowlist, so this slice edits no config file
+at all. That matters twice: an undeclared key is dropped at FORMAT time (the
+call site compiles, the line fires, the operator reads it bare), and any
+touch of `config/*.exs` turns a hot deploy cold. Reusing declared keys buys
+both — and it is also what decided the two shapes below.
+
+`:network` on the suppression line but not `:channel`, though `:channel` is
+allowlisted too and the message path knows it. One reporter serves both
+doors and the presence door has no channel, so taking it would either split
+the reporter in two or print an empty field half the time. The network is
+the context both doors carry, and on a multi-network bouncer it is what
+turns "something was withheld" into "something was withheld on azzurra".
+
+`endpoint:` stays the full vendor URL on the delivered line, and that is a
+call worth naming rather than leaving to be discovered. A Web Push endpoint
+is a CAPABILITY — holding it lets anyone POST to that device — and while it
+already rode all of this function's failure arms, the frequency now goes
+from broken subscriptions only to every successful delivery, into a stdout
+that persists across restarts and ships out with any log forwarder. The
+alternatives are what settled it. `Push.VendorLog` logs the host alone
+(#1321, "a path segment can itself be a credential") and can afford to
+precisely because its own moduledoc names THIS line as the correlation
+anchor; host-only here would leave nothing to anchor to and could not
+separate two iPhones on `web.push.apple.com`, which is the multi-device case
+the line exists for. A subscription row id would be the clean answer and
+costs a new metadata key, hence a cold deploy. If the exposure is judged to
+outweigh the correlation, the cure is `:vendor` here too plus that id, the
+next time something else is already paying for a cold deploy.
 
 ### One reporter, two doors, and the ordering that carries the meaning
 
@@ -52579,6 +52612,19 @@ root cause of a socket stuck at `visible` is untouched and remains open.
 rather than a bare `:foreground_visible` literal because it is published on
 the telemetry metadata; no second reason is anticipated, and none is
 invented here to justify the shape.
+
+`[:grappa, :push, :suppressed]` counts withheld TRIGGER DISPATCHES, not
+undelivered pushes, and the difference is a real population: a subject with
+the PWA open and NO registered device is counted, though
+`Sender.send_to_subject/2` would have hit its empty-list arm and sent
+nothing either way. Deliberate, on a layering argument — this module decides
+whether to dispatch, `Push.Sender` owns what a dispatch reaches — and on
+cost: separating them means a `push_subscriptions` read on EVERY
+suppression, which under `channel_messages_all` is per channel message, to
+answer a question the device-list UI already answers directly. Anyone
+reading the counter as "pushes the user did not get" is reading it wrong,
+which is why the moduledoc says what it measures instead of posing the
+looser question the first draft posed.
 
 The rendered-output tests lower the global Logger level and therefore live
 in their own `async: false` file (`push/observability_log_test.exs`),

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52475,3 +52475,110 @@ nothing, and a control nobody has mutated is a control nobody has tested.**
   looked at.
 
 _cic only. No wire change, no protocol bump, no migration — cic bundle deploy._
+<!-- entry #2067 -->
+
+---
+
+## 2026-09-10 — issue 2067: the delivered push and the withheld one both said nothing
+
+Two paths through the push stack produced no output of any kind, and the
+absence of output was read — correctly, given what the code offered — as
+absence of work. `Push.Sender.send_to_subscription/2`'s vendor-2xx arm
+returned without a `Logger` line while all four of its siblings logged, and
+the `#182` foreground gate in `Push.Triggers` skipped an entire fan-out
+inside a bare `if`, with neither a line nor a counter. So an operator with
+no notification on their phone and an empty `journalctl -u grappa | grep
+push` could not distinguish three quite different situations: the trigger
+never fired, the trigger fired and the gate held the push back, or the push
+was delivered and the phone dropped it. The issue was filed off a live
+debugging session where the answer turned out to be the second — a
+client socket stuck reporting the foreground — and reaching that answer
+needed three RPCs into a running node.
+
+### The level is the decision, not a detail
+
+`info`, for both lines. `debug` is below the default bar on every substrate
+we ship, so a `debug` line answers the operator's question exactly as badly
+as the silence did for anyone who has not already reconfigured their
+logger — which is everyone, at the moment they need it. The counter-argument
+is volume, and it does not survive contact with the trigger conditions: a
+delivery happens only when a message passes `should_notify?/5` AND no device
+of that subject has the PWA on-screen, so `push.send delivered` is one line
+per notification per registered device, not one per IRC message. A
+suppression is bounded the same way from the other side. The sibling
+`push.send subscription gone — deleted` has sat at `info` since B2 for the
+same class of event, so `info` is also what the module already does.
+
+### What was NOT added, and why
+
+No success telemetry. The issue's text reads the existing events as
+error-only (`"Telemetry fires on the error paths (:222, :246, :304)"`), but
+`[:grappa, :push, :send, :stop]` carries `%{success: x, gone: y, error: z}`
+— the success axis is already exported, at the fan-out aggregate where a
+rate belongs. A per-subscription success counter would restate a number the
+aggregate already has, which is design-discipline (1): derive, do not
+duplicate. Only the LOG half of that half of the issue was missing.
+
+No new Logger metadata key. `:reason`, `:subject_kind`, `:user_id`,
+`:visitor_id` and `:endpoint` are all already in the `config/config.exs`
+`:metadata` allowlist, so this slice edits no config file at all. That
+matters twice: an undeclared key is dropped at FORMAT time (the call site
+compiles, the line fires, the operator reads it bare), and any touch of
+`config/*.exs` turns a hot deploy cold. Reusing declared keys buys both.
+
+### One reporter, two doors, and the ordering that carries the meaning
+
+`Triggers` has two dispatch paths — the message one and the `/notify`
+presence one — and both end at the same gate. They report through a single
+`report_suppressed/2` emitting a single `[:grappa, :push, :suppressed]`
+event, rather than one event per path: an operator asking "how often is
+push being held back?" must not have to add two counters, and two call sites
+maintaining two spellings of the same event is exactly how they drift.
+
+The gate stays the SECOND conjunct of the `and` at both call sites, and that
+placement is now load-bearing rather than incidental. Short-circuit
+evaluation means a message the prefs never matched never reaches the gate
+and therefore cannot be counted as suppressed. Reversing the conjuncts would
+leave the code delivering identically while making the new event report
+every non-notify-worthy PRIVMSG as a withheld push — the old lie, in a
+louder voice. Three tests pin it from both sides: a visible device with a
+matching message emits the event, a visible device with a NON-matching
+message emits nothing, and a delivered fan-out emits nothing either.
+
+Inside the reporter, the `Logger` call precedes `:telemetry.execute/3`, also
+deliberately. Anything observing the counter is then guaranteed the message
+is already on its way to the handlers, so the two halves of one withholding
+can be correlated without a sleep — which is what lets the test capture the
+rendered line out of a detached Task deterministically.
+
+### Why the delivered line sits above `touch_last_used/1`
+
+The fact being reported is the vendor 2xx, and it has already happened by
+the time the row-bump runs. Logging inside the `{:ok, _}` sub-arm would mean
+a failed `touch_last_used/1` erases the record of a delivery that did occur,
+leaving the bump's own warning as the only trace of a SUCCESSFUL send — a
+smaller version of the bug being fixed.
+
+### What is not claimed
+
+Nothing here changes what is delivered; every branch returns exactly what it
+returned before, and the boolean the gate produces is unchanged. This is an
+observability slice and it fixes no delivery defect.
+
+The reported incident is not reproduced. The self-hoster's always-visible
+socket (instance `h-irc`, 1.5.5) is described in the issue and taken as
+given; nothing was measured against that instance or any production node
+from here, and whether these two lines would in fact have shortened that
+evening is an inference from what they now print, not an observation. The
+root cause of a socket stuck at `visible` is untouched and remains open.
+
+`suppression_reason()` has one member. It is a closed type with one atom
+rather than a bare `:foreground_visible` literal because it is published on
+the telemetry metadata; no second reason is anticipated, and none is
+invented here to justify the shape.
+
+The rendered-output tests lower the global Logger level and therefore live
+in their own `async: false` file (`push/observability_log_test.exs`),
+following `client_tls_posture_log_test.exs`. They assert the FORMATTED line,
+which is the only thing that can catch an allowlist drop; the behaviour they
+sit next to — that the gate suppresses at all — stays pinned where it was.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52484,7 +52484,9 @@ _cic only. No wire change, no protocol bump, no migration — cic bundle deploy.
 Two paths through the push stack produced no output of any kind, and the
 absence of output was read — correctly, given what the code offered — as
 absence of work. `Push.Sender.send_to_subscription/2`'s vendor-2xx arm
-returned without a `Logger` line while all four of its siblings logged, and
+returned without a `Logger` line while every OTHER arm of the same `case`
+logged (five calls, not the four the issue enumerates — it misses the
+`delete_dead` `:db_unavailable` degradation), and
 the `#182` foreground gate in `Push.Triggers` skipped an entire fan-out
 inside a bare `if`, with neither a line nor a counter. So an operator with
 no notification on their phone and an empty `journalctl -u grappa | grep
@@ -52497,10 +52499,11 @@ needed three RPCs into a running node.
 
 ### The level is the decision, not a detail
 
-`info`, for both lines. `debug` is below the default bar on every substrate
-we ship, so a `debug` line answers the operator's question exactly as badly
-as the silence did for anyone who has not already reconfigured their
-logger — which is everyone, at the moment they need it. The counter-argument
+`info`, for both lines. `debug` is below the level this ships at —
+`config/prod.exs` pins `:info` and `config/runtime.exs` defaults `LOG_LEVEL`
+to the same — so a `debug` line answers the operator's question exactly as
+badly as the silence did for anyone who has not already reconfigured their
+logger, which is everyone at the moment they need it. The counter-argument
 is volume, and it does not survive contact with the trigger conditions: a
 delivery happens only when a message passes `should_notify?/5` AND no device
 of that subject has the PWA on-screen, so `push.send delivered` is one line

--- a/lib/grappa/push/sender.ex
+++ b/lib/grappa/push/sender.ex
@@ -126,17 +126,46 @@ defmodule Grappa.Push.Sender do
   so it would leave the operator's question ("did you try to send it or
   not?") answered exactly as badly as before for anyone who has not
   already reconfigured the logger — which is nobody, at the moment they
-  need it. The volume it buys is bounded by construction: a delivery
-  happens only when a message passes `Push.Triggers.should_notify?/5`
-  AND no device of that subject has the PWA on-screen, so the line is
-  one per notification per registered device, not one per IRC message.
-  The sibling `push.send subscription gone — deleted` already sits at
-  `info` for the same class of event.
+  need it. The sibling `push.send subscription gone — deleted` already
+  sits at `info` for the same class of event.
+
+  The volume is set by the subject's PREFS, and it is worth stating
+  honestly rather than waving at. A delivery needs a message that passes
+  `Push.Triggers.should_notify?/5` AND no device with the PWA
+  on-screen. Under the defaults (`channel_messages_all: false`,
+  `channel_mentions: true`, `private_messages_all: true`) that means a
+  DM or a mention, so the line is rare. An operator who turns
+  `channel_messages_all` ON has asked for a notification per channel
+  message, and gets one line per message per registered device to
+  match — the pref sets the rate, and `LOG_LEVEL` is the knob if the
+  consequence is unwanted.
 
   Success TELEMETRY is deliberately NOT added: the fan-out's
   `[:grappa, :push, :send, :stop]` already carries `success:` (see
   "Telemetry shape"), and a per-subscription success counter would
   restate a number the aggregate already has.
+
+  ### The endpoint on the line, at this frequency
+
+  `endpoint:` is the full vendor URL, which is a CAPABILITY: holding it
+  lets anyone POST to that device (they cannot decrypt without the
+  subscription's keys, but they can burn its quota). It already rode all
+  four failure arms of this function; what changes here is FREQUENCY —
+  from broken subscriptions only to every successful delivery — and
+  stdout persists across restarts and ships out with any log forwarder.
+
+  Taken deliberately, and the alternatives were the reason. `Push.VendorLog`
+  logs the HOST alone under `:vendor` (#1321, "a path segment can itself
+  be a credential") and can afford to, because its own moduledoc points
+  at THIS module's line as the correlation anchor; host-only here would
+  leave nothing to anchor to, and could not tell two iPhones on
+  `web.push.apple.com` apart, which is exactly the multi-device case the
+  line exists for. A non-capability handle — the subscription row id —
+  would need a new Logger metadata key, and any `config/*.exs` edit
+  turns a hot deploy cold. So: named, not hidden. If the exposure is
+  judged to outweigh the correlation, the cure is `:vendor` here too and
+  a subscription id once some other change is already paying for a cold
+  deploy.
 
   ## Failure handling — no silent drops
 

--- a/lib/grappa/push/sender.ex
+++ b/lib/grappa/push/sender.ex
@@ -110,6 +110,33 @@ defmodule Grappa.Push.Sender do
       Emitted from `send_to_subscription/2` whenever a 404/410
       response triggers `Push.delete_dead/1`.
 
+  ## What the operator reads (issue 2067)
+
+  Every terminal of `send_to_subscription/2` says something, the
+  DELIVERED one included. It did not until issue 2067: the vendor-2xx
+  arm returned without a line while all four of its siblings logged, so
+  an empty `journalctl -u grappa | grep push` was equally consistent
+  with "delivered fine" and "the sender was never called". That
+  ambiguity cost an evening of live debugging with a self-hoster whose
+  pushes were in fact being delivered — the silence was the whole bug.
+
+  `info`, not `debug`, and the level is the decision rather than a
+  detail. `debug` is below the default bar on every substrate we ship,
+  so it would leave the operator's question ("did you try to send it or
+  not?") answered exactly as badly as before for anyone who has not
+  already reconfigured the logger — which is nobody, at the moment they
+  need it. The volume it buys is bounded by construction: a delivery
+  happens only when a message passes `Push.Triggers.should_notify?/5`
+  AND no device of that subject has the PWA on-screen, so the line is
+  one per notification per registered device, not one per IRC message.
+  The sibling `push.send subscription gone — deleted` already sits at
+  `info` for the same class of event.
+
+  Success TELEMETRY is deliberately NOT added: the fan-out's
+  `[:grappa, :push, :send, :stop]` already carries `success:` (see
+  "Telemetry shape"), and a per-subscription success counter would
+  restate a number the aggregate already has.
+
   ## Failure handling — no silent drops
 
   Per `feedback_no_silent_drops_*`: every per-sub failure path emits
@@ -279,6 +306,14 @@ defmodule Grappa.Push.Sender do
 
     case deliver(ex_nudge_subscription, message) do
       :ok ->
+        # issue 2067 — the one terminal that used to say nothing. Logged
+        # BEFORE `touch_last_used/1` because the fact being reported is the
+        # vendor 2xx, which has already happened: putting it in the `{:ok,
+        # _}` sub-arm would make a failed row-bump erase the record of a
+        # delivery that did occur, and the warning below would then be the
+        # only trace of a SUCCESSFUL send.
+        Logger.info("push.send delivered", endpoint: sub.endpoint)
+
         case Push.touch_last_used(sub) do
           {:ok, _} ->
             :ok

--- a/lib/grappa/push/sender.ex
+++ b/lib/grappa/push/sender.ex
@@ -114,14 +114,15 @@ defmodule Grappa.Push.Sender do
 
   Every terminal of `send_to_subscription/2` says something, the
   DELIVERED one included. It did not until issue 2067: the vendor-2xx
-  arm returned without a line while all four of its siblings logged, so
-  an empty `journalctl -u grappa | grep push` was equally consistent
-  with "delivered fine" and "the sender was never called". That
-  ambiguity cost an evening of live debugging with a self-hoster whose
-  pushes were in fact being delivered — the silence was the whole bug.
+  arm returned without a line while every OTHER arm of the same `case`
+  logged, so an empty `journalctl -u grappa | grep push` was equally
+  consistent with "delivered fine" and "the sender was never called".
+  That ambiguity cost an evening of live debugging with a self-hoster
+  whose pushes were in fact being delivered — the silence was the bug.
 
   `info`, not `debug`, and the level is the decision rather than a
-  detail. `debug` is below the default bar on every substrate we ship,
+  detail. `debug` is below the level this ships at (`config/prod.exs`
+  pins `:info`; `config/runtime.exs` defaults `LOG_LEVEL` to the same),
   so it would leave the operator's question ("did you try to send it or
   not?") answered exactly as badly as before for anyone who has not
   already reconfigured the logger — which is nobody, at the moment they

--- a/lib/grappa/push/triggers.ex
+++ b/lib/grappa/push/triggers.ex
@@ -120,19 +120,43 @@ defmodule Grappa.Push.Triggers do
   reporter (`report_suppressed/2`):
 
     * `[:grappa, :push, :suppressed]` — measurements `%{count: 1}`,
-      metadata `%{subject: Grappa.Subject.t(), reason:
-      t:suppression_reason/0}`. Emitted from the message path and the
-      presence path alike; one event, because an operator asking "how
-      often is push being held back?" must not have to add up two
-      counters.
-    * a `Logger.info` `push.trigger suppressed` line carrying `reason:`
-      plus the subject, which is the half that a 2am grep actually
-      reads.
+      metadata `%{subject: Grappa.Subject.t(), network_slug:
+      String.t(), reason: t:suppression_reason/0}`. Emitted from the
+      message path and the presence path alike; ONE event, because two
+      spellings of the same withholding would have to be added together
+      before they answered anything.
+    * a `Logger.info` `push.trigger suppressed` line carrying `reason:`,
+      `network:` and the subject, which is the half that a 2am grep
+      actually reads.
 
   The DELIVERING answer stays quiet here: `Push.Sender` already emits
   `[:grappa, :push, :send, :start | :stop]` around the fan-out, and a
   second event for the same delivery would be a number to reconcile
   rather than a fact to read.
+
+  ### What the counter measures, exactly
+
+  Withheld TRIGGER dispatches, at this layer — not undelivered pushes.
+  The gate runs before the fan-out and deliberately pays no subscription
+  query, so a subject with the PWA open and NO registered device is
+  counted here even though `Sender.send_to_subject/2` would have hit its
+  empty-list arm and sent nothing either way. That is a boundary, not an
+  oversight: this module decides whether to dispatch, `Push.Sender` owns
+  what a dispatch reaches, and buying the distinction would mean a
+  `push_subscriptions` read on every suppression to answer a question
+  the device-list UI already answers directly.
+
+  ### Volume
+
+  Bounded by the PREFS, and the bound is not the same for everyone. Under
+  the defaults (`channel_messages_all: false`, `channel_mentions: true`,
+  `private_messages_all: true`) a suppression needs a DM or a mention, so
+  the line is rare. An operator who turns `channel_messages_all` ON has
+  asked to be notified for every channel message, and while their PWA is
+  on-screen that is one `:info` line and one event PER received channel
+  message per joined channel. `LOG_LEVEL` is the knob if that is not
+  wanted; the pref is what sets the rate, and it is worth knowing which
+  one you have set before reading the volume.
 
   The gate is the SECOND conjunct of the `and` at both call sites and
   must stay there. Short-circuiting means a message the prefs never
@@ -265,7 +289,7 @@ defmodule Grappa.Push.Triggers do
         # second conjunct so a message the prefs never matched short-circuits
         # away before reaching it and cannot be miscounted as suppressed.
         if should_notify?(message, network_slug, own_nick, prefs, patterns) and
-             not foreground_visible?(subject, subject_label) do
+             not foreground_visible?(subject, subject_label, network_slug) do
           payload = build_payload(message, network_slug, own_nick, subject)
           Push.Sender.send_to_subject(subject, payload)
         end
@@ -311,7 +335,7 @@ defmodule Grappa.Push.Triggers do
         # since issue 2067 it says so, through the SAME reporter as the
         # message path rather than a second event of its own.
         if should_notify_presence?(presence, prefs) and
-             not foreground_visible?(subject, subject_label) do
+             not foreground_visible?(subject, subject_label, network_slug) do
           Push.Sender.send_to_subject(subject, Payload.build_presence(nick, presence, network_slug))
         end
       end)
@@ -413,10 +437,10 @@ defmodule Grappa.Push.Triggers do
   # the reading at the `if` is unchanged and the gate keeps its position as
   # the second conjunct (see the moduledoc: that ordering is what separates
   # "withheld" from "never triggered").
-  @spec foreground_visible?(Subject.t(), String.t()) :: boolean()
-  defp foreground_visible?(subject, subject_label) do
+  @spec foreground_visible?(Subject.t(), String.t(), String.t()) :: boolean()
+  defp foreground_visible?(subject, subject_label, network_slug) do
     if WSPresence.any_visible?(subject_label) do
-      report_suppressed(subject, :foreground_visible)
+      report_suppressed(subject, network_slug, :foreground_visible)
       true
     else
       false
@@ -433,19 +457,30 @@ defmodule Grappa.Push.Triggers do
   # the handlers, so the two halves of a single withholding can be
   # correlated without a sleep.
   #
-  # `:reason`, `:subject_kind`, `:user_id` and `:visitor_id` are ALREADY in
-  # the `config/config.exs` Logger `:metadata` allowlist. That is why this
-  # slice touches no config file: an undeclared key is dropped at FORMAT
-  # time, so a new one would compile, fire, and still print bare — and
-  # editing `config/*.exs` would additionally turn a hot deploy cold.
-  @spec report_suppressed(Subject.t(), suppression_reason()) :: :ok
-  defp report_suppressed(subject, reason) do
-    Logger.info("push.trigger suppressed", [reason: reason] ++ subject_metadata(subject))
+  # `:reason`, `:network`, `:subject_kind`, `:user_id` and `:visitor_id` are
+  # ALREADY in the `config/config.exs` Logger `:metadata` allowlist. That is
+  # why this slice touches no config file: an undeclared key is dropped at
+  # FORMAT time, so a new one would compile, fire, and still print bare —
+  # and editing `config/*.exs` would additionally turn a hot deploy cold.
+  #
+  # `:network` and not `:channel`, even though the message path knows the
+  # channel and the key is allowlisted too: this reporter serves BOTH doors
+  # and the presence one has no channel, so taking it would either split the
+  # reporter in two or make it print an empty field half the time. The
+  # network is the one context both doors carry, and on a multi-network
+  # bouncer it is what turns "something was withheld" into "something was
+  # withheld on azzurra".
+  @spec report_suppressed(Subject.t(), String.t(), suppression_reason()) :: :ok
+  defp report_suppressed(subject, network_slug, reason) do
+    Logger.info(
+      "push.trigger suppressed",
+      [reason: reason, network: network_slug] ++ subject_metadata(subject)
+    )
 
     :telemetry.execute(
       [:grappa, :push, :suppressed],
       %{count: 1},
-      %{subject: subject, reason: reason}
+      %{subject: subject, network_slug: network_slug, reason: reason}
     )
   end
 

--- a/lib/grappa/push/triggers.ex
+++ b/lib/grappa/push/triggers.ex
@@ -106,6 +106,41 @@ defmodule Grappa.Push.Triggers do
   rather than re-deriving from the subject's display name, dodging
   the CP15 H3 account-name-vs-IRC-nick hazard cic-side.
 
+  ## Withholding is an event, not an absence (issue 2067)
+
+  Both dispatch paths end in the same `#182` foreground gate, and until
+  issue 2067 that gate skipped the fan-out in silence. A WITHHELD push
+  and a push that never triggered therefore looked identical from
+  outside — an operator with no notification on their phone and an empty
+  `journalctl … | grep push` had no way to tell "your own client was in
+  the foreground" from "the trigger never fired", which is precisely the
+  pair a live debugging session has to separate first.
+
+  So the suppressing answer reports, on both doors and through ONE
+  reporter (`report_suppressed/2`):
+
+    * `[:grappa, :push, :suppressed]` — measurements `%{count: 1}`,
+      metadata `%{subject: Grappa.Subject.t(), reason:
+      t:suppression_reason/0}`. Emitted from the message path and the
+      presence path alike; one event, because an operator asking "how
+      often is push being held back?" must not have to add up two
+      counters.
+    * a `Logger.info` `push.trigger suppressed` line carrying `reason:`
+      plus the subject, which is the half that a 2am grep actually
+      reads.
+
+  The DELIVERING answer stays quiet here: `Push.Sender` already emits
+  `[:grappa, :push, :send, :start | :stop]` around the fan-out, and a
+  second event for the same delivery would be a number to reconcile
+  rather than a fact to read.
+
+  The gate is the SECOND conjunct of the `and` at both call sites and
+  must stay there. Short-circuiting means a message the prefs never
+  matched never reaches the gate and so can never be counted as
+  suppressed — that ordering IS the distinction this section exists to
+  make, and reversing it would make the new event repeat the old lie in
+  a louder voice.
+
   ## No silent drops
 
   `evaluate_and_dispatch/2` always returns `:ok`. Any failure inside
@@ -118,6 +153,8 @@ defmodule Grappa.Push.Triggers do
   alias Grappa.{Mentions, Push, Subject, UserSettings, WSPresence}
   alias Grappa.Push.Payload
   alias Grappa.Scrollback.Message
+
+  require Logger
 
   # #395 — the notify-worthy kind gate. Reads the shared SSOT subset
   # (`Message.notify_kinds/0` ⊆ `Message.content_kinds/0`) instead of a
@@ -160,6 +197,18 @@ defmodule Grappa.Push.Triggers do
   Boundary cycle. Two atoms are cheaper than either alternative.
   """
   @type presence_kind :: :initial | :transition
+
+  @typedoc """
+  Why a TRIGGERED push was withheld (issue 2067). A closed set with one
+  member today — `:foreground_visible`, the `#182` gate seeing at least
+  one of the subject's devices report the PWA on-screen.
+
+  An atom and not a free string because it is published: it rides the
+  `[:grappa, :push, :suppressed]` telemetry metadata and the `reason:`
+  Logger key, so a second withholding reason must be added HERE and be
+  legible to an aggregator, not invented at a call site.
+  """
+  @type suppression_reason :: :foreground_visible
 
   # ---------------------------------------------------------------------------
   # Public — call from Session.Server
@@ -211,8 +260,12 @@ defmodule Grappa.Push.Triggers do
         # right after you background still delivers. Deliver-leaning: an
         # unreported/backgrounded device reads `:hidden`, so this never
         # suppresses to a device that hasn't claimed the foreground.
+        #
+        # issue 2067 — the gate now REPORTS when it withholds. It stays the
+        # second conjunct so a message the prefs never matched short-circuits
+        # away before reaching it and cannot be miscounted as suppressed.
         if should_notify?(message, network_slug, own_nick, prefs, patterns) and
-             not WSPresence.any_visible?(subject_label) do
+             not foreground_visible?(subject, subject_label) do
           payload = build_payload(message, network_slug, own_nick, subject)
           Push.Sender.send_to_subject(subject, payload)
         end
@@ -254,9 +307,11 @@ defmodule Grappa.Push.Triggers do
         # #182 — the same foreground-suppression gate as the message path,
         # and for the same reason it is a SEPARATE step: the pure predicate
         # stays free of IO. If ANY device has the PWA on-screen, the in-app
-        # presence toast IS the notification and the push is skipped.
+        # presence toast IS the notification and the push is skipped — and
+        # since issue 2067 it says so, through the SAME reporter as the
+        # message path rather than a second event of its own.
         if should_notify_presence?(presence, prefs) and
-             not WSPresence.any_visible?(subject_label) do
+             not foreground_visible?(subject, subject_label) do
           Push.Sender.send_to_subject(subject, Payload.build_presence(nick, presence, network_slug))
         end
       end)
@@ -344,6 +399,65 @@ defmodule Grappa.Push.Triggers do
   # ---------------------------------------------------------------------------
   # Private
   # ---------------------------------------------------------------------------
+
+  # The #182 gate, plus the report issue 2067 was filed for. Reads exactly
+  # what it used to (`WSPresence.any_visible?/1`, RAW, no debounce) and
+  # returns the same boolean; the only new thing is that the SUPPRESSING
+  # answer is no longer silent.
+  #
+  # Only that answer speaks. A `false` means the fan-out proceeds, and from
+  # there `Push.Sender`'s own start/stop telemetry is the record — reporting
+  # here as well would count every delivery twice, once as a near-miss.
+  #
+  # Both call sites reach this through the same `not …` they always had, so
+  # the reading at the `if` is unchanged and the gate keeps its position as
+  # the second conjunct (see the moduledoc: that ordering is what separates
+  # "withheld" from "never triggered").
+  @spec foreground_visible?(Subject.t(), String.t()) :: boolean()
+  defp foreground_visible?(subject, subject_label) do
+    if WSPresence.any_visible?(subject_label) do
+      report_suppressed(subject, :foreground_visible)
+      true
+    else
+      false
+    end
+  end
+
+  # Both doors on one withholding: the counter an exporter aggregates, and
+  # the line an operator greps. ONE function so the message path and the
+  # presence path can never drift into two spellings of the same event.
+  #
+  # Logger FIRST, counter second, and that order is load-bearing rather than
+  # stylistic: anything that observes the counter — the test that pins this
+  # line included — is then guaranteed the message is already on its way to
+  # the handlers, so the two halves of a single withholding can be
+  # correlated without a sleep.
+  #
+  # `:reason`, `:subject_kind`, `:user_id` and `:visitor_id` are ALREADY in
+  # the `config/config.exs` Logger `:metadata` allowlist. That is why this
+  # slice touches no config file: an undeclared key is dropped at FORMAT
+  # time, so a new one would compile, fire, and still print bare — and
+  # editing `config/*.exs` would additionally turn a hot deploy cold.
+  @spec report_suppressed(Subject.t(), suppression_reason()) :: :ok
+  defp report_suppressed(subject, reason) do
+    Logger.info("push.trigger suppressed", [reason: reason] ++ subject_metadata(subject))
+
+    :telemetry.execute(
+      [:grappa, :push, :suppressed],
+      %{count: 1},
+      %{subject: subject, reason: reason}
+    )
+  end
+
+  # There is deliberately NO catch-all: `Grappa.Subject.t/0` is a closed
+  # pair, so a third shape must crash the detached Task (a supervisor
+  # report) rather than print a suppression the operator cannot attribute
+  # to anyone. Same posture `dispatch_presence/4` takes on `change_kind()`.
+  @spec subject_metadata(Subject.t()) :: keyword()
+  defp subject_metadata({:user, id}) when is_binary(id), do: [subject_kind: :user, user_id: id]
+
+  defp subject_metadata({:visitor, id}) when is_binary(id),
+    do: [subject_kind: :visitor, visitor_id: id]
 
   # Door #1: build the push payload, stamping the current badge count when
   # the `BadgeSource` seam is configured. The triggering message is already

--- a/test/grappa/push/observability_log_test.exs
+++ b/test/grappa/push/observability_log_test.exs
@@ -150,6 +150,7 @@ defmodule Grappa.Push.ObservabilityLogTest do
 
       assert log =~ "push.trigger suppressed"
       assert log =~ "reason=foreground_visible"
+      assert log =~ "network=libera"
       assert log =~ "subject_kind=user"
       assert log =~ "user_id=#{user.id}"
 
@@ -184,6 +185,7 @@ defmodule Grappa.Push.ObservabilityLogTest do
 
       assert log =~ "push.trigger suppressed"
       assert log =~ "reason=foreground_visible"
+      assert log =~ "network=azzurra"
       assert log =~ "subject_kind=visitor"
       assert log =~ "visitor_id=#{visitor.id}"
 

--- a/test/grappa/push/observability_log_test.exs
+++ b/test/grappa/push/observability_log_test.exs
@@ -1,0 +1,200 @@
+defmodule Grappa.Push.ObservabilityLogTest do
+  @moduledoc """
+  issue 2067 — the two push paths that used to say nothing at all.
+
+  A self-hoster with no push on iOS read an empty `journalctl -u grappa |
+  grep push` as "the sender was never called". It had been called, and had
+  delivered; what was missing was any line saying so. The sibling silence is
+  the #182 foreground gate, which withholds a fan-out without recording that
+  it did — making a WITHHELD push indistinguishable from one that never
+  triggered.
+
+  `async: false`, and it lowers the global Logger level, because both lines
+  sit at `:info` while `config/test.exs` runs the suite at `:warning`. Same
+  rationale — and the same own-file requirement — as
+  `client_tls_posture_log_test.exs` and the `#1416` describe in
+  `user_socket_test.exs`: the level is process-global, so a concurrent test
+  would see it move under itself.
+
+  This file owns only what the operator READS. The delivery and gate
+  BEHAVIOUR stays in `sender_test.exs` / `triggers_test.exs`, and the
+  suppression COUNTER is asserted there too, beside the send events it has
+  to be told apart from.
+
+  Asserting the RENDERED output rather than the call site is the whole
+  point: the `config/config.exs` `:metadata` allowlist drops an undeclared
+  key at FORMAT time, so a line can compile, fire, and still print bare.
+  Only a capture can tell those two apart.
+  """
+  use Grappa.DataCase, async: false
+
+  import ExUnit.CaptureLog
+  import Grappa.AuthFixtures, only: [user_fixture: 0]
+
+  alias Grappa.{Push, WSPresence}
+  alias Grappa.Push.{Sender, Triggers}
+  alias Grappa.Scrollback.Message
+
+  # Real P-256 client public key + 16-byte auth secret (mirrors
+  # `sender_test.exs`). The ECDH path raises on random bytes BEFORE the
+  # POST, which would mask the very line under test.
+  @client_p256dh "BCfaYE5dGabdzef68MI0SN24b4Gsf1t_N3ftUlWaFGzkuudjHLor0CRjosM3c7SLZ7PfFufpsFUh8vsO1t8wCHs"
+  @client_auth "3aw2ceVFv0OIBXxAvkAlSA"
+
+  @payload %{
+    title: "vjt",
+    body: "ping in #sbiffo",
+    tag: "libera:#sbiffo",
+    url: "/?network=libera&channel=%23sbiffo"
+  }
+
+  setup do
+    original = Logger.level()
+    Logger.configure(level: :info)
+    on_exit(fn -> Logger.configure(level: original) end)
+    :ok
+  end
+
+  defp mention_message do
+    %Message{
+      id: 1,
+      channel: "#sniffo",
+      sender: "alice",
+      body: "vjt: ping",
+      kind: :privmsg,
+      server_time: 1_700_000_000_000
+    }
+  end
+
+  defp attach_telemetry(events) do
+    test_pid = self()
+    handler_id = "push-observability-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler_id,
+      events,
+      fn event, measurements, metadata, _ ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  describe "Sender.send_to_subscription/2 — the delivered line" do
+    test "a vendor 2xx leaves a log line naming the endpoint" do
+      bypass = Bypass.open()
+      endpoint = "http://localhost:#{bypass.port}/wp"
+      Bypass.expect_once(bypass, "POST", "/wp", fn conn -> Plug.Conn.resp(conn, 201, "") end)
+
+      user = user_fixture()
+
+      {:ok, sub} =
+        Push.create({:user, user.id}, %{
+          endpoint: endpoint,
+          p256dh_key: @client_p256dh,
+          auth_key: @client_auth,
+          user_agent: "Mozilla/5.0 observability-test"
+        })
+
+      log =
+        capture_log(fn ->
+          assert :ok = Sender.send_to_subscription(sub, @payload)
+          Logger.flush()
+        end)
+
+      assert log =~ "push.send delivered"
+      assert log =~ "endpoint=#{endpoint}"
+    end
+  end
+
+  describe "Triggers — the suppression line" do
+    setup do
+      :ok = WSPresence.reset_for_test()
+      :ok
+    end
+
+    # The dispatch runs in a detached Task, so the capture has to stay open
+    # until the line is out. `report_suppressed/2` logs BEFORE it counts, so
+    # observing the counter proves the Logger message is already sent and
+    # `Logger.flush/0` can finish the job — no sleep, no poll.
+    defp capture_suppression(fun) do
+      attach_telemetry([[:grappa, :push, :suppressed]])
+
+      capture_log(fn ->
+        assert :ok = fun.()
+        assert_receive {:telemetry, [:grappa, :push, :suppressed], _, _}, 2_000
+        Logger.flush()
+      end)
+    end
+
+    test "a withheld message fan-out names the reason and the subject" do
+      user = user_fixture()
+      subject = {:user, user.id}
+
+      device = spawn(fn -> Process.sleep(:infinity) end)
+      :ok = WSPresence.register(user.name, device)
+      :ok = WSPresence.set_visibility(user.name, device, true)
+      assert WSPresence.any_visible?(user.name)
+
+      log =
+        capture_suppression(fn ->
+          Triggers.evaluate_and_dispatch(mention_message(), %{
+            subject: subject,
+            subject_label: user.name,
+            network_slug: "libera",
+            own_nick: "vjt"
+          })
+        end)
+
+      assert log =~ "push.trigger suppressed"
+      assert log =~ "reason=foreground_visible"
+      assert log =~ "subject_kind=user"
+      assert log =~ "user_id=#{user.id}"
+
+      Process.exit(device, :kill)
+    end
+
+    test "a withheld presence push names the same reason and a visitor subject" do
+      visitor = visitor_fixture()
+      subject = {:visitor, visitor.id}
+      label = "visitor:" <> visitor.id
+
+      {:ok, _} =
+        Grappa.UserSettings.put_notification_prefs(
+          subject,
+          Map.put(Grappa.UserSettings.default_notification_prefs(), :presence_online, true)
+        )
+
+      device = spawn(fn -> Process.sleep(:infinity) end)
+      :ok = WSPresence.register(label, device)
+      :ok = WSPresence.set_visibility(label, device, true)
+      assert WSPresence.any_visible?(label)
+
+      log =
+        capture_suppression(fn ->
+          Triggers.dispatch_presence("alice", :online, :transition, %{
+            subject: subject,
+            subject_label: label,
+            network_slug: "azzurra",
+            own_nick: "vjt"
+          })
+        end)
+
+      assert log =~ "push.trigger suppressed"
+      assert log =~ "reason=foreground_visible"
+      assert log =~ "subject_kind=visitor"
+      assert log =~ "visitor_id=#{visitor.id}"
+
+      Process.exit(device, :kill)
+    end
+  end
+
+  defp visitor_fixture do
+    nick = "push-obs-visitor-#{System.unique_integer([:positive])}"
+    {:ok, _} = Grappa.Networks.find_or_create_network(%{slug: "azzurra"})
+    {:ok, v} = Grappa.Visitors.find_or_provision_anon(nick, "azzurra", "127.0.0.1")
+    v
+  end
+end

--- a/test/grappa/push/triggers_test.exs
+++ b/test/grappa/push/triggers_test.exs
@@ -726,6 +726,113 @@ defmodule Grappa.Push.TriggersTest do
 
       Process.exit(device, :kill)
     end
+
+    # issue 2067 — the suppression used to be silent on BOTH doors, which
+    # made a withheld push indistinguishable from one that never triggered.
+    # This is the counter half; the rendered log line is pinned in
+    # `Grappa.Push.ObservabilityLogTest`.
+    test "a withheld fan-out emits [:grappa, :push, :suppressed] naming subject + reason", %{
+      bypass: bypass,
+      endpoint: endpoint
+    } do
+      attach_telemetry([[:grappa, :push, :suppressed], [:grappa, :push, :send, :start]])
+      Bypass.stub(bypass, "POST", "/wp", fn conn -> Plug.Conn.resp(conn, 500, "should-not-happen") end)
+
+      user = user_fixture()
+      subject = {:user, user.id}
+      _ = subscription_fixture(subject, endpoint)
+
+      device = spawn(fn -> Process.sleep(:infinity) end)
+      :ok = WSPresence.register(user.name, device)
+      :ok = WSPresence.set_visibility(user.name, device, true)
+
+      m = msg(channel: "#sniffo", sender: "alice", body: "vjt: ping")
+
+      assert :ok =
+               Triggers.evaluate_and_dispatch(m, %{
+                 subject: subject,
+                 subject_label: user.name,
+                 network_slug: "libera",
+                 own_nick: "vjt"
+               })
+
+      assert_receive {:telemetry, [:grappa, :push, :suppressed], %{count: 1},
+                      %{subject: ^subject, reason: :foreground_visible}},
+                     2_000
+
+      refute_receive {:telemetry, [:grappa, :push, :send, :start], _, _}, 300
+
+      Process.exit(device, :kill)
+    end
+
+    # issue 2067's load-bearing distinction, and the reason the gate is the
+    # SECOND conjunct: a message the prefs never matched must not be counted
+    # as suppressed, or the new event answers the operator's question with
+    # the same lie the silence did. Visible device AND a non-matching body —
+    # if the `and` were ever reordered, this goes red.
+    test "a message that never triggered emits NO suppression event", %{
+      bypass: bypass,
+      endpoint: endpoint
+    } do
+      attach_telemetry([[:grappa, :push, :suppressed], [:grappa, :push, :send, :start]])
+      Bypass.stub(bypass, "POST", "/wp", fn conn -> Plug.Conn.resp(conn, 500, "should-not-happen") end)
+
+      user = user_fixture()
+      subject = {:user, user.id}
+      _ = subscription_fixture(subject, endpoint)
+
+      device = spawn(fn -> Process.sleep(:infinity) end)
+      :ok = WSPresence.register(user.name, device)
+      :ok = WSPresence.set_visibility(user.name, device, true)
+
+      # No mention, no whitelist, channel _all off by default → the pure
+      # predicate says no and the gate is never consulted.
+      m = msg(channel: "#sniffo", sender: "alice", body: "no mention here")
+
+      assert :ok =
+               Triggers.evaluate_and_dispatch(m, %{
+                 subject: subject,
+                 subject_label: user.name,
+                 network_slug: "libera",
+                 own_nick: "vjt"
+               })
+
+      refute_receive {:telemetry, [:grappa, :push, :suppressed], _, _}, 300
+      refute_receive {:telemetry, [:grappa, :push, :send, :start], _, _}, 300
+
+      Process.exit(device, :kill)
+    end
+
+    # The delivering answer stays quiet on this door: a push that went out
+    # is reported by the Sender's own start/stop pair, and counting it here
+    # too would double-count every delivery as a near-miss.
+    test "a delivered fan-out emits NO suppression event", %{bypass: bypass, endpoint: endpoint} do
+      attach_telemetry([[:grappa, :push, :suppressed], [:grappa, :push, :send, :stop]])
+      Bypass.expect(bypass, "POST", "/wp", fn conn -> Plug.Conn.resp(conn, 201, "") end)
+
+      user = user_fixture()
+      subject = {:user, user.id}
+      _ = subscription_fixture(subject, endpoint)
+
+      device = spawn(fn -> Process.sleep(:infinity) end)
+      :ok = WSPresence.register(user.name, device)
+      refute WSPresence.any_visible?(user.name)
+
+      m = msg(channel: "#sniffo", sender: "alice", body: "vjt: ping")
+
+      assert :ok =
+               Triggers.evaluate_and_dispatch(m, %{
+                 subject: subject,
+                 subject_label: user.name,
+                 network_slug: "libera",
+                 own_nick: "vjt"
+               })
+
+      assert_receive {:telemetry, [:grappa, :push, :send, :stop], _, %{subject: ^subject}}, 2_000
+      refute_receive {:telemetry, [:grappa, :push, :suppressed], _, _}, 300
+
+      Process.exit(device, :kill)
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -885,6 +992,74 @@ defmodule Grappa.Push.TriggersTest do
                )
 
       refute_receive {:telemetry, [:grappa, :push, :send, :start], _, _}, 300
+
+      Process.exit(device, :kill)
+    end
+
+    # issue 2067 — the presence door reports the withholding on the same
+    # event as the message door. Two call sites, ONE reporter: a second
+    # event name here would make an operator aggregate two counters to
+    # answer one question.
+    test "a withheld presence push emits [:grappa, :push, :suppressed] too", %{
+      bypass: bypass,
+      endpoint: endpoint
+    } do
+      attach_telemetry([[:grappa, :push, :suppressed], [:grappa, :push, :send, :start]])
+      Bypass.stub(bypass, "POST", "/wp", fn conn -> Plug.Conn.resp(conn, 500, "should-not-happen") end)
+
+      user = user_fixture()
+      subject = {:user, user.id}
+      _ = subscription_fixture(subject, endpoint)
+      :ok = with_presence_prefs(subject, presence_online: true)
+
+      device = spawn(fn -> Process.sleep(:infinity) end)
+      :ok = WSPresence.register(user.name, device)
+      :ok = WSPresence.set_visibility(user.name, device, true)
+
+      assert :ok =
+               Triggers.dispatch_presence(
+                 "alice",
+                 :online,
+                 :transition,
+                 presence_ctx(subject, user.name)
+               )
+
+      assert_receive {:telemetry, [:grappa, :push, :suppressed], %{count: 1},
+                      %{subject: ^subject, reason: :foreground_visible}},
+                     2_000
+
+      refute_receive {:telemetry, [:grappa, :push, :send, :start], _, _}, 300
+
+      Process.exit(device, :kill)
+    end
+
+    # The pref half of the same distinction: `presence_online: false` is a
+    # push that never triggered, not one that was held back.
+    test "a presence transition the pref never armed emits NO suppression event", %{
+      bypass: bypass,
+      endpoint: endpoint
+    } do
+      attach_telemetry([[:grappa, :push, :suppressed]])
+      Bypass.stub(bypass, "POST", "/wp", fn conn -> Plug.Conn.resp(conn, 500, "should-not-happen") end)
+
+      user = user_fixture()
+      subject = {:user, user.id}
+      _ = subscription_fixture(subject, endpoint)
+      :ok = with_presence_prefs(subject, presence_online: false)
+
+      device = spawn(fn -> Process.sleep(:infinity) end)
+      :ok = WSPresence.register(user.name, device)
+      :ok = WSPresence.set_visibility(user.name, device, true)
+
+      assert :ok =
+               Triggers.dispatch_presence(
+                 "alice",
+                 :online,
+                 :transition,
+                 presence_ctx(subject, user.name)
+               )
+
+      refute_receive {:telemetry, [:grappa, :push, :suppressed], _, _}, 300
 
       Process.exit(device, :kill)
     end

--- a/test/grappa/push/triggers_test.exs
+++ b/test/grappa/push/triggers_test.exs
@@ -757,7 +757,7 @@ defmodule Grappa.Push.TriggersTest do
                })
 
       assert_receive {:telemetry, [:grappa, :push, :suppressed], %{count: 1},
-                      %{subject: ^subject, reason: :foreground_visible}},
+                      %{subject: ^subject, network_slug: "libera", reason: :foreground_visible}},
                      2_000
 
       refute_receive {:telemetry, [:grappa, :push, :send, :start], _, _}, 300
@@ -1025,7 +1025,7 @@ defmodule Grappa.Push.TriggersTest do
                )
 
       assert_receive {:telemetry, [:grappa, :push, :suppressed], %{count: 1},
-                      %{subject: ^subject, reason: :foreground_visible}},
+                      %{subject: ^subject, network_slug: "azzurra", reason: :foreground_visible}},
                      2_000
 
       refute_receive {:telemetry, [:grappa, :push, :send, :start], _, _}, 300


### PR DESCRIPTION
## The defect

Observability, not delivery. Two paths through the push stack produced no
output of any kind, and the absence of output read as absence of work.

- `Push.Sender.send_to_subscription/2` returned from its vendor-2xx arm
  without a `Logger` line, while every OTHER arm of the same `case` logged.
- The `#182` foreground gate in `Push.Triggers` — on BOTH the message door
  (`evaluate_and_dispatch/2`) and the presence door (`dispatch_presence/4`) —
  skipped the whole fan-out inside a bare `if`, with neither a line nor a
  counter.

So an operator with no notification on their phone and an empty
`journalctl -u grappa | grep push` could not tell "the trigger never fired"
from "the trigger fired and the gate held it back" from "it was delivered".

## What ships

**`push.send delivered`** (`info`, `endpoint:`) on the 2xx arm, placed ABOVE
`touch_last_used/1`: the fact reported is the vendor 2xx, which has already
happened, so putting it in the `{:ok, _}` sub-arm would let a failed row-bump
erase the record of a delivery that did occur.

**`push.trigger suppressed`** (`info`, `reason:` + `network:` + subject) and
**`[:grappa, :push, :suppressed]`** (`%{count: 1}`,
`%{subject, network_slug, reason}`) from ONE `report_suppressed/3` serving
both doors. `reason` is the closed type `suppression_reason() ::
:foreground_visible`, not a free string, because it is published on the
telemetry metadata.

The gate stays the SECOND conjunct of the `and` at both call sites, and that
is now load-bearing: short-circuiting is what keeps a message the prefs never
matched from being counted as suppressed. Reverse the conjuncts and delivery
behaviour is unchanged while the new event reports every non-notify-worthy
PRIVMSG as a withheld push — the old lie, louder. Pinned red from both sides.

## The log level, and the volume — the decision you asked me to make

**`info`, for both lines.** `debug` is below the level this ships at
(`config/prod.exs` pins `:info`; `config/runtime.exs` defaults `LOG_LEVEL` to
the same), so a `debug` line answers the operator's question exactly as badly
as the silence did for anyone who has not already reconfigured their logger —
which is everyone, at the moment they need it. The sibling
`push.send subscription gone — deleted` has sat at `info` since B2 for the
same class of event.

**Expected volume: the PREFS set the rate, and the two regimes differ.**

- Defaults (`channel_messages_all: false`, `channel_mentions: true`,
  `private_messages_all: true`): a delivery or a suppression needs a DM or a
  mention. Rare — a handful of lines a day on a normal bouncer.
- `channel_messages_all: true`: `channel_match?/4` returns true
  unconditionally, so it is ONE line per received channel message per joined
  channel — delivered while the devices are backgrounded, suppressed while
  the PWA is on-screen. That operator asked for a notification per message;
  `LOG_LEVEL` is the knob if they do not want the log line that follows.

My first draft of this claimed "not one per IRC message" flatly. That was
false for the second regime and the code review caught it; it is corrected in
the moduledocs and in the entry rather than argued away.

## Logger metadata allowlist / deploy cost

**No `config/*.exs` is touched, so this stays a HOT deploy.** Every key used
— `:reason`, `:network`, `:subject_kind`, `:user_id`, `:visitor_id`,
`:endpoint` — is already in the `config/config.exs` `:metadata` allowlist.
That was a design constraint, not luck: an undeclared key is dropped at
FORMAT time, so a new one would compile, fire, and still print bare, and the
config edit that declares it turns the deploy cold.

`:channel` is allowlisted too and is deliberately NOT taken: one reporter
serves both doors, the presence door has no channel, so it would either split
the reporter in two or print an empty field half the time.

## Gates

`scripts/check.sh` **rc=0** on the pushed tree (`83776d290`) — Credo strict
6879 mods/funs no issues, 8 doctests + 65 properties + 7268 tests 0 failures,
Dialyzer 0 errors, wire types + schema in sync, Sobelow, the bats suite.
`scripts/design-notes-gate.sh` rc=0; `scripts/union-rebase.sh` rebased onto
the then-current `origin/main` and proved the union contribution intact
(`docs/DESIGN_NOTES.md: +110 -0`).

`origin/main` has since moved to `e34e2ed1b` (one commit, `.claude/skills/`
only). Not rebased onto it: it touches nothing this branch touches, and the
`#2067` marker is still unique against that tip (checked with a positive
control, so a dead grep cannot read as "clean").

Lane: COMPILE only, as allocated. Started from
`scripts/mix.sh --env=dev compile --force` because the shared `_build` is not
attributable. **STACK (docker / e2e / `integration.sh`) NOT run** — it is w1's
and I did not touch it.

## Code review

Ran, at `high`. Four findings; two changed the code or the claims, two are
answered in writing rather than by code, and both of those are recorded in
the entry as deliberate:

1. **The counter includes subjects with NO registered device** (the gate runs
   before the fan-out and pays no subscription query, so a foregrounded user
   who never granted permission is counted although `send_to_subject/2` would
   have hit its empty-list arm). **Kept, named.** It counts withheld TRIGGER
   dispatches, and the moduledoc now says that instead of posing the looser
   "how often is push held back?" the first draft posed. Buying the
   distinction means a `push_subscriptions` read on every suppression — under
   `channel_messages_all` that is a read per channel message — to answer what
   the device-list UI answers directly.
2. **The volume claim was false.** Fixed, above.
3. **`endpoint:` at every delivery is a capability URL at a new frequency.**
   Kept, and now argued in the moduledoc + entry instead of being silent.
   `Push.VendorLog` logs the host alone (#1321, "a path segment can itself be
   a credential") and can afford to only because its own moduledoc names THIS
   line as the correlation anchor; host-only here would leave nothing to
   anchor to and could not separate two iPhones on `web.push.apple.com`,
   which is the multi-device case the line exists for. The clean answer — a
   subscription row id — needs a new metadata key, hence a cold deploy. **If
   you rule the other way, the cure is written down.**
4. **No network on the suppression line.** Fixed — `network:` added to both
   the line and the telemetry metadata.

## What I refuse to assert, and what I did not measure

- **Nothing about delivery changed.** Every branch returns what it returned
  before and the gate's boolean is unchanged. This fixes no delivery defect.
- **The reported incident is not reproduced.** The always-visible socket on
  `h-irc` 1.5.5 is taken from the issue as given. Nothing was measured
  against that instance, or any production node, from here — prod is
  unreachable from this agent. Whether these two lines would in fact have
  shortened that evening is an INFERENCE from what they print, not an
  observation.
- **The root cause of a socket stuck at `visible` is untouched** and stays
  open. This slice makes the symptom legible; it does not fix it.
- **The issue's telemetry claim is wrong and I did not implement it.**
  `[:grappa, :push, :send, :stop]` already carries `%{success: ...}`, so the
  success axis was already exported at the fan-out aggregate. Only the LOG
  half was missing. No per-subscription success counter was added.
- **The count in the issue is off by one.** It enumerates four Logger calls
  in `send_to_subscription/2`; there were five — it misses the `delete_dead`
  `:db_unavailable` degradation arm. The docs count ARMS, not lines, so a
  future edit cannot make the sentence false again.
- **I did not measure the log volume on a real instance.** The two regimes
  above are read off `default_notification_prefs/0` and `channel_match?/4`,
  not off a running node's log rate.
- **`suppression_reason()` has one member** and no second reason was invented
  to justify the type.

Closing: issue 2067.
