### PR TITLE
fix(2069): answer "how many unread" from one function, at two anchors

### DIFF
--- a/cicchetto/e2e/tests/issue2069-one-unread-number.spec.ts
+++ b/cicchetto/e2e/tests/issue2069-one-unread-number.spec.ts
@@ -75,12 +75,49 @@ test.describe("issue 2069 — one number for one question", () => {
       peer.privmsg(CHANNEL, "issue 2069 one");
       peer.privmsg(CHANNEL, "issue 2069 two");
       peer.privmsg(CHANNEL, "issue 2069 three");
+
+      // 🔴 This barrier is placed BEFORE the PART on purpose, and it is not
+      // politeness — it is what makes the setup deterministic.
+      //
+      // bahamut charges FAKE-LAG per command on a connection, so a burst is
+      // served with growing delay and the ~10s overshoot the `whoisAway` budget
+      // in `fixtures/ircClient.ts` already documents. `IrcPeer.part` waits for
+      // its own PART echo on a 5s budget (`PART_TIMEOUT_MS`), and this spec
+      // used to fire JOIN + 3×PRIVMSG + PART back to back — so the PART was the
+      // FIFTH command against a bank filled by the four before it.
+      //
+      // Measured on this tree, `--repeat-each 20`: 9 reds in 20, every one of
+      // them the identical `IrcPeer: timeout waiting for part #spec-w0 (5000ms)`
+      // — the same signature CI turned on shard 2/4 of run 34553963487. The
+      // discriminator against "the testnet is just slow" is in the same logs:
+      // `IrcPeer.join` carries the SAME 5s budget and timed out ZERO times in
+      // those 20 runs. First command always fine, fifth command half the time
+      // not: that is a per-command bank, not latency.
+      //
+      // Draining it by waiting on an OBSERVABLE signal — the three messages
+      // being on the server — costs nothing the spec was not already paying
+      // (it polls this very endpoint below) and leaves the PART as a lone
+      // command against a bank that has had time to empty. No timeout is
+      // raised and no assertion is touched.
+      let after = before;
+      const peerNick = PEER_NICK.toLowerCase();
+      await expect
+        .poll(
+          async () => {
+            after = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
+            return after.filter(
+              (r) => r.id > cursorId && r.kind === "privmsg" && r.sender.toLowerCase() === peerNick,
+            ).length;
+          },
+          { timeout: 15_000 },
+        )
+        .toBe(3);
+
       await peer.part(CHANNEL, "issue 2069 done");
 
       // Barrier on the SERVER's own store, not a timeout: the PART is the last
       // row the peer produces, so its arrival proves the three messages and the
       // JOIN are already persisted (one ordered IRC stream, one session).
-      let after = before;
       await expect
         .poll(
           async () => {

--- a/cicchetto/e2e/tests/issue2069-one-unread-number.spec.ts
+++ b/cicchetto/e2e/tests/issue2069-one-unread-number.spec.ts
@@ -79,26 +79,32 @@ test.describe("issue 2069 — one number for one question", () => {
       // 🔴 This barrier is placed BEFORE the PART on purpose, and it is not
       // politeness — it is what makes the setup deterministic.
       //
-      // bahamut charges FAKE-LAG per command on a connection, so a burst is
-      // served with growing delay and the ~10s overshoot the `whoisAway` budget
-      // in `fixtures/ircClient.ts` already documents. `IrcPeer.part` waits for
-      // its own PART echo on a 5s budget (`PART_TIMEOUT_MS`), and this spec
-      // used to fire JOIN + 3×PRIVMSG + PART back to back — so the PART was the
-      // FIFTH command against a bank filled by the four before it.
+      // MEASURED, on this tree, `--repeat-each 20`:
       //
-      // Measured on this tree, `--repeat-each 20`: 9 reds in 20, every one of
-      // them the identical `IrcPeer: timeout waiting for part #spec-w0 (5000ms)`
-      // — the same signature CI turned on shard 2/4 of run 34553963487. The
-      // discriminator against "the testnet is just slow" is in the same logs:
-      // `IrcPeer.join` carries the SAME 5s budget and timed out ZERO times in
-      // those 20 runs. First command always fine, fifth command half the time
-      // not: that is a per-command bank, not latency.
+      //   * without this barrier, 9 reds in 20, every one of them the identical
+      //     `IrcPeer: timeout waiting for part #spec-w0 (5000ms)` — the same
+      //     signature CI turned on shard 2/4 of run 34553963487;
+      //   * the cost depends on the command's POSITION in the burst, not on the
+      //     clock: `IrcPeer.join` carries the SAME 5s budget (`JOIN_TIMEOUT_MS`
+      //     == `PART_TIMEOUT_MS`) and timed out ZERO times across those 20 runs.
+      //     First command always fine; fifth command — after JOIN + 3×PRIVMSG —
+      //     half the time not;
+      //   * with the barrier, 20 green in 20.
       //
-      // Draining it by waiting on an OBSERVABLE signal — the three messages
-      // being on the server — costs nothing the spec was not already paying
-      // (it polls this very endpoint below) and leaves the PART as a lone
-      // command against a bank that has had time to empty. No timeout is
-      // raised and no assertion is touched.
+      // INFERRED, and labelled as such: that the per-command cost IS bahamut's
+      // fake-lag bank. That name is READ, from the `whoisAway` comment in
+      // `fixtures/ircClient.ts` and from the ircd source — and reading a
+      // mechanism tells you a path EXISTS, never what it costs. This spec has
+      // not measured the bank: the instrument that can (`Grappa.IRC.FakeLag`,
+      // #800/S7) accounts GRAPPA's own socket, and the peer here is a separate
+      // irc-framework connection it never sees. Anything that serialises per
+      // connection would fit the same three measurements.
+      //
+      // The cure does not depend on the name. It rests on the measured half —
+      // position in the burst — so draining on an OBSERVABLE signal (the three
+      // messages being on the server, the very endpoint polled below) leaves
+      // the PART as a lone command. No timeout is raised and no assertion is
+      // touched.
       let after = before;
       const peerNick = PEER_NICK.toLowerCase();
       await expect

--- a/cicchetto/e2e/tests/issue2069-one-unread-number.spec.ts
+++ b/cicchetto/e2e/tests/issue2069-one-unread-number.spec.ts
@@ -1,0 +1,142 @@
+// issue 2069 — the sidebar pill and the in-pane divider must answer the same
+// question with the same number.
+//
+// The reported symptom C: "the divider counts presence rows (join/part/quit/
+// nick) as unread 'messages'; the sidebar badge does not." Measured at the
+// store level on `b7989f4ba` over 150 rows past the cursor (113 peer messages
+// + 37 peer JOINs) the pill read 113 and the divider rendered "150 unread
+// messages" — a label that says "messages" over a count that is not messages.
+//
+// This is the browser witness for that, and it is the only place the two
+// numbers are ever visible AT ONCE, which is how the operator noticed. The
+// vitest arms pin each surface against a fixture; only a rendered page can
+// pin that the two AGREE.
+//
+// RED pre-fix: the peer's JOIN and PART land in the unread run, so the divider
+// reads "5 unread messages" against a pill reading "3".
+//
+// Two premises are asserted rather than assumed, because without either one
+// the spec is green on the broken build:
+//
+//   * the unread run really does contain peer PRESENCE rows (otherwise the two
+//     predicates cannot disagree);
+//   * those rows are RENDERED (`#spec-wN` is far under
+//     `LARGE_CHANNEL_THRESHOLD`, so the #222 filter shows them) — a hidden
+//     presence row is excluded from the old count too, by a different rule.
+//
+// Per BUGHUNT-3 cascade rule the cursor is moved here, so it is restored to
+// tail in afterEach or downstream specs inherit a mid-list cursor.
+
+import {
+  loginAs,
+  selectChannel,
+  sidebarEventsBadge,
+  sidebarMessageBadge,
+} from "../fixtures/cicchettoPage";
+import {
+  fetchAllMessagesAsc,
+  restoreReadCursorToTail,
+  setShowEventBadge,
+} from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+const PEER_NICK = "i2069peer";
+const PRESENCE_KINDS = new Set(["join", "part", "quit", "nick_change", "mode", "kick"]);
+
+test.afterEach(async () => {
+  const vjt = specUser();
+  if (!CHANNEL) return;
+  await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL).catch(() => {});
+});
+
+test.describe("issue 2069 — one number for one question", () => {
+  test("the sidebar pill and the in-pane divider report the same unread count", async ({
+    page,
+  }) => {
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+    const vjt = specUser();
+
+    // Everything before this line is read; everything after it is the unread
+    // run under test. Planted BEFORE the peer acts so the run is exactly what
+    // this spec produces.
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+    const before = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
+    const cursorId = before[before.length - 1]?.id;
+    if (cursorId === undefined) throw new Error("issue 2069 spec: seeded channel is empty");
+
+    // A peer arrives, says three things, and leaves. JOIN and PART persist as
+    // presence rows INSIDE the unread run — which is the whole fixture.
+    const peer = await IrcPeer.connect({ nick: PEER_NICK });
+    try {
+      await peer.join(CHANNEL);
+      peer.privmsg(CHANNEL, "issue 2069 one");
+      peer.privmsg(CHANNEL, "issue 2069 two");
+      peer.privmsg(CHANNEL, "issue 2069 three");
+      await peer.part(CHANNEL, "issue 2069 done");
+
+      // Barrier on the SERVER's own store, not a timeout: the PART is the last
+      // row the peer produces, so its arrival proves the three messages and the
+      // JOIN are already persisted (one ordered IRC stream, one session).
+      let after = before;
+      await expect
+        .poll(
+          async () => {
+            after = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
+            return after.filter((r) => r.id > cursorId && r.kind === "part").length;
+          },
+          { timeout: 15_000 },
+        )
+        .toBeGreaterThan(0);
+
+      const unreadRun = after.filter((r) => r.id > cursorId);
+      const ownNick = specNick().toLowerCase();
+      const messages = unreadRun.filter(
+        (r) => !PRESENCE_KINDS.has(r.kind) && r.sender.toLowerCase() !== ownNick,
+      );
+      const presence = unreadRun.filter(
+        (r) => PRESENCE_KINDS.has(r.kind) && r.sender.toLowerCase() !== ownNick,
+      );
+
+      // PREMISE 1 — the two predicates can actually disagree here.
+      expect(messages).toHaveLength(3);
+      expect(presence.length).toBeGreaterThanOrEqual(2);
+
+      // The events pill is behind the #2037 B opt-in; turn it on so the
+      // presence rows are visible as a NUMBER too, and the spec can say where
+      // they went rather than only that they left the message count.
+      await setShowEventBadge(vjt.token, true);
+
+      await loginAs(page, vjt);
+
+      // The sidebar, with the window still UNSELECTED — the pill's own answer,
+      // before any reading can move the cursor.
+      const pill = sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL);
+      await expect(pill).toHaveText(String(messages.length), { timeout: 15_000 });
+      await expect(sidebarEventsBadge(page, NETWORK_SLUG, CHANNEL)).toHaveText(
+        String(presence.length),
+      );
+
+      await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+      // PREMISE 2 — the presence rows RENDER. If the #222 filter hid them, the
+      // old count would have excluded them for an unrelated reason and this
+      // spec would pass on the broken build.
+      const firstPresence = presence[0];
+      if (!firstPresence) throw new Error("issue 2069 spec: no peer presence row in the run");
+      await expect(
+        page.locator(`[data-testid="scrollback-line"][data-msg-id="${firstPresence.id}"]`),
+      ).toBeVisible({ timeout: 15_000 });
+
+      // THE CLAIM — the divider is the MESSAGES count, in the unit its own
+      // label announces, and it is the number the sidebar showed.
+      await expect(page.locator(".scrollback-unread-marker-label")).toHaveText(
+        `${messages.length} unread messages`,
+      );
+    } finally {
+      await peer.disconnect("issue 2069 teardown").catch(() => {});
+    }
+  });
+});

--- a/cicchetto/e2e/tests/unread-cursor-cluster.spec.ts
+++ b/cicchetto/e2e/tests/unread-cursor-cluster.spec.ts
@@ -37,7 +37,7 @@ import {
   selectChannel,
   sidebarMessageBadge,
 } from "../fixtures/cicchettoPage";
-import { restoreReadCursorToTail } from "../fixtures/grappaApi";
+import { assertMessagePersisted, restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
@@ -201,6 +201,32 @@ test.describe("unread-badges-from-cursor cluster (A → D + Z)", () => {
     try {
       await peer.join(CHANNEL);
       peer.privmsg(CHANNEL, peerBody);
+
+      // 🔴 issue 2069 — the precondition this test has always DEPENDED on and
+      // never ESTABLISHED: the peer MESSAGE must be pre-arrival, i.e. inside
+      // the first non-empty observation the pane latches `sessionTopId` from.
+      // Rows above that latch are live arrivals and draw no marker by design.
+      //
+      // It used to pass without this wait because the divider counted peer
+      // PRESENCE rows: the awaited `peer.join` above was reliably inside the
+      // latch, so the JOIN alone injected a marker reading "1 unread" — the
+      // very defect issue 2069 is about. With the count restricted to messages
+      // the JOIN no longer stands in, and the unguarded ordering surfaced as a
+      // flake: 1 red in 5 on the fix branch against 10 green in 10 on
+      // `b7989f4ba`. The mechanism is pinned deterministically in
+      // `ScrollbackPane.test.tsx` ("draws no marker when only a peer JOIN
+      // precedes the session top and the message lands live").
+      //
+      // The assertion below is UNCHANGED. What changes is that the state it
+      // describes is now actually reached: once the row is persisted, the
+      // window's opening fetch carries it, and with it the preceding JOIN.
+      await assertMessagePersisted({
+        token: vjt.token,
+        networkSlug: NETWORK_SLUG,
+        channel: CHANNEL,
+        sender: PEER_NICK,
+        body: peerBody,
+      });
 
       // Switch to #spec-wN — key-effect latches the snapshot at cursor <
       // peer-row id, rows memo injects the unread-marker. Wait for the

--- a/cicchetto/e2e/tests/unread-divider-beyond-window.spec.ts
+++ b/cicchetto/e2e/tests/unread-divider-beyond-window.spec.ts
@@ -32,12 +32,17 @@ import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
-// Own-presence kinds excluded from the unread-marker count — mirrors the
-// single source of truth `src/lib/ownPresenceEvent.ts` (`PRESENCE_KINDS`).
-// Used only to DERIVE the expected count from server data (the operator's
-// own auto-JOIN line on #spec-wN is the one such row after an early cursor);
-// it is not the behaviour under test.
-const OWN_PRESENCE_KINDS = new Set(["join", "part", "quit", "nick_change", "mode", "kick"]);
+// Presence kinds — NOT counted toward the unread-marker, whoever sent them.
+// Used only to DERIVE the expected count from server data; it is not the
+// behaviour under test.
+//
+// issue 2069 widened this from OWN presence to ALL presence. The marker's
+// label says "messages" and now counts messages, so a PEER join/part in the
+// run is excluded too; before, this derivation happened to agree only because
+// the seeded run is contiguous privmsgs plus the operator's own auto-JOIN, and
+// it would have started lying the first time another spec's peer touched the
+// channel ahead of this one.
+const PRESENCE_KINDS = new Set(["join", "part", "quit", "nick_change", "mode", "kick"]);
 
 test.describe("#156 unread divider with unread beyond the fetch window", () => {
   test("anchors the divider between last-read and first-unread with context above", async ({
@@ -70,13 +75,15 @@ test.describe("#156 unread divider with unread beyond the fetch window", () => {
       throw new Error("#156 spec: seeded #spec-wN rows missing expected indices");
     }
 
-    // True unread = rows after the cursor MINUS the operator's own
-    // presence rows (the auto-JOIN line), mirroring the in-pane marker's
-    // exclusion. Operator-action echoes don't occur in the pure seed.
+    // True unread = MESSAGE rows after the cursor, mirroring the in-pane
+    // marker's own predicate: presence rows are excluded whoever sent them
+    // (issue 2069), and so are the operator's own messages (#576). Operator-
+    // action echoes don't occur in the pure seed.
     const expectedUnread = rows.filter(
       (r) =>
         r.id > lastReadRow.id &&
-        !(OWN_PRESENCE_KINDS.has(r.kind) && r.sender.toLowerCase() === specNick().toLowerCase()),
+        !PRESENCE_KINDS.has(r.kind) &&
+        r.sender.toLowerCase() !== specNick().toLowerCase(),
     ).length;
     // Guard the chosen window: exact count requires staying under the cap.
     expect(expectedUnread).toBeGreaterThan(60);

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -47,9 +47,7 @@ import { closeMessageMenu, messageMenu, openMessageMenu } from "./lib/messageMen
 import { networkIdBySlug, networks, user } from "./lib/networks";
 import { snapshotSenderPrefix } from "./lib/nickColor";
 import { nickEquals } from "./lib/nickEquals";
-import { isOperatorActionEcho } from "./lib/operatorActionEcho";
 import { overlayCount } from "./lib/overlayScrollLock";
-import { isOwnPresenceEvent } from "./lib/ownPresenceEvent";
 import {
   channelPresenceVisible,
   presenceRowVisible,
@@ -80,6 +78,7 @@ import type { Point } from "./lib/swipe";
 import { isMobile } from "./lib/theme";
 import { formatTimestamp } from "./lib/timeFormat";
 import { type TopicShowEntry, topicShowByWindow } from "./lib/topicShow";
+import { isOperatorOwnedRow, type UnreadRowContext, unreadMessagesAfter } from "./lib/unreadCount";
 import { dismissWhoisCard, whoisCardBySlug } from "./lib/whoisCard";
 import { SERVER_WINDOW_NAME, type WindowKind } from "./lib/windowKinds";
 import MessageContextMenu from "./MessageContextMenu";
@@ -1729,15 +1728,23 @@ const ScrollbackPane: Component<Props> = (props) => {
     // of the network, not of a row, and the two predicates below plus the
     // own-JOIN anchor scan all have to agree on it.
     const casemapping = casemappingForSlug(props.networkSlug);
+    // issue 2069 — the row predicate is SHARED with the sidebar pill now
+    // (`lib/unreadCount.ts`). It used to be spelled out here, and the spelling
+    // had drifted three ways from the pill's: this line counted peer JOINs
+    // under a label that says "messages" (150 against a pill reading 113 over
+    // the same 150 rows), counted the operator's OWN messages (10 against 5),
+    // and excluded numeric-derived NOTICEs the pill counted (no marker at all
+    // against 5). All four measured on `b7989f4ba`.
+    const unreadCtx: UnreadRowContext = {
+      ownNick,
+      casemapping,
+      isSelfWindow: nickEquals(props.channelName, ownNick, casemapping),
+    };
+    // The LOCAL count — what this pane can see. It gates the marker: there has
+    // to be a row in the buffer to put the line in front of.
     const unreadCount =
       cursor !== null && sessionTop !== null
-        ? msgs.filter(
-            (m) =>
-              m.id > cursor &&
-              m.id <= sessionTop &&
-              !isOperatorActionEcho(m) &&
-              !isOwnPresenceEvent(m, ownNick, casemapping),
-          ).length
+        ? unreadMessagesAfter(msgs, cursor, sessionTop, undefined, unreadCtx)
         : 0;
     // #947 — the LABEL, which is not always the count above. `unreadCount`
     // can only see rows the pane holds, and a pane resumed by a #693 jump
@@ -1752,9 +1759,19 @@ const ScrollbackPane: Component<Props> = (props) => {
     // PLACEMENT stays with `unreadCount` and the loop below: the divider has
     // to sit between the last read row and the first unread row actually in
     // the pane, and no server count knows where that is.
-    const measured = measuredUnreadByChannel()[key()];
+    //
+    // issue 2069 — the same function, handed the measurement. The second pass
+    // over `msgs` is deliberate: the label and the placement gate are two
+    // different questions ("how many are there" vs "is there one HERE"), and
+    // deriving one from the other is what let them answer in different units
+    // in the first place. `measured.at === cursor` is gone as an explicit
+    // test — `unreadMessagesAfter` subtracts what the cursor consumed instead
+    // of discarding the answer, so a re-latched freeze no longer drops the
+    // label back to the fetch page.
     const unreadLabel =
-      measured !== undefined && measured.at === cursor ? measured.count : unreadCount;
+      cursor !== null && sessionTop !== null
+        ? unreadMessagesAfter(msgs, cursor, sessionTop, measuredUnreadByChannel()[key()], unreadCtx)
+        : 0;
     // Only inject the marker if there are unread messages AND some read messages
     // to show as context above it. When all messages are unread, put the marker
     // at the very top (before index 0). When none are unread, skip the marker.
@@ -1779,9 +1796,15 @@ const ScrollbackPane: Component<Props> = (props) => {
       // AND <= sessionTopId. Messages above sessionTopId never get a
       // marker — they're live-read arrivals during the focus session.
       // CP29 R-6: skip own-presence + operator-action-echo rows here so
-      // the marker doesn't land above a row that isn't counted in
-      // `unreadCount` — the predicate set MUST stay in lock-step with
-      // the count filter above.
+      // the marker doesn't land above a row the operator caused themselves.
+      //
+      // issue 2069 — the predicate is `isOperatorOwnedRow`, the same one the
+      // count is built on, and it is BROADER than the count: the line marks
+      // where the operator left off, so it goes above the first row somebody
+      // ELSE produced, message or presence. The label counts only the
+      // messages. That asymmetry is deliberate — narrowing placement to
+      // content would leave a run of peer JOINs sitting ABOVE the line,
+      // rendered as if they had been read.
       if (
         injectMarker &&
         !markerInjected &&
@@ -1789,8 +1812,7 @@ const ScrollbackPane: Component<Props> = (props) => {
         sessionTop !== null &&
         msg.id > cursor &&
         msg.id <= sessionTop &&
-        !isOperatorActionEcho(msg) &&
-        !isOwnPresenceEvent(msg, ownNick, casemapping)
+        !isOperatorOwnedRow(msg, unreadCtx)
       ) {
         result.push({ type: "unread-marker", count: unreadLabel, id: "unread-marker" });
         markerInjected = true;

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -3943,6 +3943,83 @@ describe("ScrollbackPane", () => {
       expect(flow[markerAt + 1]?.getAttribute("data-msg-id")).toBe("61");
     });
 
+    // 🔴 issue 2069 — the ORDERING that made `unread-cursor-cluster.spec.ts`
+    // ("focused send collapses the in-pane unread marker immediately") flaky
+    // on this branch: 1 red in 5 here, against 10 green in 10 on the base
+    // `b7989f4ba`. This arm exists so the e2e is not the only witness to it.
+    //
+    // `sessionTopId` latches the tail of the FIRST non-empty observation, and
+    // anything above it is a live arrival that draws no marker on purpose —
+    // the operator watched it land. So when the peer's JOIN falls inside that
+    // first observation but their MESSAGE does not, the two regimes disagree:
+    //
+    //   * BEFORE this slice the divider counted presence rows, so the JOIN on
+    //     its own injected a marker reading "1 unread" — which is exactly the
+    //     defect this issue is about, and exactly why the e2e went green in
+    //     that ordering. The arm above (previously "DOES count peer JOIN row
+    //     toward the unread marker") asserted that number verbatim;
+    //   * NOW only messages count, the JOIN alone injects nothing, and the
+    //     late message is a live arrival — so NO marker is the right answer.
+    //
+    // The spec's precondition (the peer message is PRE-arrival) was never
+    // guaranteed by its own setup; the presence count was masking it. Its cure
+    // is to make the precondition true, not to weaken the assertion.
+    it("draws no marker when only a peer JOIN precedes the session top and the message lands live", async () => {
+      setUserNick("vjt");
+      const beforeFocus: ScrollbackMessage[] = [
+        {
+          id: 70,
+          network: "freenode",
+          channel: "#grappa",
+          server_time: 1_700_000_000_000,
+          kind: "privmsg",
+          sender: "alice",
+          body: "read up to here",
+          meta: {},
+        },
+        {
+          id: 71,
+          network: "freenode",
+          channel: "#grappa",
+          server_time: 1_700_000_001_000,
+          kind: "join",
+          sender: "carol",
+          body: null,
+          meta: {},
+        },
+      ];
+      seedReadCursor("freenode", "#grappa", 70);
+      setScrollback({ "freenode #grappa": beforeFocus });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      // sessionTopId latches 71, the JOIN — the only unread row, and not a
+      // message, so there is no messages divider to draw.
+      expect(screen.queryByTestId("unread-marker")).toBeNull();
+
+      // The peer's MESSAGE lands after the latch: above sessionTopId, watched
+      // by the operator, therefore live-read. Still no marker.
+      setScrollback({
+        "freenode #grappa": [
+          ...beforeFocus,
+          {
+            id: 72,
+            network: "freenode",
+            channel: "#grappa",
+            server_time: 1_700_000_002_000,
+            kind: "privmsg",
+            sender: "carol",
+            body: "ciao",
+            meta: {},
+          },
+        ],
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("scrollback").querySelector('.scrollback-line[data-msg-id="72"]'),
+        ).not.toBeNull();
+      });
+      expect(screen.queryByTestId("unread-marker")).toBeNull();
+    });
+
     // Mixed-row variant: own JOIN sandwiched between a read msg and an
     // unread peer msg. Marker count should be 1 (the peer msg only) and
     // marker should land BEFORE the peer msg, not before the own JOIN.

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -107,8 +107,11 @@ const [farBehind, setFarBehind] = createSignal<
 // region is truncated (set by a jump that could only carry one page back).
 // Stamped with the cursor it was measured `at`, so the pane spends it only
 // while its frozen divider is still anchored to that same cursor.
+// issue 2069 — `through` is the top of the run the pane can account for out
+// of that measurement, so the record survives a cursor that moves through the
+// rows the pane holds. Without it the record is not spendable at all.
 const [measuredUnread, setMeasuredUnread] = createSignal<
-  Record<string, { at: number; count: number }>
+  Record<string, { at: number; count: number; through: number }>
 >({});
 // #1094 — "an older page is on the wire for this key", the state the loading
 // affordance renders from. Keyed the same way the store keys it.
@@ -3154,7 +3157,7 @@ describe("ScrollbackPane", () => {
       it("labels the divider with the server's count, not the loaded rows", () => {
         seedReadCursor("freenode", "#grappa", 1);
         setScrollback({ "freenode #grappa": fixture });
-        setMeasuredUnread({ "freenode #grappa": { at: 1, count: 3000 } });
+        setMeasuredUnread({ "freenode #grappa": { at: 1, count: 3000, through: 3 } });
         render(() => (
           <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
         ));
@@ -3168,7 +3171,7 @@ describe("ScrollbackPane", () => {
         // that is.
         seedReadCursor("freenode", "#grappa", 1);
         setScrollback({ "freenode #grappa": fixture });
-        setMeasuredUnread({ "freenode #grappa": { at: 1, count: 3000 } });
+        setMeasuredUnread({ "freenode #grappa": { at: 1, count: 3000, through: 3 } });
         render(() => (
           <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
         ));
@@ -3183,14 +3186,36 @@ describe("ScrollbackPane", () => {
         expect(flow[markerAt + 1]?.getAttribute("data-msg-id")).toBe(String(fixture[1]?.id));
       });
 
-      it("ignores a measurement taken at a DIFFERENT cursor", () => {
-        // Self-invalidating by construction: the count answers "how many rows
-        // are after id 1", so it is meaningless once the divider re-freezes
-        // somewhere else. Falling back to the loaded rows understates; reusing
-        // a stale 3000 would be a confident wrong number that never expires.
+      it("ignores a measurement anchored ABOVE this cursor", () => {
+        // The count answers "how many rows follow id 999", which says nothing
+        // about a divider frozen at 1 — the region it describes starts above
+        // the reader. Spending it would UNDER-report by everything in between.
+        //
+        // issue 2069 narrowed this arm. It used to read "a DIFFERENT cursor",
+        // and the opposite case — a cursor that has advanced INTO the measured
+        // region — is no longer discarded but subtracted, which is the whole
+        // of symptom B: discarding it dropped the badge to the fetch page and
+        // then to zero. Only the anchored-above direction is unspendable, and
+        // it is unspendable because the client has no way to reach it.
         seedReadCursor("freenode", "#grappa", 1);
         setScrollback({ "freenode #grappa": fixture });
-        setMeasuredUnread({ "freenode #grappa": { at: 999, count: 3000 } });
+        setMeasuredUnread({ "freenode #grappa": { at: 999, count: 3000, through: 1200 } });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        expect(screen.getByTestId("unread-marker")).toHaveTextContent("2 unread messages");
+      });
+
+      it("stands the measurement down once the cursor leaves the accountable run", () => {
+        // issue 2069 — `through` is the top of the contiguous run the jump
+        // loaded (and `loadNewer` extends). Past it the pane cannot say how
+        // much of the measured region the cursor consumed, so the record must
+        // stop answering rather than subtract only what it happens to hold:
+        // an own send lands the cursor at the tip with nothing unread, and a
+        // measurement that kept spending would report thousands.
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        setMeasuredUnread({ "freenode #grappa": { at: 0, count: 3000, through: 0 } });
         render(() => (
           <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
         ));
@@ -3200,7 +3225,7 @@ describe("ScrollbackPane", () => {
       it("does not leak another window's measurement into this pane", () => {
         seedReadCursor("freenode", "#grappa", 1);
         setScrollback({ "freenode #grappa": fixture });
-        setMeasuredUnread({ "freenode #other": { at: 1, count: 3000 } });
+        setMeasuredUnread({ "freenode #other": { at: 1, count: 3000, through: 3 } });
         render(() => (
           <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
         ));
@@ -3814,10 +3839,20 @@ describe("ScrollbackPane", () => {
       expect(screen.queryByTestId("unread-marker")).toBeNull();
     });
 
-    // Symmetry check: a peer JOIN IS a real event the operator hasn't seen
-    // and MUST still produce the marker — guards against over-broad
-    // suppression that would silence legitimate channel activity.
-    it("DOES count peer JOIN row toward the unread marker", () => {
+    // 🔴 issue 2069 — this arm used to be "DOES count peer JOIN row toward the
+    // unread marker" and asserted `"1 unread"`, i.e. this pane rendering
+    // "1 unread message" for a JOIN. It was asserting the defect: over the
+    // same fixture the sidebar pill reported nothing at all, because the pill
+    // splits on `isContentKind` and this line did not. Measured on
+    // `b7989f4ba`, 150 rows past the cursor: pill 113, divider 150.
+    //
+    // The arm's INTENT was right and is kept — peer activity must not be
+    // silently swallowed by an over-broad suppression. What changes is where
+    // the activity is answered: the row still RENDERS, and the count it feeds
+    // is the events bucket (`countsAsUnreadEvent`, pinned in
+    // `unreadCount.test.ts` and at the store level in
+    // `unreadOneVariable.test.ts`), not a label that says "messages".
+    it("does not label a peer JOIN as an unread MESSAGE, and still renders it", () => {
       setUserNick("vjt");
       const peerJoinFixture: ScrollbackMessage[] = [
         {
@@ -3844,8 +3879,68 @@ describe("ScrollbackPane", () => {
       seedReadCursor("freenode", "#grappa", 50);
       setScrollback({ "freenode #grappa": peerJoinFixture });
       render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
-      const marker = screen.getByTestId("unread-marker");
-      expect(marker).toHaveTextContent("1 unread");
+      // No message is unread, so there is no messages divider to draw.
+      expect(screen.queryByTestId("unread-marker")).toBeNull();
+      // ...and the JOIN is still on screen. This is the half that guards
+      // against curing the label by dropping the row.
+      expect(
+        screen.getByTestId("scrollback").querySelector('.scrollback-line[data-msg-id="51"]'),
+      ).not.toBeNull();
+    });
+
+    // The other side of the same predicate: a peer MESSAGE after the cursor
+    // still draws the line, and the JOIN sitting between them does not inflate
+    // its number. Without this arm the one above is satisfied by a divider
+    // that never appears.
+    it("counts only the MESSAGES when a peer JOIN sits in the unread run", () => {
+      setUserNick("vjt");
+      const mixedFixture: ScrollbackMessage[] = [
+        {
+          id: 60,
+          network: "freenode",
+          channel: "#grappa",
+          server_time: 1_700_000_000_000,
+          kind: "privmsg",
+          sender: "alice",
+          body: "earlier",
+          meta: {},
+        },
+        {
+          id: 61,
+          network: "freenode",
+          channel: "#grappa",
+          server_time: 1_700_000_001_000,
+          kind: "join",
+          sender: "carol",
+          body: null,
+          meta: {},
+        },
+        {
+          id: 62,
+          network: "freenode",
+          channel: "#grappa",
+          server_time: 1_700_000_002_000,
+          kind: "privmsg",
+          sender: "carol",
+          body: "ciao",
+          meta: {},
+        },
+      ];
+      seedReadCursor("freenode", "#grappa", 60);
+      setScrollback({ "freenode #grappa": mixedFixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      expect(screen.getByTestId("unread-marker")).toHaveTextContent("1 unread message");
+      // PLACEMENT is deliberately broader than the count: the line marks where
+      // the operator left off, so it goes above the JOIN — which arrived after
+      // them — rather than below it, where the JOIN would read as already seen.
+      const flow = Array.from(
+        screen
+          .getByTestId("scrollback")
+          .querySelectorAll('[data-testid="unread-marker"], .scrollback-line[data-msg-id]'),
+      );
+      const markerAt = flow.findIndex((n) => n.getAttribute("data-testid") === "unread-marker");
+      expect(flow[markerAt - 1]?.getAttribute("data-msg-id")).toBe("60");
+      expect(flow[markerAt + 1]?.getAttribute("data-msg-id")).toBe("61");
     });
 
     // Mixed-row variant: own JOIN sandwiched between a read msg and an

--- a/cicchetto/src/__tests__/loadInitialScrollback.test.ts
+++ b/cicchetto/src/__tests__/loadInitialScrollback.test.ts
@@ -312,7 +312,11 @@ describe("#693 far-behind resume", () => {
     listMessagesSpy.mockResolvedValue([row(100)]);
     await jumpToUnread("net", "#truncated");
 
-    expect(measuredUnreadByChannel()[key]).toEqual({ at: 100, count: 3000 });
+    // issue 2069 added `through`: the top of the run the jump can account for
+    // (`101 + 199`). It is what lets the record survive a cursor that moves —
+    // the count is spent minus the rows the pane HELD and the cursor passed,
+    // and that subtraction is only sound inside this run.
+    expect(measuredUnreadByChannel()[key]).toEqual({ at: 100, count: 3000, through: 300 });
   });
 
   it("a jump that drained the whole region records nothing — the rows ARE the count", async () => {

--- a/cicchetto/src/__tests__/unreadBadgeFarBehindStale.test.ts
+++ b/cicchetto/src/__tests__/unreadBadgeFarBehindStale.test.ts
@@ -293,19 +293,28 @@ describe("issue 2050 — a far-behind badge the cursor has already retired", () 
     // this arm is the measurement it was accepted WITHOUT.
     //
     // Three rows land live while the operator is still away from the tail —
-    // the channel does not stop talking because someone is scrolling. They
-    // are also what makes the badge's two candidate readings separable: the
-    // seed is a join-time snapshot and cannot move (5000), local truth is
-    // 5003. Safe under the #1229 ceiling: the pane holds one tail page, so the
-    // unread it HOLDS is ~50, an order of magnitude under the cap that would
-    // collapse the window.
+    // the channel does not stop talking because someone is scrolling. Safe
+    // under the #1229 ceiling: the pane holds one tail page, so the unread it
+    // HOLDS is ~50, an order of magnitude under the cap that would collapse
+    // the window.
     for (let id = 6001; id <= 6003; id++) {
       server.tip = id;
       scrollback.appendToScrollback(KEY, row(id, "bob"));
     }
-    // Still the frozen seed, and now demonstrably frozen: 5003 rows are unread
-    // and the badge says 5000.
-    expect(selection.messagesUnread()[KEY]).toBe(5000);
+    // 🔴 issue 2069 — these two lines expected 5000, and the comment called
+    // that "demonstrably frozen: 5003 rows are unread and the badge says
+    // 5000". It was demonstrating the DRIFT: the far-behind count grew by what
+    // the ring cap EVICTED rather than by what arrived, so below the retention
+    // cap three arrivals moved it by nothing. It is 5003 because three rows
+    // arrived, and it says so at once instead of waiting for the next full
+    // `?after=` page to fire the gap probe and correct it in one visible step.
+    //
+    // The arm loses a discriminator it used to lean on — the frozen number and
+    // local truth are now the same number, so they cannot be told apart by
+    // VALUE. That is what `farBehindByChannel()[KEY]` is asserted for directly
+    // below, and a state assertion was always the better witness of "the
+    // record still stands".
+    expect(selection.messagesUnread()[KEY]).toBe(5003);
 
     // One page up is not enough and must not be — the pane still starts
     // thousands of rows above the read position, so the region is still
@@ -313,7 +322,7 @@ describe("issue 2050 — a far-behind badge the cursor has already retired", () 
     // closes" from "retires as soon as you scroll".
     await scrollback.loadMore(SLUG, CHANNEL, noSeam);
     expect(scrollback.farBehindByChannel()[KEY]).toBeDefined();
-    expect(selection.messagesUnread()[KEY]).toBe(5000);
+    expect(selection.messagesUnread()[KEY]).toBe(5003);
 
     // Keep scrolling until the record lets go. The loop asserts no arithmetic
     // — the exit is the record's own state — so it holds for any bound that
@@ -333,12 +342,14 @@ describe("issue 2050 — a far-behind badge the cursor has already retired", () 
     expect(getReadCursor(SLUG, CHANNEL)).toBe(CAUGHT_UP_AT);
     expect(server.cursor).toBe(CAUGHT_UP_AT);
 
-    // And local truth is the WHOLE region, not a slice of it. 5003 says two
-    // things at once: the badge is no longer the seed (5000) and no longer
-    // frozen, AND the record held until every unread row was back in the pane.
-    // A bound that fired early would leave the pane holed, local truth would
-    // be short, and the badge would UNDER-report — which is the destructive
-    // unfreeze the far-behind apparatus exists to refuse.
+    // And local truth is the WHOLE region, not a slice of it: the record held
+    // until every unread row was back in the pane. A bound that fired early
+    // would leave the pane holed, local truth would be short, and the badge
+    // would UNDER-report — which is the destructive unfreeze the far-behind
+    // apparatus exists to refuse. (Pre-2069 this line ALSO said "no longer the
+    // frozen seed", by being a different number from it. It cannot say that
+    // any more — the two agree now — so the loop's exit condition above is
+    // what carries "the record retired".)
     expect(selection.messagesUnread()[KEY]).toBe(5003);
   });
 

--- a/cicchetto/src/__tests__/unreadCount.test.ts
+++ b/cicchetto/src/__tests__/unreadCount.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import type { MessageKind, ScrollbackMessage } from "../lib/api";
+import {
+  countsAsUnreadEvent,
+  countsAsUnreadMessage,
+  isOperatorOwnedRow,
+  type UnreadMeasurement,
+  type UnreadRowContext,
+  unreadMessagesAfter,
+} from "../lib/unreadCount";
+
+// issue 2069 — the contract both unread surfaces are built on.
+//
+// The sidebar pill and the in-pane divider used to spell this out separately
+// and had drifted three ways, in both directions, measured on `b7989f4ba` over
+// four fixtures. Those four fixtures are the four describes below, and each
+// one is a row class where the two surfaces disagreed:
+//
+//   fixture                      pill      divider
+//   150 rows, 113 msg + 37 JOIN  113       "150 unread messages"
+//   5 peer msgs + 5 own msgs     5         "10 unread messages"
+//   5 numeric-derived NOTICEs    5         no marker at all
+//   50 peer JOINs                (0 msgs)  "50 unread messages"
+//
+// Pinning them HERE rather than once per surface is the point: a fourth
+// consumer inherits the answer instead of re-deriving a fifth.
+
+const CASEMAPPING = "ascii" as const;
+
+const ctxFor = (overrides: Partial<UnreadRowContext>): UnreadRowContext => ({
+  ownNick: "vjt",
+  casemapping: CASEMAPPING,
+  isSelfWindow: false,
+  ...overrides,
+});
+
+const CTX = ctxFor({});
+
+const row = (
+  id: number,
+  kind: MessageKind,
+  sender: string,
+  meta: Record<string, unknown> = {},
+): ScrollbackMessage => ({
+  id,
+  network: "azzurra",
+  channel: "#grappa",
+  server_time: id,
+  kind,
+  sender,
+  body: `m${id}`,
+  meta,
+});
+
+/** ids `from`..`to`, every 4th a peer JOIN — the mixed log of the report. */
+const mixedRun = (from: number, to: number): ScrollbackMessage[] => {
+  const out: ScrollbackMessage[] = [];
+  for (let id = from; id <= to; id++) out.push(row(id, id % 4 === 0 ? "join" : "privmsg", "bob"));
+  return out;
+};
+
+describe("issue 2069 — which rows count as an unread MESSAGE", () => {
+  it("counts a peer's message", () => {
+    expect(countsAsUnreadMessage(row(1, "privmsg", "bob"), CTX)).toBe(true);
+    expect(countsAsUnreadMessage(row(2, "action", "bob"), CTX)).toBe(true);
+  });
+
+  it("counts a peer NOTICE — services chatter is real traffic", () => {
+    // No `meta.numeric`: a NickServ greeting or another user's /notice is
+    // unsolicited, and the only thing separating it from a reply to the
+    // operator's own verb is that field.
+    expect(countsAsUnreadMessage(row(3, "notice", "NickServ"), CTX)).toBe(true);
+  });
+
+  it("does NOT count a peer's presence row", () => {
+    // The divider counted these under a label that says "messages"; the pill
+    // never did. The pill was right, and the label is what says so.
+    for (const kind of ["join", "part", "quit", "nick_change", "mode", "kick"] as const) {
+      expect(countsAsUnreadMessage(row(4, kind, "carol"), CTX)).toBe(false);
+    }
+  });
+
+  it("does NOT count the operator's OWN message outside the self window", () => {
+    // #576 — a line you typed is read by definition.
+    expect(countsAsUnreadMessage(row(5, "privmsg", "vjt"), CTX)).toBe(false);
+    // The fold is the network's, not a byte compare (#372/#1861).
+    expect(countsAsUnreadMessage(row(6, "privmsg", "VJT"), CTX)).toBe(false);
+  });
+
+  it("DOES count the operator's own message in the SELF window", () => {
+    // #396 — `/msg <ownnick>` is a note-to-self, and its payload is the point.
+    // Mirrors the server's `self_window?` carve-out.
+    expect(countsAsUnreadMessage(row(7, "privmsg", "vjt"), ctxFor({ isSelfWindow: true }))).toBe(
+      true,
+    );
+  });
+
+  it("does NOT count a numeric-derived NOTICE — the operator asked for it", () => {
+    // The one class where the PILL was the wrong surface: `notice` is a
+    // content kind, so the derived badge counted a 401 the operator's own
+    // `/msg <ghost>` produced. `subscribe.ts` still gates on this predicate,
+    // but its gate stopped reaching the badge when the badge became derived.
+    expect(countsAsUnreadMessage(row(8, "notice", "irc.azzurra.org", { numeric: 401 }), CTX)).toBe(
+      false,
+    );
+  });
+
+  it("treats every operator-owned class the same way", () => {
+    expect(isOperatorOwnedRow(row(9, "privmsg", "vjt"), CTX)).toBe(true);
+    expect(isOperatorOwnedRow(row(10, "join", "vjt"), CTX)).toBe(true);
+    expect(isOperatorOwnedRow(row(11, "notice", "srv", { numeric: 401 }), CTX)).toBe(true);
+    expect(isOperatorOwnedRow(row(12, "privmsg", "bob"), CTX)).toBe(false);
+    expect(isOperatorOwnedRow(row(13, "join", "carol"), CTX)).toBe(false);
+  });
+
+  it("has no opinion when the own nick is unknown", () => {
+    // Pre-login / a network not yet in the store. `nickEquals` is null-safe
+    // and the answer must be "count it", not "exclude everything".
+    const anon = ctxFor({ ownNick: null });
+    expect(countsAsUnreadMessage(row(14, "privmsg", "vjt"), anon)).toBe(true);
+    expect(isOperatorOwnedRow(row(15, "join", "vjt"), anon)).toBe(false);
+  });
+});
+
+describe("issue 2069 — the EVENTS bucket is the same rule, other side", () => {
+  it("counts a peer's presence row and no message", () => {
+    expect(countsAsUnreadEvent(row(1, "join", "carol"), CTX)).toBe(true);
+    expect(countsAsUnreadEvent(row(2, "privmsg", "bob"), CTX)).toBe(false);
+  });
+
+  it("does NOT count the operator's own presence row", () => {
+    // A `/part → /join` cycle used to bump the faint pill by two: the badge is
+    // derived from the store, and `subscribe.ts`'s own-presence gate has not
+    // reached it since that change.
+    expect(countsAsUnreadEvent(row(3, "part", "vjt"), CTX)).toBe(false);
+    expect(countsAsUnreadEvent(row(4, "join", "vjt"), CTX)).toBe(false);
+  });
+
+  it("splits the two buckets with no row in both and none in neither", () => {
+    // The property that makes "messages + events" a partition of the rows the
+    // operator did not cause — which is what lets the two pills be read
+    // together without double-counting.
+    const rows = [
+      ...mixedRun(1, 40),
+      row(41, "privmsg", "vjt"),
+      row(42, "join", "vjt"),
+      row(43, "notice", "srv", { numeric: 366 }),
+      row(44, "notice", "NickServ"),
+    ];
+    for (const r of rows) {
+      const m = countsAsUnreadMessage(r, CTX);
+      const e = countsAsUnreadEvent(r, CTX);
+      expect(m && e).toBe(false);
+      expect(m || e).toBe(!isOperatorOwnedRow(r, CTX));
+    }
+  });
+});
+
+describe("issue 2069 — counting the region after a cursor", () => {
+  // The reported fixture: 150 rows past the cursor, 113 of them messages.
+  const rows = mixedRun(951, 1150);
+
+  it("answers in the CONTENT unit, which is what the label claims", () => {
+    expect(unreadMessagesAfter(rows, 1000, null, undefined, CTX)).toBe(113);
+  });
+
+  it("honours an upper bound — the divider's frozen session top", () => {
+    // Rows past the freeze are live-read by definition and must not renumber
+    // the line under a reader. The pill passes `null` here for the opposite
+    // reason: it is the live answer.
+    // ids 1001..1100 is 100 rows, 25 of them JOINs (every fourth) → 75.
+    expect(unreadMessagesAfter(rows, 1000, 1100, undefined, CTX)).toBe(75);
+  });
+
+  it("spends a server measurement the pane cannot answer from its rows", () => {
+    // Symptom B: the pane holds one page out of thousands. Counting the rows
+    // reports the fetch page.
+    const measured: UnreadMeasurement = { at: 1000, count: 3750, through: 1150 };
+    expect(unreadMessagesAfter(rows, 1000, null, measured, CTX)).toBe(3750);
+  });
+
+  it("subtracts what the cursor has read, instead of discarding the answer", () => {
+    // The step that used to drop the count to the page size and then to zero.
+    const measured: UnreadMeasurement = { at: 1000, count: 3750, through: 1150 };
+    // The cursor walked 1000 → 1100, which is 75 messages of the measured
+    // region (the same 75 as the bounded arm above), so 3675 remain.
+    expect(unreadMessagesAfter(rows, 1100, null, measured, CTX)).toBe(3675);
+  });
+
+  it("stands the measurement down past the run the pane can account for", () => {
+    // An own send lands the cursor at the tip, past thousands of rows the pane
+    // never held: nothing local can say how much of the region it consumed, so
+    // the record must stop answering rather than subtract only what it holds.
+    const measured: UnreadMeasurement = { at: 1000, count: 3750, through: 1150 };
+    expect(unreadMessagesAfter(rows, 9000, null, measured, CTX)).toBe(0);
+  });
+
+  it("ignores a measurement anchored above the cursor", () => {
+    const measured: UnreadMeasurement = { at: 1100, count: 3750, through: 1150 };
+    expect(unreadMessagesAfter(rows, 1000, null, measured, CTX)).toBe(113);
+  });
+
+  it("lets local truth overtake the measurement once the region is back", () => {
+    // A FLOOR, not a replacement: no separate retirement to remember.
+    const measured: UnreadMeasurement = { at: 1000, count: 10, through: 1150 };
+    expect(unreadMessagesAfter(rows, 1000, null, measured, CTX)).toBe(113);
+  });
+
+  it("never answers negative", () => {
+    const measured: UnreadMeasurement = { at: 950, count: 1, through: 1150 };
+    expect(unreadMessagesAfter(rows, 1150, null, measured, CTX)).toBe(0);
+  });
+
+  it("counts nothing in a window whose unread run is all peer presence", () => {
+    const presenceOnly = [
+      row(1000, "privmsg", "bob"),
+      ...Array.from({ length: 50 }, (_, i) => row(1001 + i, "join", `peer${i}`)),
+    ];
+    expect(unreadMessagesAfter(presenceOnly, 1000, null, undefined, CTX)).toBe(0);
+  });
+});

--- a/cicchetto/src/__tests__/unreadOneVariable.test.ts
+++ b/cicchetto/src/__tests__/unreadOneVariable.test.ts
@@ -1,0 +1,370 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GapProbe, MessageKind, ScrollbackMessage } from "../lib/api";
+import { channelKey } from "../lib/channelKey";
+
+// issue 2069 — "how many rows are behind my cursor in this window", answered
+// by variables that disagree with each other and move on their own.
+//
+// Two of the three reported symptoms are reproduced HERE, at the store level,
+// against the REAL scrollback + readCursor + selection stores and a fake
+// server that honours `after` / `before` / `limit` and answers a probe from
+// the same log it serves. A server that ignored its arguments would arm and
+// clear far-behind for reasons of its own, and every number below would be
+// the fake's rather than the store's.
+//
+// The oracle in every arm is the SERVER'S OWN ANSWER for the cursor the store
+// currently holds (`server.countMessagesAfter(cursor).messages`), not a
+// literal. A literal would pin the arithmetic of the fixture; the server
+// answer pins the PROPERTY — the badge says what is actually behind the
+// cursor — and it stays true when the fixture is edited.
+//
+// The third symptom (the in-pane divider and the sidebar badge counting
+// different populations) is not here: the divider is a projection of
+// `ScrollbackPane`, and its arms live in that file's suite, over the same
+// four fixtures. The predicate both surfaces now share is pinned on its own
+// in `unreadCount.test.ts`.
+//
+// WHAT THESE TESTS DO NOT COVER: the browser. jsdom gives the pane no
+// geometry, so the read-at-the-tail cursor arm is driven through the
+// cross-device echo instead of by scrolling, and nothing here says the
+// numbers reach a rendered badge. That is the e2e's job.
+
+vi.mock(import("../lib/api"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    listNetworks: vi.fn().mockResolvedValue([]),
+    listChannels: vi.fn().mockResolvedValue([]),
+    listMessages: vi.fn(),
+    listMessagesAfter: vi.fn(),
+    countMessagesAfter: vi.fn(),
+    sendMessage: vi.fn(),
+    me: vi.fn().mockResolvedValue({
+      kind: "user",
+      id: "u-test",
+      name: "vjt",
+      is_admin: false,
+      inserted_at: "2026-01-01T00:00:00Z",
+      read_cursors: {},
+    }),
+    login: vi.fn(),
+    logout: vi.fn(),
+    setOn401Handler: vi.fn(),
+  };
+});
+
+const SLUG = "azzurra";
+const CHANNEL = "#grappa";
+const KEY = channelKey(SLUG, CHANNEL);
+const DEFAULT_PAGE = 50;
+
+// A MIXED log — every fourth id is a peer JOIN, the rest are peer messages.
+// An all-content log cannot see a unit mismatch at all, and it also cannot see
+// the accumulator bug in arm A: that one adds the kind of the row it EVICTS,
+// which is indistinguishable from the kind of the row that arrived when every
+// row has the same kind.
+const kindOf = (id: number): MessageKind => (id % 4 === 0 ? "join" : "privmsg");
+
+const row = (id: number): ScrollbackMessage => ({
+  id,
+  network: SLUG,
+  channel: CHANNEL,
+  server_time: id,
+  kind: kindOf(id),
+  sender: "bob",
+  body: `m${id}`,
+  meta: {},
+});
+
+/** Rows 1..tip, plus the server-side read cursor the POST moves. */
+class FakeServer {
+  constructor(
+    public tip: number,
+    public cursor: number,
+  ) {}
+
+  listMessages(before?: number): ScrollbackMessage[] {
+    const hi = before === undefined ? this.tip : Math.min(this.tip, before - 1);
+    const lo = Math.max(1, hi - DEFAULT_PAGE + 1);
+    const out: ScrollbackMessage[] = [];
+    for (let i = hi; i >= lo; i--) out.push(row(i));
+    return out;
+  }
+
+  listMessagesAfter(after: number, limit: number): ScrollbackMessage[] {
+    const out: ScrollbackMessage[] = [];
+    for (let i = after + 1; i <= this.tip && out.length < limit; i++) out.push(row(i));
+    return out;
+  }
+
+  /** The three numbers `count_after_split/6` returns, over this same log. */
+  countMessagesAfter(after: number): GapProbe {
+    let gap = 0;
+    let messages = 0;
+    for (let i = after + 1; i <= this.tip; i++) {
+      gap++;
+      if (kindOf(i) === "privmsg") messages++;
+    }
+    return { gap, messages, events: gap - messages };
+  }
+}
+
+let server: FakeServer;
+
+const wireServer = async (): Promise<void> => {
+  const api = await import("../lib/api");
+  vi.mocked(api.listMessages).mockImplementation(async (_t, _s, _c, before) =>
+    server.listMessages(before),
+  );
+  vi.mocked(api.listMessagesAfter).mockImplementation(async (_t, _s, _c, after, limit) =>
+    server.listMessagesAfter(after, limit ?? DEFAULT_PAGE),
+  );
+  vi.mocked(api.countMessagesAfter).mockImplementation(async (_t, _s, _c, after) =>
+    server.countMessagesAfter(after),
+  );
+  // `readCursor.setReadCursor` POSTs through raw `fetch`. Stub the transport,
+  // not the module: the optimistic local advance lives inside it.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockImplementation(async (_url: string, init: { body: string }) => {
+      const id = JSON.parse(init.body).message_id as number;
+      if (id > server.cursor) server.cursor = id;
+      return { ok: true, status: 200, json: async () => ({}) };
+    }),
+  );
+};
+
+/** What `subscribe.ts` does on every per-channel join, initial AND rejoin. */
+const joinChannelTopic = async (): Promise<void> => {
+  const { applyJoinReply } = await import("../lib/readCursor");
+  const { setServerSeedCount } = await import("../lib/selection");
+  applyJoinReply(SLUG, CHANNEL, server.cursor);
+  const probe = server.countMessagesAfter(server.cursor);
+  setServerSeedCount(KEY, { messages: probe.messages, events: probe.events });
+};
+
+/** The badge the sidebar renders for this window, right now. */
+const badge = async (): Promise<number> => {
+  const selection = await import("../lib/selection");
+  return selection.messagesUnread()[KEY] ?? 0;
+};
+
+/** What the server would answer for the cursor the store currently holds. */
+const truth = async (): Promise<number> => {
+  const { getReadCursor } = await import("../lib/readCursor");
+  return server.countMessagesAfter(getReadCursor(SLUG, CHANNEL) ?? 0).messages;
+};
+
+/**
+ * A long absence drove this window into #693's far-behind state. Returns once
+ * the state is armed — the premise of the arms below, not a claim of their own.
+ */
+const absenceThenReconnect = async (): Promise<void> => {
+  const { refreshScrollback, farBehindByChannel } = await import("../lib/scrollback");
+  await joinChannelTopic();
+  await refreshScrollback(SLUG, CHANNEL);
+  expect(farBehindByChannel()[KEY]).toBeDefined();
+};
+
+/**
+ * Re-selecting an already-loaded window. `selection.ts`'s `selectedChannel`
+ * effect fires exactly this verb for that gesture (the load-once
+ * `loadInitialScrollback` fetches nothing on a second visit), so this is the
+ * gesture and not an approximation of it.
+ */
+const reSelect = async (): Promise<void> => {
+  const { refreshScrollback } = await import("../lib/scrollback");
+  await refreshScrollback(SLUG, CHANNEL);
+};
+
+/** Live rows landing on the per-channel WS topic while the operator is away. */
+const peerTraffic = async (n: number): Promise<void> => {
+  const { appendToScrollback } = await import("../lib/scrollback");
+  for (let i = 0; i < n; i++) {
+    server.tip += 1;
+    appendToScrollback(KEY, row(server.tip));
+  }
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  localStorage.clear();
+  vi.clearAllMocks();
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => "visible",
+  });
+  localStorage.setItem("grappa-token", "tok");
+  server = new FakeServer(6000, 1000);
+});
+
+// SYMPTOM A, as reported: "open a channel with hundreds unread → 500. Do not
+// scroll. Select another window, then re-select the first → 800."
+//
+// Measured on `b7989f4ba`, this is TWO defects and the accusation in the issue
+// named neither. A bare re-select with no traffic moves nothing. What moves is:
+//
+//   1. while the operator is away, `appendPageToScrollback` accumulates the
+//      far-behind count by the CONTENT-NESS OF THE ROW IT EVICTED rather than
+//      of the row that arrived — and adds nothing at all until the store
+//      reaches `UNREAD_RETENTION_CAP`, so the count drifts BELOW the truth
+//      (measured: 4012 against a true 4125 after 500 rows);
+//   2. the re-select's `?after=` page comes back FULL, which fires the gap
+//      probe, which re-anchors — OVERWRITING the drifted number with a fresh
+//      server measurement. 4012 → 4125 in one step, with no scroll and no read.
+//
+// So the re-probe the issue asked us to look for is real, and it is the
+// CORRECTION rather than the cause. Curing only the visible step (the jump)
+// would leave the drift, which is the number the operator reads for as long as
+// they stay away.
+describe("issue 2069 A — the far-behind count while the operator is away", () => {
+  it("tracks the server's own answer as peer traffic lands", async () => {
+    await wireServer();
+    await absenceThenReconnect();
+    expect(await badge()).toBe(await truth());
+
+    // Below the retention cap the store has not evicted anything yet: the arm
+    // that under-reported by an entire page.
+    await peerTraffic(100);
+    expect(await badge()).toBe(await truth());
+
+    // Past the cap, one eviction per arrival — where the kind mix decides
+    // whether the old accumulator drifts up or down.
+    await peerTraffic(400);
+    expect(await badge()).toBe(await truth());
+  });
+
+  it("does not move on a re-select the operator learns nothing from", async () => {
+    await wireServer();
+    await absenceThenReconnect();
+    await peerTraffic(500);
+
+    const before = await badge();
+    await reSelect();
+    // The gesture is "look away, look back". It carries no reading and no
+    // scrolling, so it may not change the answer — and it is the step the
+    // report saw, because it is where the correction became visible.
+    expect(await badge()).toBe(before);
+    await reSelect();
+    expect(await badge()).toBe(before);
+  });
+
+  it("is still the server's answer after the re-select", async () => {
+    await wireServer();
+    await absenceThenReconnect();
+    await peerTraffic(500);
+    await reSelect();
+
+    // The companion of the arm above: "did not move" is satisfied by a number
+    // that is stuck as well as by one that is right.
+    expect(await badge()).toBe(await truth());
+  });
+
+  it("does not move on a re-select with no traffic at all", async () => {
+    await wireServer();
+    await absenceThenReconnect();
+
+    const before = await badge();
+    await reSelect();
+    expect(await badge()).toBe(before);
+    expect(await badge()).toBe(await truth());
+  });
+});
+
+// SYMPTOM B, as reported: "badge and bar both read 2900 → take the jump →
+// change channel → the window reads 200. 200 is the fetch page, not a fact
+// about the conversation."
+//
+// Reproduced, and it is worse than reported: the number does not stop at the
+// page size. `jumpToUnread` retires the far-behind record, the badge falls
+// back to counting the rows the store holds, and as the operator reads through
+// the one page the jump loaded the count reaches ZERO — on a window with
+// thousands still unread. Measured on `b7989f4ba`: 3750 → 150 → 0, cursor at
+// 1200, server answer 3600.
+//
+// The measurement that would have answered every one of those was already on
+// file: `measuredUnreadByChannel` (#947), written by the very jump that caused
+// this. Only the divider ever spent it.
+describe("issue 2069 B — the count after a jump back into the unread region", () => {
+  const jump = async (): Promise<void> => {
+    const { jumpToUnread } = await import("../lib/scrollback");
+    expect(await jumpToUnread(SLUG, CHANNEL)).toBe(true);
+  };
+
+  it("survives the jump that loaded one page out of thousands", async () => {
+    await wireServer();
+    await absenceThenReconnect();
+    expect(await badge()).toBe(await truth());
+
+    await jump();
+    expect(await badge()).toBe(await truth());
+  });
+
+  it("still survives when the operator changes channel and comes back", async () => {
+    await wireServer();
+    await absenceThenReconnect();
+    await jump();
+    await reSelect();
+
+    expect(await badge()).toBe(await truth());
+  });
+
+  it("falls by what the operator read, not to the page size", async () => {
+    await wireServer();
+    await absenceThenReconnect();
+    await jump();
+    const { applyReadCursorSet } = await import("../lib/readCursor");
+
+    // Reading half the loaded page. The cross-device echo is the same cursor
+    // write the pane's read-at-the-tail arm performs, without the geometry
+    // jsdom cannot give it.
+    applyReadCursorSet(SLUG, CHANNEL, 1100);
+    expect(await badge()).toBe(await truth());
+
+    // ...and all of it. This is where the count used to reach zero.
+    applyReadCursorSet(SLUG, CHANNEL, 1200);
+    expect(await badge()).toBe(await truth());
+    expect(await badge()).toBeGreaterThan(0);
+  });
+
+  it("follows the operator paging forward through the region", async () => {
+    await wireServer();
+    await absenceThenReconnect();
+    await jump();
+    const { loadNewer } = await import("../lib/scrollback");
+    const { applyReadCursorSet } = await import("../lib/readCursor");
+
+    // Read the page, then scroll to the bottom of it — which pages the NEXT
+    // page of the region in. The count must keep describing the conversation
+    // and not the pane, all the way down.
+    applyReadCursorSet(SLUG, CHANNEL, 1200);
+    await loadNewer(SLUG, CHANNEL);
+    expect(await badge()).toBe(await truth());
+
+    applyReadCursorSet(SLUG, CHANNEL, 1400);
+    await loadNewer(SLUG, CHANNEL);
+    expect(await badge()).toBe(await truth());
+  });
+
+  it("stands down when the cursor leaves the run the pane can account for", async () => {
+    await wireServer();
+    await absenceThenReconnect();
+    await jump();
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+
+    // The operator says something from the middle of the region. The send
+    // carries the cursor to the TIP, past thousands of rows the pane never
+    // held — so nothing local can say how many of the measured region it
+    // consumed. The server's answer for the new cursor is ZERO, and a
+    // measurement that kept subtracting only what the pane happens to hold
+    // would answer thousands. It has to stand down instead.
+    server.tip = 6001;
+    vi.mocked(api.sendMessage).mockResolvedValue(row(6001));
+    await scrollback.sendMessage(SLUG, CHANNEL, "ciao");
+
+    expect(await truth()).toBe(0);
+    expect(await badge()).toBe(0);
+  });
+});

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -15,6 +15,7 @@ import { identityMoved } from "./identityMoved";
 import { identityScopedStore } from "./identityScopedStore";
 import { getReadCursor, setReadCursor } from "./readCursor";
 import { getResumeCursor, recordSeen } from "./reconnectBackfill";
+import type { UnreadMeasurement } from "./unreadCount";
 
 // Per-channel scrollback store: the source of truth for messages
 // rendered in `ScrollbackPane`. Module-singleton signal store mirroring
@@ -214,16 +215,20 @@ type CappedRing = {
   // Unread rows (id > cursor) held BEFORE the drop — the banner's count the
   // first time the bound bites. Afterwards the caller accumulates.
   unreadHeld: number;
-  // #2037 — the same two figures restricted to `@content_kinds`. The banner's
-  // number is the MESSAGES bucket now, so accumulating raw row counts into it
-  // would mix units: 200 evicted JOINs would inflate a figure the sidebar's
-  // bold pill reports without them.
+  // #2037 — the same figure restricted to `@content_kinds`. The banner's
+  // number is the MESSAGES bucket, so accounting in raw row counts would mix
+  // units: 200 evicted JOINs would move a figure the sidebar's bold pill
+  // reports without them.
   //
   // The ARMING condition stays on the raw `unreadDropped`, deliberately. What
   // arms far-behind is "a row at/after the cursor left the store", which is
   // true of a JOIN too — the divider can no longer be placed either way. Only
   // the DISPLAYED quantity is content-only.
-  contentDropped: number;
+  //
+  // issue 2069 deleted the `contentDropped` sibling this pair used to carry.
+  // The far-behind count is maintained from ARRIVALS now, not from evictions —
+  // see `appendPageToScrollback`. These two are still what ARMS the state and
+  // what it opens at.
   contentHeld: number;
   cursor: number | null;
 };
@@ -308,7 +313,6 @@ export const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): C
       rows: rows.slice(rows.length - UNREAD_RETENTION_CAP),
       unreadDropped: overflowUnread,
       unreadHeld: unreadCount,
-      contentDropped: contentCount - keptContentCount(rows, UNREAD_RETENTION_CAP),
       contentHeld: contentCount,
       cursor,
     };
@@ -325,17 +329,10 @@ export const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): C
     rows: dropCount > 0 ? rows.slice(dropCount) : rows,
     unreadDropped: 0,
     unreadHeld: unreadCount,
-    contentDropped: 0,
     contentHeld: contentCount,
     cursor,
   };
 };
-
-// #2037 — content rows surviving inside the kept tail slice. Subtracting this
-// from the held count gives what the bite actually took, in the same unit the
-// banner reports.
-const keptContentCount = (rows: ScrollbackMessage[], keep: number): number =>
-  rows.slice(Math.max(0, rows.length - keep)).filter((m) => isContentKind(m.kind)).length;
 
 // #788 — how THE identity rule applies to this module. The predicate itself,
 // and why a continuation that outlived its identity must do nothing further
@@ -501,6 +498,17 @@ const exports = identityScopedStore((onIdentityChange) => {
   // fetch cap leaking into a user-visible number, one notch after the case
   // #693 suppressed.
   //
+  //   * `through` — the newest id the pane can ACCOUNT for out of that
+  //     measurement: the top of the contiguous run the jump loaded, extended
+  //     by `loadNewer` as the pane pages forward into the region. issue 2069
+  //     added it, and it is what lets the record survive a cursor that moves:
+  //     `unreadMessagesAfter` subtracts the rows the cursor passed, which is
+  //     only sound while the pane HELD them. A cursor that leaves the run —
+  //     an own send lands at the tip, a peer device reads ahead — is past
+  //     `through`, and the record stands down instead of answering with a
+  //     number it cannot support. Without it the badge collapsed to the fetch
+  //     page and then to ZERO on a window with thousands unread (measured on
+  //     `b7989f4ba`: 3750 → 150 → 0 against a server answer of 3600).
   //   * `count` — the same server measurement the jump affordance advertised
   //     (`far.missed`). Deliberately the SAME number and not a second one:
   //     the alternative is showing the operator a third figure for one
@@ -516,7 +524,7 @@ const exports = identityScopedStore((onIdentityChange) => {
   //     sweep: once the freeze re-latches, the answer stops applying on its
   //     own and the pane falls back to counting rows.
   const [measuredUnreadByChannel, setMeasuredUnreadByChannel] = createSignal<
-    Record<ChannelKey, { at: number; count: number }>
+    Record<ChannelKey, UnreadMeasurement>
   >({});
 
   const clearMeasuredUnread = (key: ChannelKey): void => {
@@ -655,9 +663,14 @@ const exports = identityScopedStore((onIdentityChange) => {
     // no longer place.
     let unreadDropped = 0;
     let unreadHeld = 0;
-    let contentDropped = 0;
     let contentHeld = 0;
     let prunedCursor = 0;
+    // issue 2069 — what ARRIVED: fresh rows newer than everything the pane
+    // already held. This is the quantity a far-behind window's count grows by,
+    // and it is deliberately measured BEFORE the ring cap runs, because the cap
+    // is why the pane cannot answer the question afterwards.
+    let arrivedContent = 0;
+    let arrivedEvents = 0;
     // #1229 — the rows and the far-behind flag are ONE state transition and must
     // reach consumers in ONE flush. Published as two writes, Solid runs every
     // effect of the rows change FIRST, in a world where the window has already
@@ -688,11 +701,20 @@ const exports = identityScopedStore((onIdentityChange) => {
           isCanonicallyOrdered(fresh)
             ? [...existing, ...fresh]
             : [...existing, ...fresh].sort(byServerTimeThenId);
+        // issue 2069 — an ARRIVAL is a fresh row above the pane's previous
+        // newest. Rows at or below it are backfill: already inside whatever
+        // measurement the far-behind record carries, so counting them would
+        // report the same message twice.
+        const previousNewest = tail?.id ?? 0;
+        for (const m of fresh) {
+          if (m.id <= previousNewest) continue;
+          if (isContentKind(m.kind)) arrivedContent++;
+          else arrivedEvents++;
+        }
         const capped = capScrollbackRing(key, next);
         evicted = capped.rows.length < next.length;
         unreadDropped = capped.unreadDropped;
         unreadHeld = capped.unreadHeld;
-        contentDropped = capped.contentDropped;
         contentHeld = capped.contentHeld;
         prunedCursor = capped.cursor ?? 0;
         return { ...prev, [key]: capped.rows };
@@ -703,26 +725,58 @@ const exports = identityScopedStore((onIdentityChange) => {
       if (evicted) loadMoreExhausted.delete(key);
       // #1229 — the pruned window joins the #693 far-behind state: divider
       // suppressed, "N unread — jump back" banner up, `jumpToUnread` rebuilding
-      // the region from the server around this same `resumeFrom`. `missed`
+      // the region from the server around this same `resumeFrom`. The count
       // ACCUMULATES once the state is up: after the first bite the store only
       // ever holds one page, so a recount would report 200 forever while the
       // operator is thousands behind.
-      if (unreadDropped > 0) {
+      //
+      // 🔴 issue 2069 — it accumulates by what ARRIVED, not by what was
+      // EVICTED, and the difference is the whole of symptom A. Counting
+      // evictions is wrong twice over: below the retention cap nothing is
+      // evicted, so an entire page of arrivals is invisible; above it the
+      // increment carries the KIND OF THE ROW THAT LEFT, which on a mixed log
+      // is not the kind of the row that came in. Measured on `b7989f4ba` with
+      // a 3:1 message:JOIN log, 500 arrivals moved the count to 4012 against a
+      // server answer of 4125 — and the drift was invisible until the next
+      // FULL `?after=` page fired the gap probe and `anchorAtTail` overwrote
+      // the number with a fresh measurement. That correction is what the
+      // report saw as "the badge changed on a re-select": no scroll, no read,
+      // +113 in one step. Arrivals are exact, independent of the cap, and
+      // leave the probe nothing to correct.
+      if (unreadDropped > 0 || arrivedContent + arrivedEvents > 0) {
         setFarBehindByChannel((prev) => {
           const current = prev[key];
+          // Arrivals alone never ARM the state — that stays keyed on the raw
+          // `unreadDropped` (a JOIN leaving the store unplaces the divider
+          // exactly as a message does). An ordinary live append to an ordinary
+          // window returns `prev` unchanged and Solid skips the write.
+          if (current === undefined) {
+            if (unreadDropped === 0) return prev;
+            return {
+              ...prev,
+              [key]: {
+                // #2037 — opens in the CONTENT unit, the same one the probe
+                // writes and the pill reads. The rows that arrived in THIS
+                // batch are already inside `contentHeld`, so they are not
+                // added again.
+                missed: contentHeld,
+                events: unreadHeld - contentHeld,
+                resumeFrom: prunedCursor,
+              },
+            };
+          }
+          if (arrivedContent + arrivedEvents === 0) return prev;
           return {
             ...prev,
             [key]: {
-              // #2037 — accumulates in the CONTENT unit, the same one the
-              // probe writes and the pill reads. Arming still keys on the raw
-              // `unreadDropped` above: a JOIN leaving the store unplaces the
-              // divider exactly as a message does.
-              missed: current === undefined ? contentHeld : current.missed + contentDropped,
-              events:
-                current === undefined
-                  ? unreadHeld - contentHeld
-                  : current.events + (unreadDropped - contentDropped),
-              resumeFrom: prunedCursor,
+              missed: current.missed + arrivedContent,
+              events: current.events + arrivedEvents,
+              // The anchor tracks the frozen cursor exactly as it did before.
+              // The `> 0` guard is new because the arrivals-only path can now
+              // reach this line with no read cursor at all, where `?? 0` would
+              // overwrite a real anchor with zero; the eviction-only path could
+              // not, since a cap bite at/after the cursor implies one exists.
+              resumeFrom: prunedCursor > 0 ? prunedCursor : current.resumeFrom,
             },
           };
         });
@@ -1051,7 +1105,15 @@ const exports = identityScopedStore((onIdentityChange) => {
       if (afterPage.length === PAGE_LIMIT) {
         setMeasuredUnreadByChannel((prev) => ({
           ...prev,
-          [key]: { at: far.resumeFrom, count: far.missed },
+          [key]: {
+            at: far.resumeFrom,
+            count: far.missed,
+            // issue 2069 — the top of the run this jump can account for. The
+            // page is contiguous from `at` by construction (`after(at)` ASC,
+            // no cap in play at one page), so every row between the two is in
+            // the pane and a cursor moving through them is subtractable.
+            through: afterPage[afterPage.length - 1]?.id ?? far.resumeFrom,
+          },
         }));
       } else {
         clearMeasuredUnread(key);
@@ -1369,6 +1431,18 @@ const exports = identityScopedStore((onIdentityChange) => {
         loadNewerExhausted.add(key);
       } else {
         mergeIntoScrollback(key, page);
+        // issue 2069 — paging forward EXTENDS the run a carried measurement
+        // can account for. The fetch is `after(<newest loaded>)`, so the page
+        // abuts what the pane already holds and the union stays contiguous;
+        // without this the record stands down the moment the operator reads
+        // past the page the jump landed them on, which is the one gesture the
+        // record exists to survive.
+        const top = page.reduce((max, m) => (m.id > max ? m.id : max), newest.id);
+        setMeasuredUnreadByChannel((prev) => {
+          const current = prev[key];
+          if (current === undefined || top <= current.through) return prev;
+          return { ...prev, [key]: { ...current, through: top } };
+        });
       }
     } catch {
       // Transient error — do NOT latch. The user can retry by scrolling;

--- a/cicchetto/src/lib/selection.ts
+++ b/cicchetto/src/lib/selection.ts
@@ -1,5 +1,5 @@
 import { createEffect, createMemo, createSignal, on, untrack } from "solid-js";
-import { isContentKind, ownNickForNetwork } from "./api";
+import { ownNickForNetwork } from "./api";
 import { token } from "./auth";
 import { casemappingForSlug } from "./casemapping";
 import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
@@ -17,10 +17,12 @@ import { readingAtTailKey } from "./readingAtTail";
 import {
   farBehindByChannel,
   loadInitialScrollback,
+  measuredUnreadByChannel,
   refreshScrollback,
   scrollbackByChannel,
   wasLoaded,
 } from "./scrollback";
+import { countsAsUnreadEvent, type UnreadRowContext, unreadMessagesAfter } from "./unreadCount";
 import {
   HOME_WINDOW_NAME,
   HOME_WINDOW_SLUG,
@@ -441,6 +443,12 @@ const exports = identityScopedStore((onIdentityChange) => {
     }
 
     const farBehind = farBehindByChannel();
+    // issue 2069 — the server's own answer for a window whose loaded unread
+    // region is truncated (#947). Until now only the in-pane divider spent it,
+    // so the pill fell back to counting the rows the store holds — one page
+    // out of thousands after a jump, and then ZERO as the operator read
+    // through that page. Same record, same unit, now both surfaces.
+    const measured = measuredUnreadByChannel();
 
     // #2037 — a far-behind window reads its counts from the far-behind entry,
     // not from the seed. Both are `count_after_split/6` at the read cursor, so
@@ -488,32 +496,32 @@ const exports = identityScopedStore((onIdentityChange) => {
       // so it is NOT excluded there (#396). Mirrors the server self-window
       // carve-out in `Scrollback.exclude_own_authored/3`.
       const casemapping = casemappingForNetwork(net?.id ?? null);
-      const isSelfWindow = nickEquals(decoded.name, ownNick, casemapping);
-
-      let msgs = 0;
+      const ctx: UnreadRowContext = {
+        ownNick,
+        casemapping,
+        isSelfWindow: nickEquals(decoded.name, ownNick, casemapping),
+      };
+      // #239 — skip rows the presence filter hides for this channel: the pane
+      // never renders them, so counting them would leave a badge the operator
+      // can never clear by reading. Same predicate the pane's `rows()` filter
+      // uses (reconcile-to-one, not a forked filter) — which is also why the
+      // filter is applied HERE and not inside `unreadCount`: it is per-channel
+      // UI state, and the shared module must not reach for it.
+      const visible = rows.filter((row) => presenceRowVisible(key, memberCount, row.kind));
+      // issue 2069 — the MESSAGES bucket is `unreadMessagesAfter`, the one
+      // function the in-pane divider also calls. No upper bound: the pill is
+      // the LIVE answer, so an arrival past the frozen session top still
+      // counts (the divider, which must not renumber under a reader, passes
+      // its frozen top instead). The measurement is what stops the count
+      // collapsing to the fetch page after a #693 jump.
+      const msgs = unreadMessagesAfter(visible, cursor, null, measured[key], ctx);
+      // The presence sibling, same operator-owned rule. Own JOIN/PART rows
+      // used to land here — `subscribe.ts` drops them at its own gate, but
+      // that gate has not reached the badge since the count became derived,
+      // so a `/part → /join` cycle bumped the faint pill by two.
       let evts = 0;
-      for (const row of rows) {
-        if (row.id <= cursor) continue;
-        // #239 — skip rows the presence filter hides for this channel: the
-        // pane never renders them, so counting them would leave a badge the
-        // operator can never clear by reading. Same predicate the pane's
-        // `rows()` filter uses (reconcile-to-one, not a forked filter).
-        if (!presenceRowVisible(key, memberCount, row.kind)) continue;
-        if (isContentKind(row.kind)) {
-          // #576 — a content row the operator authored is read BY DEFINITION;
-          // outside the self-window it must not inflate the badge (the
-          // content-row twin of the #532 A own-presence exclusion, mirrored
-          // server-side in `Scrollback.exclude_own_authored/3`). `sender` is
-          // compared via the network's nick fold (#372/#1861 `nickEquals`) —
-          // display stays raw, the MATCH folds. Belt-and-braces over the optimistic
-          // send-time cursor advance (scrollback.ts), which has gaps (the #50
-          // empty-pane gate; a cross-device / out-of-order cursor landing
-          // below your own line).
-          if (!isSelfWindow && nickEquals(row.sender, ownNick, casemapping)) continue;
-          msgs++;
-        } else {
-          evts++;
-        }
+      for (const row of visible) {
+        if (row.id > cursor && countsAsUnreadEvent(row, ctx)) evts++;
       }
       result[key] = { messages: msgs, events: evts };
     }

--- a/cicchetto/src/lib/unreadCount.ts
+++ b/cicchetto/src/lib/unreadCount.ts
@@ -1,0 +1,140 @@
+// issue 2069 — ONE answer to "how many unread messages are in this window".
+//
+// Before this module the question had four implementations that disagreed with
+// each other in both directions, measured on `b7989f4ba` over one fixture of
+// 150 rows past the cursor (113 peer messages + 37 peer JOINs):
+//
+//   * the sidebar pill said 113, splitting on `isContentKind`;
+//   * the in-pane divider said "150 unread messages", filtering only operator
+//     echoes and own presence — so it counted the JOINs, under a label that
+//     says "messages";
+//   * the divider counted the operator's OWN messages (10 where the pill said
+//     5) and the pill counted numeric-derived NOTICEs the divider excluded
+//     (5 where the divider drew no marker at all);
+//   * a window with nothing but 50 peer JOINs unread drew "50 unread messages"
+//     beside a pill reading nothing.
+//
+// The two predicate modules this one composes each claim, in their own
+// moduledoc, to be the "single source of truth" shared by "subscribe.ts (the
+// sidebar badge gate)" and the in-pane marker. That was true when the badge
+// was BUMPED per row. It stopped being true when the badge became DERIVED from
+// `(scrollbackByChannel, readCursors, serverSeedCounts)` — `subscribe.ts` still
+// calls both predicates, but the early-return it guards now only reaches the
+// mention beep, and the derivation in `selection.ts` never saw them. Nothing
+// broke loudly; the two surfaces just drifted apart, one row class at a time.
+// So the predicate lives HERE, where both surfaces reach it, and neither
+// surface re-derives it.
+//
+// ## Why the two surfaces still differ, and must
+//
+// The issue asks for "one variable ... it must not change while the cursor
+// does not move". That is right for the DIVIDER and wrong for the PILL, so
+// what this module publishes is one FUNCTION evaluated at two anchors, not one
+// value read twice:
+//
+//   * the divider passes the FROZEN cursor and the frozen session top — the
+//     freeze contract, which exists so the line does not renumber under a
+//     reader (DESIGN_NOTES 2026-06-08);
+//   * the pill passes the LIVE cursor and no upper bound — a pill that ignored
+//     arrivals while the cursor sat still would stop telling the operator that
+//     a window is receiving traffic, which is the pill's whole job.
+//
+// Same population, same unit, same source-selection. Different anchors, on
+// purpose.
+
+import { isContentKind, type ScrollbackMessage } from "./api";
+import type { Casemapping } from "./isupport";
+import { nickEquals } from "./nickEquals";
+import { isOperatorActionEcho } from "./operatorActionEcho";
+import { isOwnPresenceEvent } from "./ownPresenceEvent";
+
+/**
+ * Who the operator is, for this window. `isSelfWindow` is the #396 carve-out:
+ * the pane keyed to your own nick is the ONE window where own content is
+ * legitimate payload (a note-to-self), so it is not excluded there. Mirrors
+ * the server's `self_window?` in `Scrollback.count_after_split/6`.
+ */
+export type UnreadRowContext = {
+  ownNick: string | null;
+  casemapping: Casemapping;
+  isSelfWindow: boolean;
+};
+
+/**
+ * A row that exists because of the operator's OWN action: their own message,
+ * their own presence verb, or a numeric-derived server reply to something they
+ * typed. Never an alert, on any surface.
+ *
+ * @returns true when the row must not count as unread anywhere.
+ */
+export const isOperatorOwnedRow = (message: ScrollbackMessage, ctx: UnreadRowContext): boolean => {
+  if (isOperatorActionEcho(message)) return true;
+  if (isOwnPresenceEvent(message, ctx.ownNick, ctx.casemapping)) return true;
+  // #576 — own CONTENT is read by definition, outside the self window.
+  if (!isContentKind(message.kind)) return false;
+  return !ctx.isSelfWindow && nickEquals(message.sender, ctx.ownNick, ctx.casemapping);
+};
+
+/**
+ * @returns true when the row counts toward the number rendered as
+ *          "N unread messages" — the CONTENT unit, on every surface.
+ */
+export const countsAsUnreadMessage = (message: ScrollbackMessage, ctx: UnreadRowContext): boolean =>
+  isContentKind(message.kind) && !isOperatorOwnedRow(message, ctx);
+
+/**
+ * @returns true when the row counts toward the faint EVENTS pill — the
+ *          presence sibling of the bucket above, same operator-owned rule.
+ */
+export const countsAsUnreadEvent = (message: ScrollbackMessage, ctx: UnreadRowContext): boolean =>
+  !isContentKind(message.kind) && !isOperatorOwnedRow(message, ctx);
+
+/**
+ * A server measurement still on file for this window: "`count` unread messages
+ * follow id `at`, and the pane can account for every row up to `through`".
+ *
+ * `through` is what makes the record spendable after the cursor moves. The
+ * subtraction below only works while every row the cursor passed is one the
+ * pane HELD — page forward and the run grows with it; jump the cursor to the
+ * tip on an own send and it does not, so the record stands down rather than
+ * answering with a number it cannot support.
+ */
+export type UnreadMeasurement = { at: number; count: number; through: number };
+
+/**
+ * How many unread MESSAGES follow `cursor` in this window.
+ *
+ * @param rows   the window's loaded rows, ASC by id, presence filter already
+ *               applied by the caller (the pane and the pill share
+ *               `presenceRowVisible`, which is per-channel state neither this
+ *               module nor its callers should re-derive).
+ * @param cursor the read position to count after.
+ * @param upTo   upper bound on the LOCAL count (the divider's frozen session
+ *               top); `null` counts to the newest row the pane holds.
+ * @param measured the server's answer for this window, if one is on file.
+ * @returns a count, never negative.
+ */
+export const unreadMessagesAfter = (
+  rows: readonly ScrollbackMessage[],
+  cursor: number,
+  upTo: number | null,
+  measured: UnreadMeasurement | undefined,
+  ctx: UnreadRowContext,
+): number => {
+  let local = 0;
+  let consumed = 0;
+  const spendable = measured !== undefined && cursor >= measured.at && cursor <= measured.through;
+  for (const message of rows) {
+    if (!countsAsUnreadMessage(message, ctx)) continue;
+    if (message.id > cursor && (upTo === null || message.id <= upTo)) local++;
+    if (spendable && measured !== undefined && message.id > measured.at && message.id <= cursor)
+      consumed++;
+  }
+  if (!spendable || measured === undefined) return local;
+  // A FLOOR, not a replacement. Once the pane has paged the region back in,
+  // local truth overtakes the measurement and the record stops mattering
+  // without anyone having to retire it — the same self-invalidating shape
+  // #947 chose for its `at` stamp, generalised so a cursor that moved does
+  // not throw the answer away.
+  return Math.max(local, measured.count - consumed);
+};

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52848,3 +52848,49 @@ precondition was satisfied by the discarded rows will fail for the right
 reason.** Read such a red as an oracle before reading it as a regression — but
 prove which it is on both refs, because the two are indistinguishable from the
 red alone.
+
+### The fifth command, and why a green first command does not vouch for it
+
+CI turned this slice's own browser witness red on one shard —
+`issue2069-one-unread-number.spec.ts`, `IrcPeer: timeout waiting for part
+#spec-w0 (5000ms)` — while the full local suite had passed it twice. The frame
+was in `fixtures/ircClient.ts` rather than in an assertion, which is suggestive
+and proves nothing: a shared fixture can be the victim as easily as the culprit.
+
+It reproduces, and hard: `--repeat-each 20` on the unfixed tree gives **9 reds
+in 20**, every one carrying that identical signature. So the argument never had
+to be settled on the code.
+
+**bahamut charges fake-lag per COMMAND**, and the spec fired JOIN + 3×PRIVMSG +
+PART back to back on one connection, making the PART the FIFTH command against a
+bank the four before it had filled. `IrcPeer.part` waits for its own echo on
+`PART_TIMEOUT_MS` = 5s, while the overshoot this file's own `whoisAway` comment
+documents is ~10s — the budget is under the known worst case, and only for
+callers that arrive late in a burst.
+
+The discriminator against "the testnet is just slow" is in the same 20 runs and
+costs nothing to read: **`IrcPeer.join` carries the SAME 5s budget and timed out
+zero times.** First command always fine, fifth command half the time not. That
+is a per-command bank, not latency — and it is why a spec can be green a hundred
+times on its first wait and still be a coin flip on its last.
+
+Cured by draining the bank on an OBSERVABLE signal: poll until the three
+messages are on the server (the endpoint the spec was already polling
+afterwards), THEN send the PART, so it goes out alone. **No timeout raised, no
+assertion touched.** Measured after: **20 green in 20** — `0.55^20 ≈ 6e-6` had
+the rate stayed where it was.
+
+Two things worth carrying forward. First, **the timeouts in `ircClient.ts` are
+not interchangeable**: `join`/`part`/`nick`/`mode`/`kick` sit at 5s while
+`topic`/`privmsg`/`whois` sit at 15s precisely because the latter were found
+behind the lag bank. A wait's budget is only sound for the POSITION its caller
+occupies in a burst, and nothing in the API says which position that is. Second,
+the general rule: **a burst of IRC commands on one connection is not a setup
+step, it is a queue** — barrier between the plants and the closer, or the closer
+inherits every penalty the plants earned.
+
+Six other specs call `IrcPeer.part`; the closest, `issue2037`, fires four
+commands where this one fired five. They are not touched here — none has been
+seen red, and widening a cure past its measurement is how a fixture acquires
+ballast nobody can later justify. The mechanism is written down so the next
+sighting is diagnosed in one reading instead of re-derived.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52803,3 +52803,48 @@ contains peer presence rows, and that those rows RENDER (`#spec-wN` is far
 under `LARGE_CHANNEL_THRESHOLD`), because a hidden presence row is excluded
 from the old count too, by a different rule, and the spec would be green on the
 broken build.
+
+### The e2e that was green for the defect's reason
+
+The full `scripts/integration.sh` over this branch turned one red inside the
+slice's own subject — `unread-cursor-cluster.spec.ts`, "focused send collapses
+the in-pane unread marker immediately" — and the honest reading of it is the
+opposite of the obvious one, so it goes on the record rather than into the diff.
+
+Attribution, measured on both refs rather than argued:
+
+| | this branch | base `b7989f4ba` |
+| --- | --- | --- |
+| `unread-cursor-cluster:184` | 1 red in 5 | 10 green in 10 |
+
+So the slice caused it. What it did NOT do is break the behaviour the spec
+describes. `sessionTopId` latches the tail of the FIRST non-empty observation
+the pane makes, and every row above that latch is a live arrival that draws no
+marker on purpose — the operator watched it land. The spec sends the peer's
+PRIVMSG and navigates immediately, so which side of the latch that row falls on
+was never established by its setup. The awaited `peer.join` before it reliably
+WAS inside the latch, and while the divider counted presence rows the JOIN alone
+injected `1 unread` — so the spec went green, in that ordering, on the strength
+of the exact defect this entry is about. Restrict the count to messages and the
+stand-in disappears; the unguarded ordering stops being masked and starts being
+a flake.
+
+That is a precondition the spec depended on and never established, not a
+weakened contract, so the cure is to establish it (`assertMessagePersisted`
+before the navigation) and the assertion is untouched. Measured after:
+**20 green in 20**, against a pre-fix rate of 1 in 5 — `0.8^20 ≈ 1.2%` if the
+ordering were still free.
+
+Both directions of the mechanism are now pinned in-process, so the browser is
+no longer the only witness: `b7989f4ba` renders `1 unread` for a lone peer JOIN
+(its own `DOES count peer JOIN row toward the unread marker`, re-run on the base
+to measure it rather than cite it), and this branch renders no marker for the
+same fixture plus a late-arriving message ("draws no marker when only a peer
+JOIN precedes the session top and the message lands live").
+
+The general rule this leaves behind: **when a slice narrows what counts, every
+green that was resting on the wider count becomes suspect, and a spec whose
+precondition was satisfied by the discarded rows will fail for the right
+reason.** Read such a red as an oracle before reading it as a regression — but
+prove which it is on both refs, because the two are indistinguishable from the
+red alone.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52861,33 +52861,46 @@ It reproduces, and hard: `--repeat-each 20` on the unfixed tree gives **9 reds
 in 20**, every one carrying that identical signature. So the argument never had
 to be settled on the code.
 
-**bahamut charges fake-lag per COMMAND**, and the spec fired JOIN + 3×PRIVMSG +
-PART back to back on one connection, making the PART the FIFTH command against a
-bank the four before it had filled. `IrcPeer.part` waits for its own echo on
-`PART_TIMEOUT_MS` = 5s, while the overshoot this file's own `whoisAway` comment
-documents is ~10s — the budget is under the known worst case, and only for
-callers that arrive late in a burst.
+What is MEASURED is that the cost tracks the command's POSITION in a burst
+rather than the clock. The spec fired JOIN + 3×PRIVMSG + PART back to back on
+one connection, making the PART the fifth command, and `IrcPeer.part` waits for
+its own echo on `PART_TIMEOUT_MS` = 5s. **`IrcPeer.join` carries the SAME 5s
+budget and timed out zero times across those 20 runs.** First command always
+fine, fifth command half the time not — which is why a spec can be green a
+hundred times on its first wait and still be a coin flip on its last.
 
-The discriminator against "the testnet is just slow" is in the same 20 runs and
-costs nothing to read: **`IrcPeer.join` carries the SAME 5s budget and timed out
-zero times.** First command always fine, fifth command half the time not. That
-is a per-command bank, not latency — and it is why a spec can be green a hundred
-times on its first wait and still be a coin flip on its last.
+What is INFERRED, and must be written as inference, is that this per-command
+cost IS bahamut's fake-lag bank. That name was READ — from the `whoisAway`
+comment in `fixtures/ircClient.ts` and from the ircd source — and **reading a
+mechanism tells you a path EXISTS, never what it costs**. #800/S7 exists
+precisely because two retractions in one cycle came from treating that reading
+as a measurement, and the instrument it built (`Grappa.IRC.FakeLag`) does not
+close the gap here: it accounts GRAPPA's own socket, while the peer in an e2e is
+a separate irc-framework connection that instrument never sees. Any
+per-connection serialisation would fit all three measurements equally well.
 
-Cured by draining the bank on an OBSERVABLE signal: poll until the three
+The cure is therefore built on the measured half and not on the name — which is
+also why it survives if the name turns out wrong.
+
+Cured by draining whatever the burst filled, on an OBSERVABLE signal: poll until the three
 messages are on the server (the endpoint the spec was already polling
 afterwards), THEN send the PART, so it goes out alone. **No timeout raised, no
 assertion touched.** Measured after: **20 green in 20** — `0.55^20 ≈ 6e-6` had
 the rate stayed where it was.
 
-Two things worth carrying forward. First, **the timeouts in `ircClient.ts` are
+Three things worth carrying forward. First, **the timeouts in `ircClient.ts` are
 not interchangeable**: `join`/`part`/`nick`/`mode`/`kick` sit at 5s while
-`topic`/`privmsg`/`whois` sit at 15s precisely because the latter were found
-behind the lag bank. A wait's budget is only sound for the POSITION its caller
-occupies in a burst, and nothing in the API says which position that is. Second,
-the general rule: **a burst of IRC commands on one connection is not a setup
-step, it is a queue** — barrier between the plants and the closer, or the closer
-inherits every penalty the plants earned.
+`topic`/`privmsg`/`whois` sit at 15s, and the 15s ones carry a comment saying
+why. A wait's budget is only sound for the POSITION its caller occupies in a
+burst, and nothing in the API says which position that is. Second: **a burst of
+IRC commands on one connection is not a setup step, it is a queue** — barrier
+between the plants and the closer, or the closer inherits every penalty the
+plants earned. Third, the epistemic one, because it is the trap this very entry
+walked into on its first draft: **name the mechanism only as far as you measured
+it.** "The fifth command costs what the first does not" is measured here and
+carries the cure on its own; "the fake-lag bank did it" is a reading, it names
+a path rather than a price, and it would have shipped as a fact if nobody had
+asked which of the two it was.
 
 Six other specs call `IrcPeer.part`; the closest, `issue2037`, fires four
 commands where this one fired five. They are not touched here — none has been

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52631,3 +52631,175 @@ in their own `async: false` file (`push/observability_log_test.exs`),
 following `client_tls_posture_log_test.exs`. They assert the FORMATTED line,
 which is the only thing that can catch an allowlist drop; the behaviour they
 sit next to — that the gate suppresses at all — stays pinned where it was.
+<!-- entry #2069 -->
+
+---
+
+## 2026-09-11 — #2069: one question, one function, two anchors
+
+vjt on staging: three ways of saying "how many rows are behind my cursor in
+this window", disagreeing with each other and moving without anyone reading
+anything. (A) open a channel with hundreds unread, read nothing, look away and
+back — 500 becomes 800. (B) take the "2900 unread — jump back" affordance,
+change channel, come back — 200, which is the fetch page. (C) the in-pane
+divider counts join/part/quit/nick as unread "messages"; the sidebar pill does
+not.
+
+The issue proposed mechanisms for A and B and said outright that neither was
+reproduced. Both proposals were wrong in an instructive way, and finding that
+out cost less than curing them would have.
+
+### What was measured, on `b7989f4ba`, before anything was changed
+
+Against the real `scrollback` + `readCursor` + `selection` stores and a fake
+server that honours `after`/`before`/`limit` and answers its probe out of the
+same log it serves — with a MIXED log, every fourth row a peer JOIN, because a
+uniform log cannot see any of the three defects.
+
+**C is three divergences, not one, and they run in both directions.** Over one
+fixture of 150 rows past the cursor (113 peer messages, 37 peer JOINs):
+
+| rows past the cursor | sidebar pill | in-pane divider |
+| --- | --- | --- |
+| 113 peer messages + 37 peer JOINs | 113 | `150 unread messages` |
+| 5 peer + 5 own messages | 5 | `10 unread messages` |
+| 5 numeric-derived NOTICEs | 5 | no marker at all |
+| 50 peer JOINs | 0 | `50 unread messages` |
+
+The label says "messages". Two of those rows say the pill was right; the third
+says the DIVIDER was, because `notice` is a content kind and the derived pill
+counted a 401 the operator's own `/msg <ghost>` produced.
+
+The reason all three exist is one stale sentence, and it is in the source.
+`operatorActionEcho.ts` and `ownPresenceEvent.ts` each claim to be the "single
+source of truth" shared by "subscribe.ts (the sidebar badge gate)" and the
+in-pane marker. That was true while the badge was BUMPED per row. `subscribe.ts`
+still calls both predicates — the early return is right there — but since the
+2026-06-01 bucket-B2 change the badge is DERIVED from `(scrollbackByChannel,
+readCursors, serverSeedCounts)`, and the derivation never saw them. The gate
+kept guarding the mention beep and stopped guarding the thing its own comment
+names. Nothing broke loudly; two surfaces drifted apart one row class at a
+time, and the comment stayed.
+
+**A does not reproduce as reported, and the mechanism the issue named is not
+the cause.** A bare re-select with no traffic moves nothing — measured across
+two re-selects on a far-behind window, on a not-far-behind window (gap 150) and
+on a just-far-behind one (gap 250): stable in all three. What moves is the
+far-behind count while the operator is AWAY. `appendPageToScrollback`
+accumulated it by the content-ness of the row the ring cap EVICTED rather than
+of the row that ARRIVED, and added nothing at all while the store sat under
+`UNREAD_RETENTION_CAP`. Measured: 500 arrivals took it to 4012 against a server
+answer of 4125, and the per-step error was neither constant nor signed
+(-75, -113, -113). Then the re-select's `?after=<high-water>` page came back
+FULL, which fires the gap probe, which re-anchored and OVERWROTE the drifted
+number with a fresh measurement: 4012 → 4125 in one step, no scroll, no read.
+
+So the discriminator the issue asked for — "does a re-select re-probe
+`/messages/count`?" — has the answer YES, conditionally, and the re-probe is
+the CORRECTION rather than the cause. Curing the visible step would have left
+the drift, which is the number the operator actually reads for as long as they
+stay away.
+
+**B reproduces, and it is worse than reported.** It does not stop at the page
+size. The jump retires the far-behind record, the pill falls back to counting
+held rows, and as the operator reads through the one page the jump loaded the
+count reaches ZERO on a window with thousands unread: 3750 → 150 → 0, cursor at
+1200, server answer 3600. The measurement that answers every one of those was
+already on file — `measuredUnreadByChannel` (#947), written by that same jump —
+and only the divider ever spent it.
+
+### The shape
+
+`lib/unreadCount.ts` publishes one row predicate and one region count. Both
+surfaces call them and neither re-derives.
+
+The issue asked for "one variable … it must not change while the cursor does
+not move". That is right for the DIVIDER and wrong for the PILL, so what ships
+is one FUNCTION at two anchors rather than one value read twice. The divider
+passes the frozen cursor and the frozen session top (the freeze contract: the
+line must not renumber under a reader). The pill passes the live cursor and no
+bound, because a pill that ignored arrivals while the cursor sat still would
+stop saying the window is receiving traffic, which is the pill's whole job.
+Same population, same unit, same source-selection; different anchors, on
+purpose.
+
+PLACEMENT is deliberately BROADER than the count. The line marks where the
+operator left off, so it goes above the first row somebody ELSE produced,
+message or presence, while the label counts only messages. Narrowing placement
+to content would leave a run of peer JOINs sitting above the line, rendered as
+if they had been read.
+
+A is cured at the accumulator: count ARRIVALS (fresh rows above the pane's
+previous newest), not evictions. Exact, independent of the cap, and it leaves
+the probe nothing to correct — which is what removes the visible step. The
+eviction-side bookkeeping (`contentDropped`, `keptContentCount`) is deleted
+rather than kept beside it.
+
+B is cured by letting the pill spend the same #947 record, minus what the
+cursor consumed, so the number falls by what was READ instead of by what was
+FETCHED. The record gains `through`: the top of the contiguous run the pane can
+account for, written by the jump and extended by `loadNewer` as the pane pages
+forward. The subtraction is only sound while every row the cursor passed is one
+the pane HELD, so past that run the record stands down rather than answering
+with a number it cannot support — an own send lands the cursor at the tip with
+nothing unread, and a record that kept spending would report thousands. The
+count is a FLOOR (`max(local, count - consumed)`), not a replacement, so local
+truth overtakes it as the region comes back and nobody has to remember to
+retire it.
+
+### What this does NOT fix, stated rather than discovered later
+
+* **The server's population and the client's differ by numeric-derived
+  NOTICEs.** `Scrollback.count_after_split/6` excludes own-authored rows but
+  knows nothing about `meta.numeric`, which is a client concept. So
+  `count - consumed` can run high by the number of such rows the operator read
+  inside the measured region. Bounded, rare (they land in `$server` and ghost
+  query windows, not busy channels), and NOT cured with a second predicate for
+  the subtraction — a second predicate is the fork this entry exists to remove.
+* **The arrivals accumulator counts own-authored content**, exactly as the
+  eviction one did. It has no `ownNick` to fold against without an import cycle
+  into `networks`, and the far-behind cursor is frozen, so an own send adds one
+  either way. No regression, no cure.
+* **A cross-device read-ahead still under-reports.** The peer device moves the
+  cursor past rows this pane never held; the record stands down and the pill
+  answers from local rows. That is what it did before, and inventing a number
+  there would be worse than a low one.
+* **The SHORT-page arm of `jumpToUnread` is very nearly unreachable.** A
+  far-behind window has >200 unread by definition and `resumeFrom` does not
+  move, so `after(resumeFrom, 200)` is always full. Its `clearMeasuredUnread`
+  branch is near-dead. Named, not deleted: it is the correct answer if the
+  region ever shrinks under it (an archive purge), and the test that tried to
+  construct it is the one arm of this slice that had to be replaced by a
+  property that IS reachable.
+
+### The bigger answer, not taken here
+
+The server already pushes per-window `messages`/`events` on `window_counts`,
+on every message and on every cursor advance, and cic throws them away
+(`selection.ts` says so in as many words, citing #239 — that the presence
+filter is a client concern, which is true of the EVENTS bucket and not of the
+MESSAGES one). Adopting that field would collapse `serverSeedCounts`,
+`farBehindByChannel.missed` and `measuredUnreadByChannel` into one
+authoritative number and delete every accumulator in this entry. It is a
+redesign of the client's unread model, not a bug fix, and it is a decision for
+vjt rather than one to take inside a slice that was asked to stop three numbers
+lying.
+
+### Evidence
+
+Six mutants, one per mechanism, each killed by named arms with the unmutated
+tree green at 7026 (control run first, tree restored by `git checkout` after
+each): dropping the operator-echo clause (3 deaths, one of them a
+PRE-EXISTING pane test, which is what proves the pane is wired to the shared
+predicate), dropping the local floor (2), dropping the `through` guard (3),
+dropping the content split (21), disabling the arrival count (4, one of them
+the pre-existing #1229 arming test), and making the pill ignore the
+measurement (4).
+
+The browser witness is `issue2069-one-unread-number.spec.ts`, and it is the
+only place the two numbers are visible AT ONCE — which is how vjt noticed. It
+asserts both premises rather than assuming them: that the unread run really
+contains peer presence rows, and that those rows RENDER (`#spec-wN` is far
+under `LARGE_CHANNEL_THRESHOLD`), because a hidden presence row is excluded
+from the old count too, by a different rule, and the spec would be green on the
+broken build.


### PR DESCRIPTION
Three surfaces answered "how many rows are behind my cursor in this window"
and gave three different numbers, one of which moved while nobody read
anything. This makes them one function.

Addresses issue 2069.

## What was measured, before anything was changed

On `b7989f4ba`, against the real `scrollback` + `readCursor` + `selection`
stores and a fake server that honours `after`/`before`/`limit` and answers
its probe out of the same log it serves. The log is **mixed** — every fourth
row a peer JOIN — because a uniform log cannot see any of the three defects.

**All three symptoms reproduce.** Two of them do not reproduce the way the
issue described them, and that changed the cure.

### C — the divergence, and it is triple, not single

| rows past the cursor | sidebar pill | in-pane divider |
| --- | --- | --- |
| 113 peer messages + 37 peer JOINs | 113 | `150 unread messages` |
| 5 peer + 5 own messages | 5 | `10 unread messages` |
| 5 numeric-derived NOTICEs | 5 | no marker at all |
| 50 peer JOINs | 0 | `50 unread messages` |

Two of those rows say the pill was right; the third says the DIVIDER was.

The common cause is one stale sentence, in the source. `operatorActionEcho.ts`
and `ownPresenceEvent.ts` each claim to be the "single source of truth" shared
by "subscribe.ts (the sidebar badge gate)" and the in-pane marker. That was
true while the badge was BUMPED per row. `subscribe.ts` still calls both
predicates, but since the 2026-06-01 bucket-B2 change the badge is DERIVED
from `(scrollbackByChannel, readCursors, serverSeedCounts)`, and the
derivation never saw them. The gate kept guarding the mention beep and stopped
guarding the thing its own comment names.

### A — reproduced, but NOT by the mechanism the issue named

A bare re-select with no traffic moves nothing — measured across two
re-selects on a far-behind window, on a not-far-behind one (gap 150) and on a
just-far-behind one (gap 250): stable in all three.

What moves is the count while the operator is AWAY. `appendPageToScrollback`
accumulated it by the content-ness of the row the ring cap EVICTED rather than
of the row that ARRIVED, and added nothing at all below `UNREAD_RETENTION_CAP`.
Measured: 500 arrivals took it to 4012 against a server answer of 4125, error
neither constant nor signed (-75, -113, -113). The re-select's page then came
back FULL, fired the gap probe, and OVERWROTE the drifted number with a fresh
measurement: +113 in one step, no scroll, no read.

So the discriminator the issue asked for — "does a re-select re-probe
`/messages/count`?" — is YES, conditionally, and **the re-probe is the
CORRECTION, not the cause**. Curing the visible step would have left the drift,
which is the number the operator actually reads for as long as they stay away.

### B — reproduced, and worse than reported

It does not stop at the page size. The jump retires the far-behind record, the
pill falls back to counting held rows, and as the operator reads through the
one page the jump loaded the count reaches **ZERO** on a window with thousands
unread: 3750 → 150 → 0, cursor at 1200, server answer 3600. The measurement
that answers all of those was already on file — `measuredUnreadByChannel`
(#947), written by that same jump — and only the divider ever spent it.

## The shape

New `cicchetto/src/lib/unreadCount.ts`: one row predicate
(`isOperatorOwnedRow` / `countsAsUnreadMessage` / `countsAsUnreadEvent`) and
one region count (`unreadMessagesAfter`). `selection.ts` and
`ScrollbackPane.tsx` both call them; neither re-derives.

**One function, TWO anchors** — and this is where the issue's "one variable"
is wrong taken literally. The divider passes the FROZEN cursor and the frozen
session top (the freeze contract: the line must not renumber under a reader).
The pill passes the LIVE cursor and no bound, because a pill that ignored
arrivals while the cursor sat still would stop saying the window is receiving
traffic, which is the pill's whole job. Same population, same unit, same
source-selection; different anchors, on purpose.

**Placement stays BROADER than the count.** The line marks where the operator
left off, so it goes above the first row somebody ELSE produced — message or
presence — while the label counts only messages. Narrowing placement to
content would leave a run of peer JOINs above the line, rendered as if read.

- **A** is cured at the accumulator: count ARRIVALS (fresh rows above the
  pane's previous newest), not evictions. Exact, cap-independent, and it
  leaves the probe nothing to correct. `contentDropped` and `keptContentCount`
  are deleted rather than kept beside it.
- **B** is cured by letting the pill spend the same #947 record, minus what
  the cursor consumed, so the number falls by what was READ instead of by what
  was FETCHED. The record gains `through` (the top of the contiguous run the
  pane can account for, written by the jump and extended by `loadNewer`);
  past that run it stands down rather than answering with a number it cannot
  support — an own send lands the cursor at the tip with nothing unread, and a
  record that kept spending would report thousands. It is a FLOOR
  (`max(local, count - consumed)`), so local truth overtakes it as the region
  comes back and nobody has to remember to retire it.

## Coverage: all three, all reproduced

A, B and C are each reproduced on the measurement bench and each cured, with
the limits named below. Two tests ASSERTED the defect and were corrected, not
deleted: the pane's `"DOES count peer JOIN row toward the unread marker"` and
the issue-2050 arm that called the drift "demonstrably frozen".

## The two reds the full integration run turned, and which is whose

The full `scripts/integration.sh` was run TWICE end to end (the scoped `--grep`
is not the ship gate). Neither run is green, nothing is buried, and every red
was attributed by measurement rather than by argument.

| run | result | reds |
| --- | --- | --- |
| #1, before the spec fix | 2 failed / 973 passed / 1 skipped | `issue1964`, `unread-cursor-cluster:184` |
| #2, after the spec fix | 2 failed / 973 passed / 1 skipped | `issue1964`, `cp15-b6-part-archive-rejoin` |

| spec | this branch | base `b7989f4ba` | whose |
| --- | --- | --- | --- |
| `issue1964-upload-confirm-preview:97` | 5 red in 5 | **10 red in 10** | **main's**, not this slice's |
| `unread-cursor-cluster:184` | 1 red in 5 → **20 green in 20** after the fix | 10 green in 10 | **was this slice's**, cured |
| `cp15-b6-part-archive-rejoin:55` | green in run #1, red in run #2, **5 green in 5** isolated | — | **flake**, not this slice's |

### `cp15-b6` — flake, and the two runs are what prove it

It fails on `.members-pane li` never showing the operator's own nick after the
re-join — the member roster, which this slice does not touch. The decisive point
is that **the production code is byte-identical between run #1 and run #2**: the
only commit between them changes two test files and `DESIGN_NOTES.md`. Same
production tree, green once and red once, plus 5 green in 5 in isolation. That
is non-determinism, not a regression. I did not chase it further and I did not
touch it — it belongs to whoever owns that spec, not to this branch.

### `issue1964` — pre-existing red on main

`each staged file previews as what it actually is` fails on the video arm
(`video.error.code` is 4, `MEDIA_ERR_SRC_NOT_SUPPORTED`, where 0 is expected).
Deterministic on the base commit with nothing of mine in the tree, and nothing
in this slice touches uploads, media policy or the preview path. Reported as a
finding about main, not fixed here — it is a different subject and folding it
into this branch would hide it.

### `unread-cursor-cluster:184` — mine, and it is an ORACLE, not the cure

Stated up front because it would be easy to bury in the diff: the slice caused
this red, and the behaviour the spec describes is not broken.

`sessionTopId` latches the tail of the FIRST non-empty observation the pane
makes; every row above that latch is a live arrival that draws no marker on
purpose (the operator watched it land). The spec sends the peer's PRIVMSG and
navigates immediately, so which side of the latch that row falls on was never
established by its setup. The awaited `peer.join` before it reliably WAS inside
the latch — and while the divider counted presence rows, that JOIN on its own
injected a marker reading `1 unread`. So the spec went green, in that ordering,
on the strength of the exact defect this PR removes. Restrict the count to
messages and the stand-in disappears; the unguarded ordering stops being masked.

So the cure is to make the precondition TRUE (`assertMessagePersisted` before
the navigation), and **the assertion is untouched** — no assert was weakened to
buy green. Measured after the fix: **20 green in 20**, against 1 in 5 before
(`0.8^20 ≈ 1.2%` if the ordering were still free).

The mechanism no longer needs a browser to be seen. Both directions are pinned
in-process: `b7989f4ba` renders `1 unread` for a lone peer JOIN (its own
`DOES count peer JOIN row toward the unread marker`, re-run on the base to
MEASURE it rather than cite it), and this branch renders no marker for the same
fixture plus a late-arriving message (new arm, `draws no marker when only a peer
JOIN precedes the session top and the message lands live`).

## What I refused to assert

- **That the re-select is the bug.** It reproduces the visible step, and the
  issue named it as the mechanism, but the measurement says it is the
  correction of a drift that happens elsewhere. I did not ship a cure for the
  step.
- **That the divider's number was simply wrong.** On the numeric-NOTICE row of
  the table the divider is the one telling the truth. The fix is a shared
  population, not "make the divider agree with the pill".
- **That the e2e proves both surfaces red without the cure.** It does not, and
  the limit is stated below.
- **That `count - consumed` is exact.** It is a floor with a named population
  gap, and it is shipped as a floor for that reason.
- **That the near-dead `clearMeasuredUnread` arm is dead.** I could not
  construct it; I named it and left it.
- **That the full integration suite is green.** It is not: `issue1964` is red,
  on this branch and on the base alike. I am not claiming a ship gate I did not
  clear, and I did not touch that spec to clear it.
- **That the `unread-cursor-cluster` red was a flake.** It was not — it belongs
  to this branch, measured. I am also not claiming the cure was wrong, and the
  two refs are what separate those readings.

## What I did NOT reproduce

- The issue's stated mechanism for A: a bare re-select re-probing and
  inflating the count on its own. Measured stable on three configurations.
- The issue's stated bound for B: "falls back to the page size". It does not
  stop there — it reaches zero.

## Limits, stated rather than discovered later

- **Server and client populations differ by numeric-derived NOTICEs.**
  `Scrollback.count_after_split/6` excludes own-authored rows but knows
  nothing about `meta.numeric`, a client concept, so `count - consumed` can
  run high by the number of such rows read inside the measured region.
  Bounded, rare (they land in `$server` and ghost query windows, not busy
  channels), and deliberately NOT cured with a second predicate — a second
  predicate is exactly the fork this slice removes.
- **The arrivals accumulator counts own-authored content**, exactly as the
  eviction one did. No `ownNick` available without an import cycle into
  `networks`, and the far-behind cursor is frozen. No regression, no cure.
- **A cross-device read-ahead still under-reports.** The peer device moves the
  cursor past rows this pane never held; the record stands down and the pill
  answers from local rows. That is what it did before.
- **The SHORT-page arm of `jumpToUnread` is very nearly unreachable.** A
  far-behind window has >200 unread by definition and `resumeFrom` does not
  move, so `after(resumeFrom, 200)` is always full. Its `clearMeasuredUnread`
  branch is near-dead: named, not deleted — it is the correct answer if the
  region ever shrinks (an archive purge).
- **The e2e red-without-the-cure proof stops at the pill.** The mutant sits in
  the SHARED predicate, so the spec dies on the PILL assert, which comes
  first; the DIVIDER assert in that arm was never reached.

## The bigger answer, not taken here

The server already pushes per-window `messages`/`events` on `window_counts`,
on every message and on every cursor advance, and cic throws them away
(`selection.ts` says so, citing #239 — that the presence filter is a client
concern, which is true of the EVENTS bucket and not of the MESSAGES one).
Adopting that field would collapse `serverSeedCounts`,
`farBehindByChannel.missed` and `measuredUnreadByChannel` into one
authoritative number and delete every accumulator in this PR. It is a redesign
of the client's unread model, not a bug fix, and it is vjt's call, not one to
take inside a slice asked to stop three numbers lying.

## Evidence

- `scripts/bun.sh run check` — green, 5/5 stages.
- `scripts/bun.sh run test` — 7026 passed, 0 failed.
- **Six mutants, one per mechanism, six killed.** Control run (unmutated tree)
  green at 7026 first, tree restored by `git checkout` after each. Deaths:
  operator-echo clause dropped (3, one a PRE-EXISTING pane test), local floor
  dropped (2), `through` guard dropped (3), content split dropped (21),
  arrival count disabled (4, one the pre-existing #1229 arming test),
  measurement ignored by the pill (4). Two mutants killing PRE-EXISTING tests
  is what proves the surfaces are genuinely wired to the shared predicate.
- **Browser witness**, `cicchetto/e2e/tests/issue2069-one-unread-number.spec.ts`
  — the only place the two numbers are visible AT ONCE, which is how vjt
  noticed. It asserts both premises rather than assuming them: that the unread
  run really contains peer presence rows, and that those rows RENDER
  (`#spec-wN` is far under `LARGE_CHANNEL_THRESHOLD`), because a hidden
  presence row is excluded from the old count too, by a different rule, and
  the spec would be green on the broken build.
- **Red without the cure, proven**: with the "no content split" mutant the
  spec fails exhibiting the mutated DOM — `class="sidebar-msg-unread"
  aria-label="5 unread messages"`, 5 instead of 3 (3 messages + 2 presence
  rows). That exact number is also the oracle that the source mutation
  REACHES the bundle.
- Full `scripts/integration.sh`, twice end to end — 973 passed each time, with
  the two residual reds attributed above. **The ship gate is NOT clear**, and
  the residue is not mine: `issue1964` is red on the base with none of my code
  in the tree, and `cp15-b6` is non-deterministic across two runs of identical
  production code. Whether that is shippable is not my call.
- `scripts/design-notes-gate.sh` — `rc=0`, marker + separator present, marker
  verified unique against `origin/main`'s tip (0 occurrences, positive control:
  352 markers exist).
