### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,68 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security bug.** grappa-irc runs a
+live instance with real users ([irc.sindro.me](https://irc.sindro.me)) and is
+self-hosted by others. A public issue publishes the bug to everyone in the
+same instant it reaches the maintainer, which is the one outcome this file
+exists to avoid.
+
+Report privately, through either channel:
+
+1. **GitHub private vulnerability reporting** — the preferred route. Use the
+   *Report a vulnerability* button on this repository's **Security** tab. It
+   opens a thread visible only to you and the maintainer.
+2. **Email** — `vjt@openssl.it`, the maintainer. Use this if you would rather
+   not go through GitHub, or if the button above is not there.
+
+This project publishes no PGP key. If you want an encrypted channel, ask for
+one in a first message that carries no details.
+
+## Scope
+
+In scope:
+
+- **the server** — `lib/grappa/**` and everything it exposes: the REST API,
+  the WebSocket (Phoenix Channels) surface, authentication and session
+  handling, the upstream IRC client, scrollback storage.
+- **the client** — `cicchetto/**`, the browser PWA.
+- **the live instance** — [irc.sindro.me](https://irc.sindro.me), for
+  findings you can demonstrate **against your own account and your own
+  data**.
+
+Out of scope:
+
+- **Denial of service, load testing, and traffic flooding** against the live
+  instance or its upstream networks. Do not run these; report the weakness
+  instead of exercising it.
+- **Other people's accounts, messages, or scrollback** on the live instance.
+  If a bug lets you reach them, stop at the proof that it does — do not
+  collect the data.
+- **Upstream IRC networks** (Azzurra, Libera, OFTC, …). They are not ours;
+  report those to the network's own staff.
+- **Third-party dependencies**, which belong upstream — though do tell us if
+  the way grappa uses one makes the impact worse than upstream's own advisory
+  describes.
+- **Automated scanner output with no demonstrated impact.**
+
+## What to expect
+
+- **Acknowledgement is best effort.** This is a spare-time project with one
+  maintainer and a handful of contributors. There is no on-call rotation and
+  no guaranteed response time. Any specific number of hours or days written
+  here would be a number this project cannot keep, and a policy that
+  over-promises is worse than no policy.
+- **Fix first, disclose after.** We will work the fix privately, then
+  publish, and we will agree the timing of that publication with you rather
+  than deciding it alone.
+- **Credit if you want it.** Named in the release notes and the decision log,
+  or left anonymous — your call.
+- **No bug bounty.** There is no reward programme, no money and no swag.
+
+## Supported versions
+
+Only the current release — the newest `v*` tag, which is the number in the
+repository's `VERSION` file — and the tip of `main` are supported. Older tags
+receive no backports; there are no maintenance branches. Self-hosters should
+track the latest release.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,31 +14,38 @@ Report privately, through either channel:
    *Report a vulnerability* button on this repository's **Security** tab. It
    opens a thread visible only to you and the maintainer.
 2. **Email** — `vjt@openssl.it`, the maintainer. Use this if you would rather
-   not go through GitHub, or if the button above is not there.
-
-This project publishes no PGP key. If you want an encrypted channel, ask for
-one in a first message that carries no details.
+   not go through GitHub. This project publishes no PGP key; if you want an
+   encrypted channel, ask for one in a first message that carries no details.
 
 ## Scope
 
-In scope:
+**Test against an instance you run yourself.** The repository carries
+everything needed to stand one up, and a finding reproduced on your own
+deployment is worth exactly as much here as one reproduced anywhere else —
+while costing nobody else's uptime, data or attention.
+
+In scope, on an instance you run yourself:
 
 - **the server** — `lib/grappa/**` and everything it exposes: the REST API,
   the WebSocket (Phoenix Channels) surface, authentication and session
   handling, the upstream IRC client, scrollback storage.
 - **the client** — `cicchetto/**`, the browser PWA.
-- **the live instance** — [irc.sindro.me](https://irc.sindro.me), for
-  findings you can demonstrate **against your own account and your own
-  data**.
 
 Out of scope:
 
-- **Denial of service, load testing, and traffic flooding** against the live
-  instance or its upstream networks. Do not run these; report the weakness
-  instead of exercising it.
-- **Other people's accounts, messages, or scrollback** on the live instance.
-  If a bug lets you reach them, stop at the proof that it does — do not
-  collect the data.
+- **The live instance.** [irc.sindro.me](https://irc.sindro.me) is not a test
+  target. Do not probe it, scan it or attack it — **not even against your own
+  account and your own data**. Stand up your own instance and demonstrate the
+  finding there instead.
+- **Denial of service, load testing and traffic flooding.** Report the
+  weakness; do not exercise it. A resource-exhaustion bug is a good report
+  when you can describe the mechanism, and never a good demonstration. This
+  holds wherever you would run it, your own instance included when it is
+  pointed at a real IRC network — that traffic lands on somebody else's
+  servers.
+- **Other people's accounts, messages or scrollback.** On your own instance,
+  create the second account yourself. If a bug reaches data that is not
+  yours, stop at the proof that it does and do not collect it.
 - **Upstream IRC networks** (Azzurra, Libera, OFTC, …). They are not ours;
   report those to the network's own staff.
 - **Third-party dependencies**, which belong upstream — though do tell us if
@@ -66,3 +73,15 @@ Only the current release — the newest `v*` tag, which is the number in the
 repository's `VERSION` file — and the tip of `main` are supported. Older tags
 receive no backports; there are no maintenance branches. Self-hosters should
 track the latest release.
+
+## No warranty
+
+grappa-irc is free software, provided **as is** under the
+[MIT License](LICENSE), which disclaims every warranty — express or implied —
+and all liability. That file is the binding text on both, and nothing on this
+page softens it. Running this software, self-hosted or otherwise, is at your
+own risk.
+
+Reporting a vulnerability earns no entitlement either: not to a fix, not to a
+fix by any date, not to a reply, and not to compensation. *What to expect*
+above says what this project intends to do. It is an intention, not a debt.


### PR DESCRIPTION
Addresses issue 2073.

The repo is public and has no disclosure door, so today the only way to
reach the maintainer with a vulnerability is a public issue — publishing
the bug to everyone in the same instant it arrives, on software with a
live instance and self-hosters.

One file, `SECURITY.md`, in the repository root (where the rest of the
project docs live; GitHub reads it there just the same). Nothing else in
the diff: no settings, no workflow, no test, no badge.

## Updated after vjt's ruling on the wording

The first cut of this file put the live instance **in** scope with a
carve-out. The ruling reverses that, so the Scope section was rewritten
rather than reworded. Second commit on the branch.

- **The live instance is out of scope, with no carve-out.**
  `irc.sindro.me` is not a test target — not even against your own
  account and your own data. Whoever hunts for holes stands up their own
  instance, and the file says why: a report that asks us to take your
  word that you stayed inside your own account is one we cannot verify,
  and the risk lands on the other people logged into that server.
- **Two dependent bullets were rewritten, not left standing.** "Denial
  of service … against the live instance" and "Other people's accounts …
  on the live instance" both presupposed a permission that no longer
  exists. A file that says *do not touch it* at one bullet and *do not
  flood it* three bullets later describes two worlds and the reader
  picks the comfortable one. Both are now classes that hold wherever you
  run them, keeping the imperative that survives: report the weakness
  instead of exercising it. The DoS bullet gains the case that used to
  hide behind "the live instance" — your own deployment pointed at a
  real IRC network, where the traffic lands on somebody else's servers.
- **The Scope section now opens with the positive form.** A policy that
  only forbids leaves a reporter nowhere to go.
- **No warranty**, split by owner. The software half **points at
  `LICENSE`** instead of restating it — MIT already disclaims every
  warranty and all liability, and a second copy here is one more thing
  to drift out of step with the binding text. The report half is not in
  the licence and so is written out: reporting earns no fix, no date, no
  reply, no compensation. *What to expect* is an intention, not a debt.
- **"or if the button above is not there" is dropped.** Private
  vulnerability reporting is on, so the clause described no reachable
  state. Verified first-hand rather than taken from the announcement:
  `repos/vjt/grappa-irc/private-vulnerability-reporting` answers
  `{"enabled":true}`.
- **The PGP sentence folds into the email bullet.** With route 1 a
  private channel of its own, that paragraph only ever spoke to route 2;
  standing alone it read as if the whole file lacked one. Same content,
  less text, and it still promises neither a key nor a reply. Editorial
  call, taken here.

Untouched on purpose, because the file already said both well: no SLA
and no bounty with acknowledgement best effort, and support limited to
the newest `v*` tag plus the tip of `main` with no backports.

## The two channels

GitHub private vulnerability reporting as the preferred route, and
`vjt@openssl.it` as the out-of-band contact. The address is the one
ruled for this file; it is not justified here by anything read out of
the tree.

## Checked

Every email, URL and handle in the finished file was swept out with a
regex that was itself controlled against planted values — it returns
exactly two, `https://irc.sindro.me` and `vjt@openssl.it`, both of them
already ruled. No address, domain, key or handle was introduced.

Four checks are the full round on this branch: `SECURITY.md` is not in
`integration.yml`'s `paths:`, so 4/4 is complete rather than partial.