### PR TITLE
cic: one IME guard for ComposeBox and TopicBar, so a candidate-commit Enter is not a send

### DIFF
--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -26,6 +26,7 @@ import { placeCaretAtEndInView, placeCaretInView } from "./lib/composeCaret";
 import { composePlaceholder } from "./lib/composePlaceholder";
 import { diagPush } from "./lib/diagLog";
 import { frameBudgetForTarget } from "./lib/frameBudget";
+import { isComposingKeystroke } from "./lib/imeComposition";
 import { frameBudgetBaseForNetwork } from "./lib/isupport";
 import { createNetworkReconnect } from "./lib/networkReconnect";
 import { networkBySlug } from "./lib/networks";
@@ -619,6 +620,18 @@ const ComposeBox: Component<Props> = (props) => {
   };
 
   const onKeyDown = (e: KeyboardEvent) => {
+    // issue 2041 — an IME composition owns the keystroke, not us. The Enter
+    // that COMMITS a candidate arrives as a plain `key: "Enter"`, and the
+    // arrows walk the candidate list; acting on either sends a half-typed
+    // line and — via `preventDefault` below — eats the keystroke the IME was
+    // waiting for, so the word never finishes either.
+    //
+    // Placed above the whole chord table on purpose: every branch here is a
+    // verb that competes with the IME for the key, so one guard is the
+    // smaller diff AND the wider fix. Same predicate on TopicBar (the sibling
+    // commit surface) — see `lib/imeComposition` for why it is a module and
+    // what it deliberately does not consult.
+    if (isComposingKeystroke(e)) return;
     if (e.key === "Enter") {
       // #974 — EVERY Enter sends, modifier or not. vjt's ruling (2026-08-07)
       // reverses his 2026-08-06 one: a Shift+Enter that refuses also EATS the

--- a/cicchetto/src/TopicBar.tsx
+++ b/cicchetto/src/TopicBar.tsx
@@ -11,6 +11,7 @@ import {
   topicByChannel,
 } from "./lib/channelTopic";
 import { friendlyError } from "./lib/friendlyError";
+import { isComposingKeystroke } from "./lib/imeComposition";
 import { mircPlainText } from "./lib/mircFormat";
 import { openModeModal } from "./lib/modeModal";
 import { networkIdBySlug } from "./lib/networks";
@@ -274,7 +275,17 @@ const TopicBar: Component<Props> = (props) => {
   //
   // `preventDefault` is what stops the textarea inserting its own break; the
   // flatten STAYS regardless, because a PASTE still carries newlines in.
+  //
+  // issue 2041 — the IME guard comes FIRST, above the chord. With a
+  // compose-based input (Japanese, Chinese, Korean) the Enter that COMMITS
+  // the candidate arrives as a plain `key: "Enter"`; without the check it
+  // sets the topic to a half-typed line AND the `preventDefault` below eats
+  // the keystroke the IME needed, so the word never finishes either. Above
+  // the chord and not inside it, because the 2026-09-10 ruling made EVERY
+  // Enter a commit here, modifier included. Same shape, same predicate, on
+  // ComposeBox — one chord, one semantics, on both surfaces.
   const onEditorKeyDown = (e: KeyboardEvent): void => {
+    if (isComposingKeystroke(e)) return;
     if (e.key !== "Enter") return;
     e.preventDefault();
     void submitEdit();

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -590,6 +590,84 @@ describe("ComposeBox", () => {
     expect(compose.setDraft).not.toHaveBeenCalled();
   });
 
+  // issue 2041 — an IME (Japanese, Chinese, Korean, and every other
+  // compose-based input) delivers the Enter that COMMITS THE CANDIDATE to the
+  // page as an ordinary keydown with `key: "Enter"`. `isComposing` is the only
+  // thing separating it from a real send. Two things go wrong without the
+  // check, and the second is the worse one: the half-typed line is sent, AND
+  // `preventDefault` eats the keystroke the IME was waiting for, so the word
+  // is never finished either.
+  //
+  // The SAME guard sits on TopicBar, from the SAME predicate
+  // (`lib/imeComposition`) — the issue was filed on both surfaces at once so
+  // this chord could not grow a second semantics on the second one.
+  //
+  // The guard is at the TOP of the handler rather than inside the Enter
+  // branch, and the arrow case below is why: EVERY branch here is a verb that
+  // competes with the IME for the keystroke (Enter commits a candidate, the
+  // arrows walk the candidate list). One guard is both the smaller diff and
+  // the wider fix. Only the Enter half is what issue 2041 claims; the arrow
+  // half comes out of the placement and is asserted so it stays.
+  describe("issue 2041 — a keystroke inside an IME composition is not ours", () => {
+    it("the Enter that commits an IME candidate does NOT submit", async () => {
+      const compose = await import("../lib/compose");
+      vi.mocked(compose.submit).mockResolvedValue({ ok: true });
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      const ta = screen.getByPlaceholderText(/message #a/i);
+      const ev = new KeyboardEvent("keydown", {
+        key: "Enter",
+        isComposing: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      ta.dispatchEvent(ev);
+      expect(compose.submit).not.toHaveBeenCalled();
+      // NOT cancelled: eating the keystroke is the second half of the bug —
+      // the IME needs this Enter to commit the candidate.
+      expect(ev.defaultPrevented).toBe(false);
+    });
+
+    it("Shift+Enter inside a composition does not submit either", async () => {
+      // #974 made EVERY Enter a send key, modifier included — which is exactly
+      // why the IME guard has to sit above the chord, not inside one arm.
+      const compose = await import("../lib/compose");
+      vi.mocked(compose.submit).mockResolvedValue({ ok: true });
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      const ta = screen.getByPlaceholderText(/message #a/i);
+      const ev = new KeyboardEvent("keydown", {
+        key: "Enter",
+        shiftKey: true,
+        isComposing: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      ta.dispatchEvent(ev);
+      expect(compose.submit).not.toHaveBeenCalled();
+      expect(ev.defaultPrevented).toBe(false);
+    });
+
+    it("the arrows walk the IME candidate list, not the send history", async () => {
+      const compose = await import("../lib/compose");
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      const ta = screen.getByPlaceholderText(/message #a/i);
+      fireEvent.keyDown(ta, { key: "ArrowUp", isComposing: true });
+      fireEvent.keyDown(ta, { key: "ArrowDown", isComposing: true });
+      expect(compose.recallPrev).not.toHaveBeenCalled();
+      expect(compose.recallNext).not.toHaveBeenCalled();
+    });
+
+    it("a plain Enter with no composition still submits — the guard is not a mute", async () => {
+      // The negative control. A guard that refused everything would pass the
+      // three tests above and break the product.
+      const compose = await import("../lib/compose");
+      vi.mocked(compose.submit).mockResolvedValue({ ok: true });
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      const ta = screen.getByPlaceholderText(/message #a/i);
+      fireEvent.keyDown(ta, { key: "Enter", isComposing: false });
+      expect(compose.submit).toHaveBeenCalledWith(expect.anything(), "freenode", "#a");
+    });
+  });
+
   it("Up arrow on first-line cursor calls recallPrev", async () => {
     const compose = await import("../lib/compose");
     render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);

--- a/cicchetto/src/__tests__/TopicBar.test.tsx
+++ b/cicchetto/src/__tests__/TopicBar.test.tsx
@@ -532,6 +532,52 @@ describe("TopicBar", () => {
         expect(postTopicMock).toHaveBeenCalledWith("tok-test", "freenode", "#italia", "shifted");
       });
 
+      // issue 2041 — an IME (Japanese, Chinese, Korean, and every other
+      // compose-based input) delivers the Enter that COMMITS THE CANDIDATE to
+      // the page as an ordinary keydown with `key: "Enter"`. `isComposing` is
+      // the only thing separating it from a real commit. Two things go wrong
+      // without the check, and the second is the worse one: the half-typed
+      // line becomes the topic, AND `preventDefault` eats the keystroke the
+      // IME was waiting for, so the word is never finished either.
+      //
+      // The SAME guard sits on ComposeBox, from the SAME predicate
+      // (`lib/imeComposition`). The issue was filed on both surfaces at once
+      // for exactly that reason: this chord must not grow a second semantics
+      // on the second surface.
+      it("issue 2041 — the Enter that commits an IME candidate does NOT set the topic", () => {
+        withTopic("Old topic");
+        render(() => <TopicBar {...baseProps()} />);
+        enterEdit();
+        const editor = screen.getByTestId("topic-modal-editor") as HTMLTextAreaElement;
+        fireEvent.input(editor, { target: { value: "にほんご" } });
+        // NOT cancelled — the keystroke belongs to the IME. `fireEvent`
+        // returns false on a cancelled event, so `true` IS the assertion that
+        // we let it through.
+        expect(fireEvent.keyDown(editor, { key: "Enter", isComposing: true })).toBe(true);
+        expect(postTopicMock).not.toHaveBeenCalled();
+        expect(clearTopicMock).not.toHaveBeenCalled();
+        // Still editing, modal still open, draft intact.
+        expect((screen.getByTestId("topic-modal-editor") as HTMLTextAreaElement).value).toBe(
+          "にほんご",
+        );
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      it("issue 2041 — Shift+Enter during a composition does not set it either", () => {
+        // The #974/2026-09-10 ruling made EVERY Enter a commit key on this
+        // surface, modifier included — which is precisely why the IME guard
+        // has to be above the chord and not inside one arm of it.
+        withTopic("Old topic");
+        render(() => <TopicBar {...baseProps()} />);
+        enterEdit();
+        const editor = screen.getByTestId("topic-modal-editor") as HTMLTextAreaElement;
+        fireEvent.input(editor, { target: { value: "にほんご" } });
+        expect(fireEvent.keyDown(editor, { key: "Enter", shiftKey: true, isComposing: true })).toBe(
+          true,
+        );
+        expect(postTopicMock).not.toHaveBeenCalled();
+      });
+
       // #232 guardrail — the new element-level keydown may exist, but it must
       // NOT become a second ESC authority. The isolation is that `keybindings`
       // (the ONE global keydown listener, which drives the shared overlay

--- a/cicchetto/src/lib/imeComposition.ts
+++ b/cicchetto/src/lib/imeComposition.ts
@@ -1,0 +1,53 @@
+// issue 2041 — the ONE predicate answering "does this keystroke belong to an
+// IME composition rather than to us?"
+//
+// An IME (Japanese, Chinese, Korean, and every other compose-based input)
+// spends ordinary keys while a candidate is being built: Enter COMMITS the
+// candidate, the arrows WALK the candidate list. Those keystrokes reach the
+// page as ordinary `keydown`s — `key: "Enter"`, `key: "ArrowUp"` — and
+// `isComposing` is the only thing separating them from the real chord. A
+// commit-key handler that does not ask gets it wrong TWICE: it fires its own
+// verb on a half-typed line, and its `preventDefault` eats the keystroke the
+// IME was waiting for, so the word is never finished either.
+//
+// 🔴 WHY THIS IS A MODULE AND NOT AN INLINE `!e.isComposing`. The expression
+// is one property read; a function around it buys nothing. What it hosts is
+// the DECISION — what cic consults, and what it deliberately does not — with
+// one home for the next person to change instead of three. cic has THREE
+// keydown surfaces that must ask, and issue 2041 exists precisely because the
+// same chord grew a second semantics on a second surface without the first
+// one's guard coming along:
+//   * ComposeBox  — Enter sends the message (#974).
+//   * TopicBar    — Enter sets the topic (issue 2035).
+//   * keybindings — the irssi-shaped printable-key auto-focus redirect. This
+//                   one already asked, inline, since before either ruling;
+//                   it is routed through here so the third site cannot drift
+//                   from the two.
+//
+// 🔴 `keyCode === 229` IS DELIBERATELY ABSENT, AND THIS IS NOT A MEASUREMENT.
+// It is the pre-`isComposing` workaround for engines that reported a
+// composition only through the legacy `keyCode`. We did NOT measure whether
+// any engine cic supports still needs it, and this comment is not evidence
+// that none does. What is on the record instead: the declared build target is
+// `es2022` (`tsconfig.json`, `vite.config.ts`), the e2e matrix is chromium +
+// webkit, and `isComposing` alone is already shipped prior art in
+// `keybindings.ts`. `keyCode` is deprecated besides. If a real IME on a real
+// engine is ever observed committing through `keyCode` with `isComposing`
+// false, the fallback belongs HERE — added once, for all three surfaces — and
+// with the measurement written next to it.
+//
+// ⚠️ Nothing in this module has been measured against a real IME. It is a
+// read of the spec and of the handlers; see the issue-2041 DESIGN_NOTES entry
+// for exactly what is and is not claimed.
+
+/**
+ * True when `e` was delivered while an IME composition was in flight — i.e.
+ * the keystroke belongs to the input method, not to the application.
+ *
+ * A handler that owns a commit chord (Enter) or a navigation chord (the
+ * arrows) must bail on `true` WITHOUT calling `preventDefault`: swallowing
+ * the event denies the IME the very keystroke it is waiting for.
+ */
+export function isComposingKeystroke(e: KeyboardEvent): boolean {
+  return e.isComposing;
+}

--- a/cicchetto/src/lib/keybindings.ts
+++ b/cicchetto/src/lib/keybindings.ts
@@ -19,6 +19,7 @@
 // closing an open drawer. One listener, ordered topmost-first — never a
 // second global keydown listener racing this one.
 
+import { isComposingKeystroke } from "./imeComposition";
 import { runTopmostOverlayEscape } from "./overlayScrollLock";
 
 export type KeybindingHandlers = {
@@ -128,7 +129,11 @@ function onKeydown(e: KeyboardEvent): void {
     !e.ctrlKey &&
     !e.metaKey &&
     !e.altKey &&
-    !e.isComposing &&
+    // issue 2041 — this check is the oldest of the three; it is routed
+    // through the shared predicate so the surface that had it cannot drift
+    // from the two that just got it (ComposeBox, TopicBar). Behaviour is
+    // unchanged: `isComposingKeystroke` is `e.isComposing`.
+    !isComposingKeystroke(e) &&
     e.key.length === 1 &&
     !isTypingTarget(e.target)
   ) {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53010,3 +53010,87 @@ different term, not denoise-specific, and not measured. Reaching
 per-network own nick, which is `networks.ts`, which is the documented circular
 import pair with `selection.ts` — so it is a slice of its own, not a line to
 slip in here.
+<!-- entry #2041 -->
+
+---
+
+## 2026-09-11 — #2041: one IME guard for both commit surfaces, and what it does not claim
+
+`ComposeBox` (Enter sends, #974) and `TopicBar`'s modal editor (Enter sets the
+topic, issue 2035) both treat Enter as a commit key, and neither asked
+`KeyboardEvent.isComposing`. With a compose-based input method — Japanese,
+Chinese, Korean — the Enter that COMMITS THE CANDIDATE reaches the page as an
+ordinary `keydown` with `key: "Enter"`, so both surfaces fired their verb on a
+half-typed line. The `preventDefault` each one calls made it worse than a
+spurious send: it ate the keystroke the IME was waiting for, so the word was
+never finished either. `Shift+Enter` inherited the same fault on both surfaces,
+because the 2026-08-07 (#974) and 2026-09-10 (issue 2035) rulings made EVERY
+Enter a commit, modifier included.
+
+**One predicate, not two guards.** `cicchetto/src/lib/imeComposition.ts`
+exports `isComposingKeystroke/1` and both surfaces call it. The expression it
+wraps is one property read and buys nothing on its own — what the module hosts
+is the DECISION, with one home instead of three. That is the point of the
+issue rather than a tidiness preference: it was filed on both surfaces at once
+precisely because the Enter chord had already grown a second semantics on a
+second surface without the first one's guard travelling with it, and a cure
+applied to one of them would have reproduced that split one layer down.
+
+**Three sites, not two.** `lib/keybindings.ts` — the single global keydown
+listener — already consulted `e.isComposing` inline, on the irssi-shaped
+printable-key auto-focus redirect, since before either Enter ruling. It is
+routed through the shared predicate here with no behaviour change, so the
+surface that HAD the check cannot drift from the two that just got it. Its
+existing test ("IME composition keys do NOT dispatch insertIntoCompose") stays
+green and is the evidence the substitution is inert.
+
+**The guard sits ABOVE the chord table, not inside the Enter branch**, and the
+placement is deliberate on both surfaces. Every branch in `ComposeBox`'s
+handler is a verb that competes with the IME for the keystroke: Enter commits
+a candidate, and the arrows WALK THE CANDIDATE LIST while `ArrowUp`/`ArrowDown`
+there walk the send history. One guard at the top is simultaneously the
+smaller diff and the wider fix. On `TopicBar` the same placement is what keeps
+the two handlers one shape.
+
+### What is NOT claimed
+
+The issue was filed with its own "not claimed" section and this entry does not
+quietly upgrade it.
+
+- **No measurement against a real IME.** Nobody typed Japanese into either box
+  and watched what arrives. The cure is a read of the handlers and of the spec.
+- **The tests are SYNTHETIC.** They dispatch a `KeyboardEvent` carrying
+  `isComposing: true` under jsdom. That is not an input method: it asserts what
+  the handler does with the flag, never that a real IME on a real engine sets
+  it on the commit Enter. The negative control (a plain Enter with
+  `isComposing: false` still submits) is what keeps the guard from being a mute,
+  and the pre-existing `keybindings` test is the evidence the flag genuinely
+  propagates through jsdom and discriminates — but both live on the same
+  synthetic side of the line.
+- **No measurement on a real browser at all.** There is no e2e arm; Playwright
+  can synthesise a `CompositionEvent`, which would be the same simulation one
+  layer out.
+- **No claim this ever bit a user of this instance.**
+
+### `keyCode === 229` is deliberately absent, and that is a decision, not a finding
+
+The legacy fallback for engines that signalled a composition only through
+`keyCode` was NOT added. We did not measure whether any engine cic supports
+still needs it, and the absence is not evidence that none does. What IS on the
+record: the declared build target is `es2022` (`tsconfig.json`,
+`vite.config.ts`), the e2e matrix is chromium + webkit, `isComposing` alone is
+already shipped prior art in `keybindings.ts`, and `keyCode` is deprecated. If
+a real IME is ever observed committing with `isComposing` false, the fallback
+belongs in `imeComposition.ts` — added once, for all three surfaces, with the
+measurement written beside it. Adding it now by reflex would have put an
+unmeasured branch in the one module whose job is to hold the measured decision.
+
+### Named and not cured
+
+`keybindings.ts` handles Tab (nick-complete, compose-input-gated) and Escape
+(the #232 single overlay authority) ABOVE its composition check, so both still
+fire during a composition. Whether that is wrong is a real question — some IMEs
+spend Tab on candidate selection, and Escape cancels a composition — but it is
+a different surface with a different authority (#232 deleted every per-dialog
+Esc handler to get there, and gating the global one is not a line to slip into
+this slice). Unmeasured, named here so it is not rediscovered as new.


### PR DESCRIPTION
Closes out the gap reported in issue 2041 (both surfaces, one guard).

## The defect

`ComposeBox` sends on Enter (#974) and `TopicBar`'s modal editor sets the
topic on Enter (issue 2035). Neither consulted `KeyboardEvent.isComposing`.

With a compose-based input method — Japanese, Chinese, Korean — the Enter that
**commits the candidate** reaches the page as an ordinary `keydown` with
`key: "Enter"`. Both surfaces fired their verb on a half-typed line, and the
`preventDefault` each one calls made it worse than a spurious send: it ate the
keystroke the IME was waiting for, so the word was never finished either.
`Shift+Enter` carried the same fault on both, because the 2026-08-07 (#974) and
2026-09-10 (issue 2035) rulings each made **every** Enter a commit.

## The cure: one predicate, three call sites

`cicchetto/src/lib/imeComposition.ts` exports `isComposingKeystroke/1`.

The expression it wraps is one property read and buys nothing on its own. What
the module hosts is the **decision**, in one home instead of three — and that
is the substance of the issue rather than tidiness. It was filed on both
surfaces at once precisely because this chord had already grown a second
semantics on a second surface without the first one's guard travelling with it;
curing one surface would have reproduced that split one layer down.

There turned out to be a **third** site: `lib/keybindings.ts` already consulted
`e.isComposing` inline, on the irssi-shaped printable-key auto-focus redirect,
since before either Enter ruling. It is routed through the shared predicate
with no behaviour change, so the surface that *had* the check cannot drift from
the two that just got it. Its pre-existing test staying green is the evidence
the substitution is inert.

**The guard sits above the chord table, not inside the Enter branch.** Every
branch competes with the IME for the keystroke: Enter commits a candidate, and
the arrows walk the candidate list where `ComposeBox` walks the send history.
One guard at the top is at once the smaller diff and the wider fix. Only the
Enter half is what the issue claims; the arrow half falls out of the placement
and is asserted so it stays.

## 🔴 What this does NOT claim

The issue was filed with its own refusal section. This PR does not quietly
upgrade it.

- **No measurement against a real IME.** Nobody has typed Japanese into either
  box and watched what arrives. The cure is a read of the handlers and of the
  spec.
- **The tests are SYNTHETIC.** They dispatch a `KeyboardEvent` carrying
  `isComposing: true` under jsdom. That is not an input method — it asserts
  what the handler does with the flag, never that a real IME on a real engine
  sets it on the commit Enter.
- **No real-browser arm at all.** No e2e was added; Playwright would synthesise
  a `CompositionEvent`, which is the same simulation one layer out.
- **No claim this has ever bitten a user of this instance.**

What *is* measured, and only this: the flag genuinely propagates through jsdom
and discriminates — the four new `ComposeBox` cases include a negative control
(a plain Enter with `isComposing: false` still submits) that keeps the guard
from being a mute, and it was green in the same run where the three composing
cases were red before the fix.

### `keyCode === 229` is deliberately absent — a decision, not a finding

The legacy fallback was **not** added. We did not measure whether any engine
cic supports still needs it, and its absence is not evidence that none does.
On the record instead: the declared build target is `es2022`
(`tsconfig.json`, `vite.config.ts`), the e2e matrix is chromium + webkit,
`isComposing` alone is already shipped prior art in `keybindings.ts`, and
`keyCode` is deprecated. If a real IME is ever observed committing with
`isComposing` false, the fallback belongs in `imeComposition.ts` — added once,
for all three surfaces, with the measurement beside it.

### Named and not cured

`keybindings.ts` handles Tab (nick-complete) and Escape (the #232 single
overlay authority) *above* its composition check, so both still fire during a
composition. Whether that is wrong is a real question, but it is a different
surface with a different authority and a different argument — recorded in
DESIGN_NOTES so it is not rediscovered as new.

## Gates

Run whole from the worktree root, rc captured to a file, never through a pipe:

| gate | rc |
|---|---|
| `scripts/bun.sh run check` (5 stages: lock drift, test location, biome src+e2e, tsc src, tsc e2e) | **0** |
| `scripts/bun.sh run test` — 350 files, 7036 tests | **0** |
| `scripts/design-notes-gate.sh` — `1 new entry heading(s), separator and marker present` | **0** |

TDD order held: the six new cases were written first and ran **5 red / 1 green**
(the negative control being the green), then green after the guard.

No STACK or COMPILE lane was taken — this touches `cicchetto/` only.