### PR TITLE
2071: count the far-behind events bucket through the presence filter

### DIFF
--- a/cicchetto/src/__tests__/unreadDenoisedFarBehind.test.ts
+++ b/cicchetto/src/__tests__/unreadDenoisedFarBehind.test.ts
@@ -1,0 +1,297 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GapProbe, MessageKind, ScrollbackMessage } from "../lib/api";
+import { channelKey } from "../lib/channelKey";
+
+// issue 2071 — a counter that keeps growing on a DENOISED window the operator
+// has already looked at, while the read cursor stands still.
+//
+// The far-behind record (#693) carries the SAME pair the server's
+// `count_after_split/6` returns — a MESSAGES bucket and an EVENTS bucket — and
+// it is SEEDED from exactly that call, taken behind
+// `Grappa.PresenceFilter.Resolver`. It is then MAINTAINED client-side, and the
+// maintenance counted raw kinds: `capScrollbackRing` opened the events bucket
+// at `unreadHeld - contentHeld` and `appendPageToScrollback` accumulated
+// arrivals at `!isContentKind`. Neither asked `presenceRowVisible`.
+//
+// On a channel showing presence those two populations coincide and nothing is
+// visible. On a DENOISED one they differ by the whole presence volume of the
+// channel: the seed excludes join/part/quit/nick_change/mode, the accumulator
+// counts them, and the operator can never read the difference away because the
+// pane does not render a single one of those rows. Measured on `4a33c6747`
+// over a 3:1 noise log, 120 arrivals: the pill climbed 0 → 22 → 45 → 67 → 90
+// against a server answer of 0 at every step.
+//
+// The oracle in every arm is the SERVER'S OWN ANSWER for the cursor the store
+// currently holds, never a literal — same discipline as
+// `unreadOneVariable.test.ts`, and it is what makes the presence-SHOWN control
+// meaningful: that arm passes on both sides of the fix, so the cure is the
+// filter and not a blanket change to the bucket.
+
+vi.mock(import("../lib/api"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    listNetworks: vi.fn().mockResolvedValue([]),
+    listChannels: vi.fn().mockResolvedValue([]),
+    listMessages: vi.fn(),
+    listMessagesAfter: vi.fn(),
+    countMessagesAfter: vi.fn(),
+    sendMessage: vi.fn(),
+    me: vi.fn().mockResolvedValue({
+      kind: "user",
+      id: "u-test",
+      name: "vjt",
+      is_admin: false,
+      inserted_at: "2026-01-01T00:00:00Z",
+      read_cursors: {},
+    }),
+    login: vi.fn(),
+    logout: vi.fn(),
+    setOn401Handler: vi.fn(),
+  };
+});
+
+const SLUG = "azzurra";
+const CHANNEL = "#grappa";
+const KEY = channelKey(SLUG, CHANNEL);
+const DEFAULT_PAGE = 50;
+
+// The suppressed set, restated as the FIXTURE's own noise definition. It is
+// deliberately NOT imported from `presenceFilter`: this file is measuring
+// whether the store agrees with that module, and taking the set from the
+// module under test would make the two agree by construction.
+const NOISE: ReadonlySet<MessageKind> = new Set(["join", "part", "quit", "nick_change", "mode"]);
+
+// 3 presence rows for every content row — what a denoised channel looks like,
+// and the ratio that makes a raw-vs-filtered mismatch visible at all. An
+// all-content log cannot see this defect: the two populations coincide.
+const kindOf = (id: number): MessageKind => (id % 4 === 1 ? "privmsg" : "join");
+
+const row = (id: number): ScrollbackMessage => ({
+  id,
+  network: SLUG,
+  channel: CHANNEL,
+  server_time: id,
+  kind: kindOf(id),
+  sender: "bob",
+  body: `m${id}`,
+  meta: {},
+});
+
+/**
+ * A server that honours the DENOISE posture the way the real one does (#458):
+ * the history reads AND the `/messages/count` probe both omit the suppressed
+ * kinds for a window that hides presence, because both route through
+ * `Grappa.PresenceFilter.Resolver`. The LIVE WS tail is UNFILTERED — cic
+ * filters that at render, which is the whole asymmetry under test.
+ */
+class FakeServer {
+  constructor(
+    public tip: number,
+    public cursor: number,
+    public denoised: boolean,
+  ) {}
+
+  private visible(id: number): boolean {
+    return !this.denoised || !NOISE.has(kindOf(id));
+  }
+
+  listMessages(before?: number): ScrollbackMessage[] {
+    const hi = before === undefined ? this.tip : Math.min(this.tip, before - 1);
+    const out: ScrollbackMessage[] = [];
+    for (let i = hi; i >= 1 && out.length < DEFAULT_PAGE; i--) {
+      if (this.visible(i)) out.push(row(i));
+    }
+    return out;
+  }
+
+  listMessagesAfter(after: number, limit: number): ScrollbackMessage[] {
+    const out: ScrollbackMessage[] = [];
+    for (let i = after + 1; i <= this.tip && out.length < limit; i++) {
+      if (this.visible(i)) out.push(row(i));
+    }
+    return out;
+  }
+
+  /** The three numbers `count_after_split/6` returns, over this same log. */
+  countMessagesAfter(after: number): GapProbe {
+    let gap = 0;
+    let messages = 0;
+    for (let i = after + 1; i <= this.tip; i++) {
+      if (!this.visible(i)) continue;
+      gap++;
+      if (kindOf(i) === "privmsg") messages++;
+    }
+    return { gap, messages, events: gap - messages };
+  }
+}
+
+let server: FakeServer;
+
+const wireServer = async (): Promise<void> => {
+  const api = await import("../lib/api");
+  vi.mocked(api.listMessages).mockImplementation(async (_t, _s, _c, before) =>
+    server.listMessages(before),
+  );
+  vi.mocked(api.listMessagesAfter).mockImplementation(async (_t, _s, _c, after, limit) =>
+    server.listMessagesAfter(after, limit ?? DEFAULT_PAGE),
+  );
+  vi.mocked(api.countMessagesAfter).mockImplementation(async (_t, _s, _c, after) =>
+    server.countMessagesAfter(after),
+  );
+  // `readCursor.setReadCursor` POSTs through raw `fetch`. Stub the transport,
+  // not the module: the optimistic local advance lives inside it.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockImplementation(async (_url: string, init: { body: string }) => {
+      const id = JSON.parse(init.body).message_id as number;
+      if (id > server.cursor) server.cursor = id;
+      return { ok: true, status: 200, json: async () => ({}) };
+    }),
+  );
+};
+
+/** The operator's explicit per-channel "hide presence" pin (#222 / #449). */
+const denoise = async (): Promise<void> => {
+  const { setChannelPresencePref } = await import("../lib/presenceFilter");
+  setChannelPresencePref(KEY, "hide");
+};
+
+/** What `subscribe.ts` does on every per-channel join, initial AND rejoin. */
+const joinChannelTopic = async (): Promise<void> => {
+  const { applyJoinReply } = await import("../lib/readCursor");
+  const { setServerSeedCount } = await import("../lib/selection");
+  applyJoinReply(SLUG, CHANNEL, server.cursor);
+  const probe = server.countMessagesAfter(server.cursor);
+  setServerSeedCount(KEY, { messages: probe.messages, events: probe.events });
+};
+
+/** The FIRST selection of a window — `selection.ts`'s load-once hydrate. */
+const firstSelect = async (): Promise<void> => {
+  const { loadInitialScrollback } = await import("../lib/scrollback");
+  await loadInitialScrollback(SLUG, CHANNEL);
+};
+
+/**
+ * Re-selecting an already-loaded window. `selection.ts`'s `selectedChannel`
+ * effect fires exactly this verb for that gesture (the load-once
+ * `loadInitialScrollback` fetches nothing on a second visit), so this is the
+ * gesture and not an approximation of it.
+ */
+const reSelect = async (): Promise<void> => {
+  const { refreshScrollback } = await import("../lib/scrollback");
+  await refreshScrollback(SLUG, CHANNEL);
+};
+
+/** Live rows landing on the per-channel WS topic — UNFILTERED, as they are. */
+const peerTraffic = async (n: number): Promise<void> => {
+  const { appendToScrollback } = await import("../lib/scrollback");
+  const { recordSeen } = await import("../lib/reconnectBackfill");
+  for (let i = 0; i < n; i++) {
+    server.tip += 1;
+    const m = row(server.tip);
+    appendToScrollback(KEY, m);
+    recordSeen(KEY, m);
+  }
+};
+
+const cursorNow = async (): Promise<number> => {
+  const { getReadCursor } = await import("../lib/readCursor");
+  return getReadCursor(SLUG, CHANNEL) ?? 0;
+};
+
+/** The two pills the sidebar renders for this window, right now. */
+const pills = async (): Promise<{ messages: number; events: number }> => {
+  const selection = await import("../lib/selection");
+  return {
+    messages: selection.messagesUnread()[KEY] ?? 0,
+    events: selection.eventsUnread()[KEY] ?? 0,
+  };
+};
+
+/** What the server would answer for the cursor the store currently holds. */
+const truth = async (): Promise<{ messages: number; events: number }> => {
+  const probe = server.countMessagesAfter(await cursorNow());
+  return { messages: probe.messages, events: probe.events };
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  localStorage.clear();
+  vi.clearAllMocks();
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => "visible",
+  });
+  localStorage.setItem("grappa-token", "tok");
+});
+
+// The gesture as the reporter typed it. This arm PASSES on `4a33c6747` and is
+// here to keep passing: the property it states — a count derived twice for the
+// same window with the cursor standing still is the same count — is the one
+// the issue names, and nothing below is allowed to break it.
+describe("issue 2071 — the gesture: select, leave, re-select, cursor still", () => {
+  it("does not move the pills on a DENOISED window with a live marker", async () => {
+    // Raw gap 160 rows, 40 of them content: under the far-behind bound on both
+    // the raw and the filtered reading, so the window keeps its in-pane marker.
+    server = new FakeServer(1160, 1000, true);
+    await wireServer();
+    await denoise();
+    await joinChannelTopic();
+    await firstSelect();
+
+    const pinned = await cursorNow();
+    const before = await pills();
+    expect(before).toEqual(await truth());
+
+    await reSelect();
+    expect(await pills()).toEqual(before);
+    await reSelect();
+    expect(await pills()).toEqual(before);
+    expect(await cursorNow()).toBe(pinned);
+  });
+});
+
+// The arm that FAILS on `4a33c6747`. Same gesture, one state further along:
+// the window has gone far behind, so the pills are answered by the far-behind
+// record rather than by the loaded rows — and that record is maintained in a
+// population the operator's pane does not share.
+describe("issue 2071 — the far-behind record under a presence filter", () => {
+  const arrivalsTrackTheServer = async (denoised: boolean): Promise<void> => {
+    // Raw gap 800, 200 of it content: the anchored hydrate fills the pane to
+    // the retention bound, so the next arrivals push the unread region over it
+    // and the far-behind record opens.
+    server = new FakeServer(1800, 1000, denoised);
+    await wireServer();
+    if (denoised) await denoise();
+    await joinChannelTopic();
+    await firstSelect();
+
+    const pinned = await cursorNow();
+    // Four batches, so a per-batch drift is distinguishable from a one-off.
+    for (let batch = 0; batch < 4; batch++) {
+      await peerTraffic(30);
+      expect(await pills()).toEqual(await truth());
+      // Nothing here reads, scrolls or sends: the cursor must not have moved,
+      // or the oracle above is answering a different question each time.
+      expect(await cursorNow()).toBe(pinned);
+    }
+
+    // And the gesture itself still carries no information.
+    const settled = await pills();
+    await reSelect();
+    expect(await pills()).toEqual(settled);
+  };
+
+  it("tracks the server's own answer on a DENOISED window", async () => {
+    await arrivalsTrackTheServer(true);
+  });
+
+  // The control. It passes on BOTH sides of the fix: with presence shown the
+  // raw and the filtered populations coincide, so a cure that merely changed
+  // the bucket — rather than teaching it the filter — would show up HERE.
+  it("tracks the server's own answer with presence SHOWN", async () => {
+    await arrivalsTrackTheServer(false);
+  });
+});

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -13,6 +13,8 @@ import { token } from "./auth";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
 import { identityMoved } from "./identityMoved";
 import { identityScopedStore } from "./identityScopedStore";
+import { membersByChannel } from "./members";
+import { presenceRowVisible } from "./presenceFilter";
 import { getReadCursor, setReadCursor } from "./readCursor";
 import { getResumeCursor, recordSeen } from "./reconnectBackfill";
 import type { UnreadMeasurement } from "./unreadCount";
@@ -212,8 +214,13 @@ const isCanonicallyOrdered = (rows: ScrollbackMessage[]): boolean => {
 type CappedRing = {
   rows: ScrollbackMessage[];
   unreadDropped: number;
-  // Unread rows (id > cursor) held BEFORE the drop — the banner's count the
-  // first time the bound bites. Afterwards the caller accumulates.
+  // Unread rows (id > cursor) held BEFORE the drop — the RAW region size the
+  // ceiling above was measured against. issue 2071 took its last production
+  // consumer away (the events bucket used to be `unreadHeld - contentHeld`);
+  // it stays because it is what the cap OBSERVED, which is the thing
+  // `scrollback.test.ts`'s contiguity invariant has to be able to address, and
+  // it is the one number here that must NOT be filtered — the cap is about
+  // store size, not about what the operator can see.
   unreadHeld: number;
   // #2037 — the same figure restricted to `@content_kinds`. The banner's
   // number is the MESSAGES bucket, so accounting in raw row counts would mix
@@ -230,8 +237,24 @@ type CappedRing = {
   // see `appendPageToScrollback`. These two are still what ARMS the state and
   // what it opens at.
   contentHeld: number;
+  // issue 2071 — the EVENTS bucket, the sibling of `contentHeld` and the
+  // second half of the pair `count_after_split/6` returns. It is a COUNT of
+  // its own and not `unreadHeld - contentHeld`, because that subtraction
+  // answers in the RAW population while the seed it opens beside was taken
+  // behind `Grappa.PresenceFilter.Resolver`. On a denoised window the two
+  // differ by every join/part/quit/nick_change/mode in the region — rows the
+  // pane does not render, so the operator cannot read the difference away.
+  eventHeld: number;
   cursor: number | null;
 };
+
+// issue 2071 — the live member count for a channel, the second input the
+// presence tri-state needs (`resolvePresenceVisible`: an explicit pin wins,
+// unset follows the count against `LARGE_CHANNEL_THRESHOLD`). Read here rather
+// than threaded through `capScrollbackRing`'s signature so the two far-behind
+// maintenance sites below cannot be given different answers — the divergence
+// that IS this issue.
+const memberCountFor = (key: ChannelKey): number => (membersByChannel()[key] ?? []).length;
 
 // #1538 — exported for its structural contiguity test, and for nothing else:
 // no production caller outside this module. Same reason
@@ -257,6 +280,12 @@ export const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): C
   // the two can never describe different regions.
   const unreadRows = firstUnread === -1 ? [] : rows.slice(firstUnread);
   const contentCount = unreadRows.filter((m) => isContentKind(m.kind)).length;
+  // issue 2071 — the EVENTS bucket, and it is NOT `unreadCount - contentCount`.
+  // That subtraction is the raw remainder, and on a denoised window the raw
+  // remainder is mostly rows the pane never renders. See `eventHeld`.
+  const eventCount = unreadRows.filter(
+    (m) => !isContentKind(m.kind) && presenceRowVisible(key, memberCountFor(key), m.kind),
+  ).length;
 
   // #1229 — the protected region has a ceiling of its own, applied BEFORE the
   // ring cap because it can bite while the total is still under it (900 unread
@@ -314,6 +343,7 @@ export const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): C
       unreadDropped: overflowUnread,
       unreadHeld: unreadCount,
       contentHeld: contentCount,
+      eventHeld: eventCount,
       cursor,
     };
   }
@@ -330,6 +360,7 @@ export const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): C
     unreadDropped: 0,
     unreadHeld: unreadCount,
     contentHeld: contentCount,
+    eventHeld: eventCount,
     cursor,
   };
 };
@@ -662,8 +693,8 @@ const exports = identityScopedStore((onIdentityChange) => {
     // far behind and the pane must say so instead of drawing a divider it can
     // no longer place.
     let unreadDropped = 0;
-    let unreadHeld = 0;
     let contentHeld = 0;
+    let eventHeld = 0;
     let prunedCursor = 0;
     // issue 2069 — what ARRIVED: fresh rows newer than everything the pane
     // already held. This is the quantity a far-behind window's count grows by,
@@ -706,16 +737,24 @@ const exports = identityScopedStore((onIdentityChange) => {
         // measurement the far-behind record carries, so counting them would
         // report the same message twice.
         const previousNewest = tail?.id ?? 0;
+        // issue 2071 — the EVENTS half asks the presence filter; the CONTENT
+        // half does not have to, because no content kind is in
+        // `SUPPRESSED_PRESENCE_KINDS` and the filter can never take one away.
+        // The asymmetry is real, not an oversight: these two buckets accumulate
+        // a record SEEDED by `count_after_split/6` behind
+        // `Grappa.PresenceFilter.Resolver`, so the population has to match on
+        // both halves, and only one half can diverge.
+        const memberCount = memberCountFor(key);
         for (const m of fresh) {
           if (m.id <= previousNewest) continue;
           if (isContentKind(m.kind)) arrivedContent++;
-          else arrivedEvents++;
+          else if (presenceRowVisible(key, memberCount, m.kind)) arrivedEvents++;
         }
         const capped = capScrollbackRing(key, next);
         evicted = capped.rows.length < next.length;
         unreadDropped = capped.unreadDropped;
-        unreadHeld = capped.unreadHeld;
         contentHeld = capped.contentHeld;
+        eventHeld = capped.eventHeld;
         prunedCursor = capped.cursor ?? 0;
         return { ...prev, [key]: capped.rows };
       });
@@ -759,8 +798,15 @@ const exports = identityScopedStore((onIdentityChange) => {
                 // writes and the pill reads. The rows that arrived in THIS
                 // batch are already inside `contentHeld`, so they are not
                 // added again.
+                //
+                // issue 2071 — and the EVENTS bucket opens in the VISIBLE unit
+                // for the same reason, which is why this is `eventHeld` and no
+                // longer `unreadHeld - contentHeld`. That subtraction opened
+                // the record in the raw population, so a denoised window armed
+                // holding every hidden join/part in the region — a faint pill
+                // the pane cannot render and the operator cannot clear.
                 missed: contentHeld,
-                events: unreadHeld - contentHeld,
+                events: eventHeld,
                 resumeFrom: prunedCursor,
               },
             };

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52907,3 +52907,106 @@ commands where this one fired five. They are not touched here — none has been
 seen red, and widening a cure past its measurement is how a fixture acquires
 ballast nobody can later justify. The mechanism is written down so the next
 sighting is diagnosed in one reading instead of re-derived.
+<!-- entry #2071 -->
+
+---
+
+## 2026-09-11 — #2071: the far-behind record's events bucket, counted in a population the pane does not share
+
+vjt on staging (`1.5.5-4a33c6747`): an unread counter that keeps climbing on a
+window already looked at, cursor standing still, **only on a DENOISED channel**.
+The issue filed three candidates and said so — *"a candidate list, not a
+diagnosis"*. It is none of the three. All three are killed below with numbers,
+because reading a mechanism tells you a path EXISTS and never that it is the
+one that fired.
+
+### What actually moves
+
+The far-behind record (#693) carries the pair `count_after_split/6` returns — a
+MESSAGES bucket and an EVENTS bucket — and it is SEEDED from exactly that call,
+taken behind `Grappa.PresenceFilter.Resolver`. It is then MAINTAINED
+client-side, and both maintenance sites counted RAW kinds:
+
+* `capScrollbackRing` opened it at `events: unreadHeld - contentHeld` — the raw
+  remainder of the unread region;
+* `appendPageToScrollback` accumulated arrivals at `else arrivedEvents++`.
+
+Neither asked `presenceRowVisible`. So the record is seeded in the FILTERED
+population and grown in the RAW one. On a channel showing presence those
+coincide and nothing is visible; on a denoised one they differ by the channel's
+whole presence volume, and the difference is rows the pane never renders — so
+the operator cannot read it away, and it only ever goes up.
+
+Measured on `4a33c6747`, 3:1 join:message log, 30 arrivals per batch, cursor
+pinned throughout, oracle = the server's own answer for that cursor:
+
+```
+denoised   pill 0 -> 22 -> 45 -> 67 -> 90     server answer 0 at every step
+shown      pill 600 -> 622 -> 645 -> 667 -> 690   == server answer, exactly
+```
+
+One bit of fixture differs between those two lines. The cure is therefore the
+FILTER and not the bucket: `eventHeld` is a count of its own (visible,
+non-content, unread) rather than a subtraction, and the arrivals loop gates its
+events half on `presenceRowVisible`. Its content half does NOT, and that
+asymmetry is deliberate — no content kind is in `SUPPRESSED_PRESENCE_KINDS`, so
+the filter cannot take one away. The presence-SHOWN arm of
+`unreadDenoisedFarBehind.test.ts` passes on BOTH sides of the change, which is
+what makes it evidence rather than decoration.
+
+### The three candidates, each killed by a number
+
+1. **The measurement floor vs. the client-only filter.** It cannot reach the
+   MESSAGES bucket at all: `countsAsUnreadMessage` requires `isContentKind`,
+   and no content kind is presence-suppressed, so the client filter can never
+   remove a row the server's measurement counted. Measured: `msgs` tracks the
+   server answer exactly (200/208/215/223/230) on BOTH postures. The floor has
+   exactly one discontinuity and it is elsewhere — see the hazard below.
+2. **#2043, the two resolver doors.** Flip the server's presence posture
+   mid-session and re-seed the window: the pills move by **0** (msgs 40→40→40,
+   evts 0→0→0) while the server's own event answer goes 0 → 120. The
+   resolver's answer reaches the badge only through the SEED, and the seed
+   loses to local truth on any window the operator has opened. #2043 is real
+   and stays open on its own merits; it is **not** this issue's face, and this
+   issue should not be closed into it.
+3. **`trailingHiddenAdvanceTarget`.** Built a window where the advance really
+   fires: the cursor moves 10 → 14 across the hidden run, and both buckets are
+   unchanged (msgs 4→4, evts 0→0). Moving the cursor over rows nobody counts
+   changes nothing anybody counts.
+
+### A hazard found while killing candidate 1, NOT fixed here
+
+`unreadMessagesAfter`'s `spendable` gate is a step function at `measured.at`:
+with a record `{at: 100, count: 3600}` over a pane holding 200 content rows, a
+cursor at **99 answers 200** and a cursor at **100 answers 3600**. One id of
+forward movement, a 3400 jump. It is unreachable through
+`setCursorIfAdvances` (forward-only, and the record is written with
+`at === cursor`), but `applyReadCursorSet` — the cross-device echo — is
+unconditional and admits backward moves, so a peer device reading backwards
+below `at` and this one moving forward again would step through it. Named
+rather than cured: nothing measured says it fires, and a cure for a step
+nobody has stood on is a cure with no oracle.
+
+### What is NOT established
+
+**The reproduction's UI state is not the report's.** Every arm in which the
+counter grows has the far-behind record ARMED, and `injectMarker` suppresses
+the in-pane divider whenever it is — so the pane shows the "N unread — jump
+back" bar, while the report says the marker was up and moving. Two readings
+survive and the measurement does not separate them: either the reporter's
+window was in the far-behind state and "marker" names the bar, or there is a
+second, marker-preserving path to a growing count that this fixture does not
+build. The literal gesture the issue asks for — select → leave → re-select, a
+denoised window with a LIVE marker, cursor pinned — **passes on
+`4a33c6747`** (48 → 48 → 48). It is kept as the first arm of the new suite
+anyway: it is the property the issue names, and nothing here may break it.
+
+Also unestablished, and adjacent: the far-behind MESSAGES bucket counts the
+operator's OWN content (`isContentKind` alone) where the server's split
+excludes it via `own_nick`. Same class as the defect cured here — a bucket
+maintained in a different population from the one it was seeded in — but a
+different term, not denoise-specific, and not measured. Reaching
+`countsAsUnreadEvent`/`isOperatorOwnedRow` from `scrollback.ts` needs the
+per-network own nick, which is `networks.ts`, which is the documented circular
+import pair with `selection.ts` — so it is a slice of its own, not a line to
+slip in here.


### PR DESCRIPTION
Addresses issue 2071 (no closing keyword — the call is the orchestrator's).

## What moves, and why only on a denoised channel

The far-behind record (693) carries the pair `count_after_split/6` returns and
is **seeded** from exactly that call, taken behind
`Grappa.PresenceFilter.Resolver`. It was then **maintained** client-side in the
RAW population:

* `capScrollbackRing` opened its events bucket at `unreadHeld - contentHeld`;
* `appendPageToScrollback` accumulated arrivals at a bare `!isContentKind`.

Neither asked `presenceRowVisible`. Seeded filtered, grown raw. With presence
shown the two populations coincide and nothing is visible; on a **denoised**
window they differ by the channel's whole presence volume — rows the pane never
renders, so the operator cannot read the difference away and the faint pill only
ever climbs.

Measured on `4a33c6747`, 3:1 join:message log, cursor pinned throughout, 30
arrivals per batch, oracle = the server's own answer for that cursor:

```
denoised   0 -> 22 -> 45 -> 67 -> 90         server answer 0 at every step
shown      600 -> 622 -> 645 -> 667 -> 690   == server answer, exactly
```

One bit of fixture separates those two lines, so the cure is the **filter**, not
the bucket: `eventHeld` becomes a count of its own (visible, non-content,
unread) instead of a subtraction, and the arrivals loop gates its events half on
`presenceRowVisible`. Its content half deliberately does not — no content kind
is in `SUPPRESSED_PRESENCE_KINDS`, so the filter can never take one away.

The presence-SHOWN arm of the new suite is green on **both** sides of the
change. That is what makes it evidence rather than decoration: a cure that
merely moved the bucket would have shown up there.

## The three candidates the issue listed — each killed by a number

The issue says up front it is *"a candidate list, not a diagnosis"*. It is none
of the three.

1. **The measurement floor vs. the client-only filter** — cannot reach the
   MESSAGES bucket at all. `countsAsUnreadMessage` requires `isContentKind` and
   no content kind is presence-suppressed, so the client filter can never remove
   a row the measurement counted. Measured: `msgs` tracks the server answer
   exactly (200/208/215/223/230) on both postures.
2. **2043, the two resolver doors** — flip the server's posture mid-session and
   re-seed: the pills move by **0** (msgs 40→40→40, evts 0→0→0) while the
   server's own event answer goes 0 → 120. The resolver reaches the badge only
   through the SEED, and the seed loses to local truth on any hydrated window.
   ⚖️ **2043 is real and stays open on its own merits, but this is not its face
   and this issue should not be folded into it.** The call is yours; the
   measurement is above.
3. **`trailingHiddenAdvanceTarget`** — built a window where the advance really
   fires: cursor 10 → 14 across the hidden run, both buckets unchanged
   (msgs 4→4, evts 0→0).

## Found while killing candidate 1 — named, not cured

`unreadMessagesAfter`'s `spendable` gate is a step function at `measured.at`:
with `{at: 100, count: 3600}` over a pane holding 200 content rows, a cursor at
**99 answers 200** and at **100 answers 3600**. Unreachable through
`setCursorIfAdvances` (forward-only, and the record is written with
`at === cursor`), but `applyReadCursorSet` — the cross-device echo — is
unconditional and admits backward moves. Nothing measured says it fires, so it
is written down rather than patched.

## 🔴 What I did NOT establish

**The reproduction's UI state is not the report's.** Every arm where the counter
grows has the far-behind record ARMED, and `injectMarker` suppresses the in-pane
divider whenever it is — so the pane shows the "N unread — jump back" bar, while
the report says the marker was up and moving. Two readings survive and this
measurement does not separate them: either the reporter's window was in the
far-behind state and "marker" names the bar, or there is a second,
marker-preserving path this fixture does not build.

**The literal gesture the issue asks for passes on `4a33c6747`** — select →
leave → re-select, denoised window with a LIVE marker, cursor pinned:
48 → 48 → 48. It is kept as the first arm of the new suite anyway, because it is
the property the issue names and nothing here may break it. I did not weaken an
assert to make anything pass.

Also named and not touched: the far-behind MESSAGES bucket counts the operator's
OWN content where the server's split excludes it via `own_nick` — same class,
different term, not denoise-specific, not measured, and reaching the predicate
from `scrollback.ts` needs `networks.ts`, the documented circular-import pair.

## Gates

| gate | result |
|---|---|
| `bun run test` (cic unit) | 350 files, **7030 tests**, green |
| `bun run check` (lock drift + biome + tsc src + tsc e2e) | 5 stages, **0 failed** |
| `scripts/design-notes-gate.sh` | `1 new entry heading(s), separator and marker present.` |

No Elixir touched. e2e not run — no lane allocated for it; say the word if you
want it.