### PR TITLE
cic: count far-behind the way the server counts it — one definition, four call sites

### DIFF
--- a/cicchetto/src/__tests__/farBehindOwnAuthored.test.ts
+++ b/cicchetto/src/__tests__/farBehindOwnAuthored.test.ts
@@ -106,19 +106,24 @@ const senderOf = (id: number): string => senders.get(id) ?? PEER_NICK;
 /** Seed the backlog: one row in three is the operator's own. */
 const seedBacklog = (tip: number): void => {
   senders.clear();
+  kinds.clear();
   for (let i = 1; i <= tip; i++) senders.set(i, i % 3 === 0 ? OWN_NICK : PEER_NICK);
 };
 
-// All CONTENT: presence is shown in every arm, so the events axis is collapsed
-// and this fixture measures the own-authored term alone.
-const KIND: MessageKind = "privmsg";
+// The kinds law, same shape and same discipline as the senders one: written
+// once, read by the fake server AND by the rows it hands the client. Content
+// unless an arm says otherwise — presence is SHOWN throughout, so a `join` here
+// is a visible event row and not a filtered one.
+const kinds = new Map<number, MessageKind>();
+const kindOf = (id: number): MessageKind => kinds.get(id) ?? "privmsg";
+const isContent = (id: number): boolean => kindOf(id) === "privmsg";
 
 const row = (id: number, channel: string): ScrollbackMessage => ({
   id,
   network: SLUG,
   channel,
   server_time: id,
-  kind: KIND,
+  kind: kindOf(id),
   sender: senderOf(id),
   body: `m${id}`,
   meta: {},
@@ -141,9 +146,19 @@ class FakeServer {
     return this.channel === OWN_NICK;
   }
 
-  private counts(id: number): boolean {
-    if (this.selfWindow) return true; // #396 — own content is payload here
-    return senderOf(id) !== OWN_NICK; // #576 — own content read by definition
+  /**
+   * `exclude_own_authored/3`, in the order the real query applies it: the row
+   * is dropped from the result set BEFORE the content/event grouping, so the
+   * exclusion narrows BOTH buckets rather than just the content one.
+   *
+   *   * peer / channel window — own CONTENT (#576) and own PRESENCE (#532 A)
+   *     are both excluded.
+   *   * self window (#396) — own content is a legitimate note-to-self and
+   *     survives; own PRESENCE is still stripped.
+   */
+  private excluded(id: number): boolean {
+    if (senderOf(id) !== OWN_NICK) return false;
+    return this.selfWindow ? !isContent(id) : true;
   }
 
   listMessages(before?: number): ScrollbackMessage[] {
@@ -164,11 +179,14 @@ class FakeServer {
   countMessagesAfter(after: number): GapProbe {
     let gap = 0;
     let messages = 0;
+    let events = 0;
     for (let i = after + 1; i <= this.tip; i++) {
+      if (this.excluded(i)) continue;
       gap++;
-      if (this.counts(i)) messages++;
+      if (isContent(i)) messages++;
+      else events++;
     }
-    return { gap, messages, events: gap - messages };
+    return { gap, messages, events };
   }
 }
 
@@ -263,8 +281,36 @@ const messagesPill = async (): Promise<number> => {
   return selection.messagesUnread()[keyFor()] ?? 0;
 };
 
+/** Its faint sibling — the EVENTS pill for the same window. */
+const eventsPill = async (): Promise<number> => {
+  const selection = await import("../lib/selection");
+  return selection.eventsUnread()[keyFor()] ?? 0;
+};
+
 /** What the server would answer for the cursor the store currently holds. */
 const truth = async (): Promise<number> => server.countMessagesAfter(await cursorNow()).messages;
+
+/** The same, for the events bucket. */
+const eventsTruth = async (): Promise<number> =>
+  server.countMessagesAfter(await cursorNow()).events;
+
+/**
+ * Presence rows landing live, authored by the operator or by a peer. A `part`
+ * the operator issued from another client is the events-bucket twin of the
+ * multi-device message case: an action they performed, echoed here.
+ */
+const presenceTraffic = async (n: number, who: "own" | "peer"): Promise<void> => {
+  const { appendToScrollback } = await import("../lib/scrollback");
+  const { recordSeen } = await import("../lib/reconnectBackfill");
+  for (let i = 0; i < n; i++) {
+    server.tip += 1;
+    senders.set(server.tip, who === "own" ? OWN_NICK : PEER_NICK);
+    kinds.set(server.tip, "join");
+    const m = row(server.tip, server.channel);
+    appendToScrollback(keyFor(), m);
+    recordSeen(keyFor(), m);
+  }
+};
 
 /** Proof the window really is in the far-behind state these arms are about. */
 const isFarBehind = async (): Promise<boolean> => {
@@ -406,6 +452,77 @@ describe("issue 2045 — far.missed counts own-authored content the server exclu
     expect(settled).toBe(await truth());
     await reSelect();
     expect(await messagesPill()).toBe(settled);
+    expect(await cursorNow()).toBe(pinned);
+  });
+});
+
+// issue 2045, the sibling bucket. NOT named by the issue, which scopes itself
+// to `far.missed` — recorded here and in DESIGN_NOTES as a deliberate widening,
+// on one measurement: the server applies `exclude_own_authored/3` BEFORE the
+// content/event grouping in `count_after_split/6`, so the exclusion narrows
+// BOTH buckets. `far.events` therefore had the identical divergence, one line
+// below the one the issue names and from the same term.
+//
+// Fixing only the content half would have left `countsAsUnreadMessage(...)` on
+// one line and a hand-rolled `!isContentKind(...)` on the next — the module's
+// own published sibling ignored right beside it, which is the half-migration
+// CLAUDE.md warns propagates.
+describe("issue 2045 — the EVENTS bucket carries the same term", () => {
+  const openFarBehindByProbe = async (): Promise<void> => {
+    seedBacklog(1800);
+    server = new FakeServer(1800, 1000, CHANNEL);
+    await wireServer();
+    await joinChannelTopic();
+    await firstSelect();
+    await traffic(30, "peer");
+    expect(await isFarBehind()).toBe(true);
+  };
+
+  it("does not grow by presence the operator caused from another device", async () => {
+    // A JOIN or PART the operator issued elsewhere is an action they performed
+    // (#532 A), not something to catch up on — and the server has never
+    // counted it.
+    await openFarBehindByProbe();
+    const pinned = await cursorNow();
+    for (let batch = 0; batch < 3; batch++) {
+      await presenceTraffic(10, "own");
+      expect(await eventsPill()).toBe(await eventsTruth());
+      expect(await cursorNow()).toBe(pinned);
+    }
+  });
+
+  it("still counts a PEER's presence — the exclusion is not a mute here either", async () => {
+    // The negative control for this bucket. Passes on both sides of the fix.
+    await openFarBehindByProbe();
+    const before = await eventsPill();
+    await presenceTraffic(12, "peer");
+    const after = await eventsPill();
+    expect(after).toBe(await eventsTruth());
+    expect(after).toBeGreaterThan(before);
+  });
+
+  it("strips own presence even in the SELF window, where own CONTENT counts", async () => {
+    // The asymmetry the #396 carve-out actually draws, and the sharpest test of
+    // whether the real predicate is being used: in the self window own content
+    // is payload and own PRESENCE is still stripped. A cure that passed
+    // `isSelfWindow` through to both buckets uniformly fails here.
+    seedBacklog(1800);
+    server = new FakeServer(1800, 1000, OWN_NICK);
+    await wireServer();
+    await joinChannelTopic();
+    await firstSelect();
+    await traffic(30, "peer");
+    expect(await isFarBehind()).toBe(true);
+
+    const pinned = await cursorNow();
+    const messagesBefore = await messagesPill();
+    await traffic(10, "own");
+    await presenceTraffic(10, "own");
+    // Own content STILL counts here…
+    expect(await messagesPill()).toBe(await truth());
+    expect(await messagesPill()).toBeGreaterThan(messagesBefore);
+    // …and own presence still does not.
+    expect(await eventsPill()).toBe(await eventsTruth());
     expect(await cursorNow()).toBe(pinned);
   });
 });

--- a/cicchetto/src/__tests__/farBehindOwnAuthored.test.ts
+++ b/cicchetto/src/__tests__/farBehindOwnAuthored.test.ts
@@ -1,0 +1,411 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GapProbe, MessageKind, RawNetwork, ScrollbackMessage } from "../lib/api";
+import { type ChannelKey, channelKey } from "../lib/channelKey";
+
+// issue 2045 — `far.missed` has TWO producers and they disagree on one term.
+//
+//   * the PROBE — `Scrollback.count_after_split/6`, server — counts content
+//     kinds with own-authored EXCLUDED (`exclude_own_authored/3`).
+//   * the PRUNE — `capScrollbackRing`, client — counted content kinds with
+//     own-authored INCLUDED. One line, `isContentKind(m.kind)`, and no
+//     own-nick arm anywhere in the function.
+//
+// The server's answer is the right one and it is not a preference: a line the
+// operator typed is read BY DEFINITION (#576 content), and a self-PART or a
+// KICK they issued is an action they performed rather than something to catch
+// up on (#532 A presence). `count_after_split/6` says so in its own comment,
+// and cic already agrees everywhere else — `unreadCount.ts` publishes
+// `countsAsUnreadMessage`, whose moduledoc says it mirrors that very function.
+// The far-behind maintenance path was the one place that never asked.
+//
+// Why it bites NOW: before #2037 A the prune path accumulated RAW row counts
+// while the probe returned a split, so the two were obviously different
+// quantities. A narrowed the prune path to the content unit, and the two now
+// agree on everything except this term. That is worse in one specific way, and
+// it is the heart of the issue: two numbers that differ by a lot are visibly
+// two numbers; two numbers that differ by three are indistinguishable from one
+// number until somebody counts.
+//
+// ## The oracle
+//
+// Every arm compares against the SERVER'S OWN ANSWER for the cursor the store
+// currently holds, never against a literal — the same discipline as
+// `unreadDenoisedFarBehind.test.ts`. `FakeServer.countMessagesAfter` therefore
+// implements BOTH halves of `exclude_own_authored/3`, including the #396
+// self-window carve-out, because a fake that only implemented the half under
+// test would make the fix agree with itself.
+//
+// ## Presence is SHOWN in every arm, deliberately
+//
+// The sibling defect (issue 2071) is on the PRESENCE axis of the same two
+// buckets. Leaving presence shown collapses that axis — the raw and filtered
+// populations coincide — so anything these arms measure is the own-authored
+// term and nothing else.
+
+vi.mock(import("../lib/api"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    listNetworks: vi.fn().mockResolvedValue([]),
+    listChannels: vi.fn().mockResolvedValue([]),
+    listMessages: vi.fn(),
+    listMessagesAfter: vi.fn(),
+    countMessagesAfter: vi.fn(),
+    sendMessage: vi.fn(),
+    me: vi.fn().mockResolvedValue({
+      kind: "user",
+      id: "u-test",
+      name: "vjt",
+      is_admin: false,
+      inserted_at: "2026-01-01T00:00:00Z",
+      read_cursors: {},
+    }),
+    login: vi.fn(),
+    logout: vi.fn(),
+    setOn401Handler: vi.fn(),
+  };
+});
+
+const SLUG = "azzurra";
+const CHANNEL = "#grappa";
+const DEFAULT_PAGE = 50;
+
+// 🔴 The per-network IRC nick, and it is NOT the account name by construction.
+// `ownNickForNetwork(net, me)` returns `net.nick`, and the api moduledoc warns
+// at length that the two differ after a NickServ ghost recovery. A fixture that
+// made them equal would pass with the account name substituted for the nick —
+// exactly the H3 bug that warning exists for.
+const OWN_NICK = "vjt-grappa";
+const PEER_NICK = "bob";
+
+const NET: RawNetwork = {
+  kind: "user",
+  id: 1,
+  slug: SLUG,
+  nick: OWN_NICK,
+  connection_state: "connected",
+  connection_state_reason: null,
+  connection_state_changed_at: null,
+  inserted_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+// 🔴 ONE law, read by BOTH sides. Authorship lives in this map and nowhere
+// else: the FakeServer's count and the rows it hands the client both read it,
+// so the oracle can never describe a log the client was not given.
+//
+// It is a map and not `id % 3` because the arms need to steer authorship of
+// the LIVE tail. An earlier version selected ids by skipping the ones whose
+// author did not match — which left the server counting rows that were never
+// delivered, and the client then read LOWER than the server. That is the
+// opposite of the defect under test, and it is exactly what the two control
+// arms are here to catch.
+const senders = new Map<number, string>();
+const senderOf = (id: number): string => senders.get(id) ?? PEER_NICK;
+
+/** Seed the backlog: one row in three is the operator's own. */
+const seedBacklog = (tip: number): void => {
+  senders.clear();
+  for (let i = 1; i <= tip; i++) senders.set(i, i % 3 === 0 ? OWN_NICK : PEER_NICK);
+};
+
+// All CONTENT: presence is shown in every arm, so the events axis is collapsed
+// and this fixture measures the own-authored term alone.
+const KIND: MessageKind = "privmsg";
+
+const row = (id: number, channel: string): ScrollbackMessage => ({
+  id,
+  network: SLUG,
+  channel,
+  server_time: id,
+  kind: KIND,
+  sender: senderOf(id),
+  body: `m${id}`,
+  meta: {},
+});
+
+/**
+ * A server that answers `/messages/count` the way the real one does. The
+ * own-authored exclusion mirrors `Scrollback.exclude_own_authored/3` INCLUDING
+ * the #396 self-window carve-out: in the window keyed to the operator's own
+ * nick, own content is a legitimate note-to-self and still counts.
+ */
+class FakeServer {
+  constructor(
+    public tip: number,
+    public cursor: number,
+    public channel: string,
+  ) {}
+
+  private get selfWindow(): boolean {
+    return this.channel === OWN_NICK;
+  }
+
+  private counts(id: number): boolean {
+    if (this.selfWindow) return true; // #396 — own content is payload here
+    return senderOf(id) !== OWN_NICK; // #576 — own content read by definition
+  }
+
+  listMessages(before?: number): ScrollbackMessage[] {
+    const hi = before === undefined ? this.tip : Math.min(this.tip, before - 1);
+    const out: ScrollbackMessage[] = [];
+    for (let i = hi; i >= 1 && out.length < DEFAULT_PAGE; i--) out.push(row(i, this.channel));
+    return out;
+  }
+
+  listMessagesAfter(after: number, limit: number): ScrollbackMessage[] {
+    const out: ScrollbackMessage[] = [];
+    for (let i = after + 1; i <= this.tip && out.length < limit; i++)
+      out.push(row(i, this.channel));
+    return out;
+  }
+
+  /** The pair `count_after_split/6` returns over this same log. */
+  countMessagesAfter(after: number): GapProbe {
+    let gap = 0;
+    let messages = 0;
+    for (let i = after + 1; i <= this.tip; i++) {
+      gap++;
+      if (this.counts(i)) messages++;
+    }
+    return { gap, messages, events: gap - messages };
+  }
+}
+
+let server: FakeServer;
+
+const wireServer = async (): Promise<void> => {
+  const api = await import("../lib/api");
+  vi.mocked(api.listNetworks).mockResolvedValue([NET]);
+  vi.mocked(api.listMessages).mockImplementation(async (_t, _s, _c, before) =>
+    server.listMessages(before),
+  );
+  vi.mocked(api.listMessagesAfter).mockImplementation(async (_t, _s, _c, after, limit) =>
+    server.listMessagesAfter(after, limit ?? DEFAULT_PAGE),
+  );
+  vi.mocked(api.countMessagesAfter).mockImplementation(async (_t, _s, _c, after) =>
+    server.countMessagesAfter(after),
+  );
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockImplementation(async (_url: string, init: { body: string }) => {
+      const id = JSON.parse(init.body).message_id as number;
+      if (id > server.cursor) server.cursor = id;
+      return { ok: true, status: 200, json: async () => ({}) };
+    }),
+  );
+  // The own nick only exists once BOTH the me() and the networks resource have
+  // hydrated. Without this wait `networkBySlug` is undefined, `ownNick` is null
+  // and the exclusion is inert — the arms would pass for the wrong reason.
+  const auth = await import("../lib/auth");
+  const networks = await import("../lib/networks");
+  auth.setToken("tok2045");
+  await vi.waitFor(() => {
+    expect(networks.networkBySlug(SLUG)?.nick).toBe(OWN_NICK);
+  });
+};
+
+const keyFor = (): ChannelKey => channelKey(SLUG, server.channel);
+
+/** What `subscribe.ts` does on every per-channel join. */
+const joinChannelTopic = async (): Promise<void> => {
+  const { applyJoinReply } = await import("../lib/readCursor");
+  const { setServerSeedCount } = await import("../lib/selection");
+  applyJoinReply(SLUG, server.channel, server.cursor);
+  const probe = server.countMessagesAfter(server.cursor);
+  setServerSeedCount(keyFor(), { messages: probe.messages, events: probe.events });
+};
+
+const firstSelect = async (): Promise<void> => {
+  const { loadInitialScrollback } = await import("../lib/scrollback");
+  await loadInitialScrollback(SLUG, server.channel);
+};
+
+const reSelect = async (): Promise<void> => {
+  const { refreshScrollback } = await import("../lib/scrollback");
+  await refreshScrollback(SLUG, server.channel);
+};
+
+/**
+ * Live rows landing on the per-channel WS topic.
+ *
+ * ⚠️ `own` is the case that makes this defect non-theoretical: it is the
+ * MULTI-DEVICE one. Lines the operator sends from their phone are echoed to
+ * every other connected client, so they land here — past the laptop's read
+ * cursor, authored by the operator, and counted by a laptop that has no idea
+ * they are its own. Bounded in practice by how much the operator types
+ * elsewhere; unbounded in principle.
+ */
+const traffic = async (n: number, who: "own" | "peer" | "mixed"): Promise<void> => {
+  const { appendToScrollback } = await import("../lib/scrollback");
+  const { recordSeen } = await import("../lib/reconnectBackfill");
+  for (let i = 0; i < n; i++) {
+    // CONSECUTIVE ids, every one of them delivered. Authorship is written into
+    // the shared law rather than searched for, so the server's log and the
+    // client's store hold exactly the same rows.
+    server.tip += 1;
+    const mine = who === "mixed" ? server.tip % 3 === 0 : who === "own";
+    senders.set(server.tip, mine ? OWN_NICK : PEER_NICK);
+    const m = row(server.tip, server.channel);
+    appendToScrollback(keyFor(), m);
+    recordSeen(keyFor(), m);
+  }
+};
+
+const cursorNow = async (): Promise<number> => {
+  const { getReadCursor } = await import("../lib/readCursor");
+  return getReadCursor(SLUG, server.channel) ?? 0;
+};
+
+/** The messages pill the sidebar renders for this window, right now. */
+const messagesPill = async (): Promise<number> => {
+  const selection = await import("../lib/selection");
+  return selection.messagesUnread()[keyFor()] ?? 0;
+};
+
+/** What the server would answer for the cursor the store currently holds. */
+const truth = async (): Promise<number> => server.countMessagesAfter(await cursorNow()).messages;
+
+/** Proof the window really is in the far-behind state these arms are about. */
+const isFarBehind = async (): Promise<boolean> => {
+  const { farBehindByChannel } = await import("../lib/scrollback");
+  return farBehindByChannel()[keyFor()] !== undefined;
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  localStorage.clear();
+  vi.clearAllMocks();
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => "visible",
+  });
+  localStorage.setItem("grappa-token", "tok2045");
+});
+
+describe("issue 2045 — far.missed counts own-authored content the server excludes", () => {
+  // Gap 800 with a third of it the operator's own. This is far past
+  // `isFarBehind`'s one-page bound at hydrate time, so the record is opened by
+  // the PROBE — `anchorAtTail` writing the server's own answer. The arms built
+  // on this helper therefore exercise the ACCUMULATE producer
+  // (`appendPageToScrollback`), which is the other writer of the same number.
+  const openFarBehindByProbe = async (): Promise<void> => {
+    seedBacklog(1800);
+    server = new FakeServer(1800, 1000, CHANNEL);
+    await wireServer();
+    await joinChannelTopic();
+    await firstSelect();
+    await traffic(30, "peer");
+    expect(await isFarBehind()).toBe(true);
+  };
+
+  // 🔴 The OTHER door into the same state, and the one the issue's own framing
+  // turns on: "the same window, at the same cursor, reports a different
+  // far-behind figure depending on whether it went far behind by LOCAL
+  // EVICTION (prune) or by a gap probe on open."
+  //
+  // Here the window opens NEAR — 50 unread, under `isFarBehind`'s one-page
+  // bound — so the hydrate runs no probe and writes no record. Arrivals then
+  // push the unread region past `UNREAD_RETENTION_CAP`, `capScrollbackRing`
+  // bites, and the record is OPENED by the prune with `missed: contentHeld`.
+  // That is the line the issue names, and nothing else in this file reaches it.
+  const openFarBehindByEviction = async (): Promise<void> => {
+    seedBacklog(1050);
+    server = new FakeServer(1050, 1000, CHANNEL);
+    await wireServer();
+    await joinChannelTopic();
+    await firstSelect();
+    expect(await isFarBehind()).toBe(false);
+    // Past the retention bound in one run, a third of it the operator's own.
+    await traffic(260, "mixed");
+    expect(await isFarBehind()).toBe(true);
+  };
+
+  it("opens the record on the server's number when the PRUNE opens it", async () => {
+    // The producer the issue names, in isolation: `capScrollbackRing`'s
+    // content count over the rows the pane holds, a third of which are the
+    // operator's own.
+    await openFarBehindByEviction();
+    expect(await messagesPill()).toBe(await truth());
+  });
+
+  it("agrees with the PROBE-opened window on the same cursor", async () => {
+    // The other producer. Not a duplicate of the arm above: this one asserts
+    // the number the record opens with when `anchorAtTail` writes it, and it
+    // passes on both sides of the fix — it is what says the cure moved the
+    // client TOWARDS the server rather than moving both.
+    await openFarBehindByProbe();
+    expect(await messagesPill()).toBe(await truth());
+  });
+
+  it("does not grow by lines the operator sent from another device", async () => {
+    // 🔴 The multi-device case, and the ACCUMULATE producer rather than the
+    // seed one: past the bound the record grows by what ARRIVED, so an own
+    // line echoed from the phone lands here and is added to a laptop's
+    // catch-up count. Four batches, so a per-batch drift is distinguishable
+    // from a one-off.
+    await openFarBehindByProbe();
+    const pinned = await cursorNow();
+    for (let batch = 0; batch < 4; batch++) {
+      await traffic(10, "own");
+      expect(await messagesPill()).toBe(await truth());
+      // Nothing here reads, scrolls or sends from THIS device: the cursor must
+      // not have moved, or the oracle is answering a different question each
+      // time.
+      expect(await cursorNow()).toBe(pinned);
+    }
+  });
+
+  it("still counts what a PEER sends — the exclusion is not a mute", async () => {
+    // The negative control. It passes on BOTH sides of the fix: a cure that
+    // simply stopped the bucket growing would show up HERE, and a fix that
+    // matched on the account name rather than the per-network nick would too,
+    // since `OWN_NICK` is deliberately not the account name.
+    await openFarBehindByProbe();
+    const before = await messagesPill();
+    await traffic(12, "peer");
+    const after = await messagesPill();
+    expect(after).toBe(await truth());
+    expect(after).toBeGreaterThan(before);
+  });
+
+  it("counts the operator's OWN lines in the SELF window (#396)", async () => {
+    // The carve-out, and the reason this asserts the real predicate rather
+    // than a blanket own-nick strip: the pane keyed to your own nick is the one
+    // window where own content is legitimate payload (a note-to-self), so the
+    // server counts it there and so must cic. A fix that passed
+    // `isSelfWindow: false` unconditionally would pass every arm above and
+    // fail this one.
+    seedBacklog(1800);
+    server = new FakeServer(1800, 1000, OWN_NICK);
+    await wireServer();
+    await joinChannelTopic();
+    await firstSelect();
+    await traffic(30, "peer");
+    expect(await isFarBehind()).toBe(true);
+
+    const pinned = await cursorNow();
+    const before = await messagesPill();
+    expect(before).toBe(await truth());
+    await traffic(10, "own");
+    expect(await messagesPill()).toBe(await truth());
+    expect(await messagesPill()).toBeGreaterThan(before);
+    expect(await cursorNow()).toBe(pinned);
+  });
+
+  it("carries the same number across a re-select — one producer, not two", async () => {
+    // The issue's own framing: the same window at the same cursor must not
+    // report a different figure depending on which producer answered. A
+    // re-select runs the gap probe, so this arm puts BOTH producers on the
+    // same window and demands they agree.
+    await openFarBehindByProbe();
+    await traffic(10, "own");
+    const pinned = await cursorNow();
+    const settled = await messagesPill();
+    expect(settled).toBe(await truth());
+    await reSelect();
+    expect(await messagesPill()).toBe(settled);
+    expect(await cursorNow()).toBe(pinned);
+  });
+});

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -17,7 +17,8 @@ import { membersByChannel } from "./members";
 import { presenceRowVisible } from "./presenceFilter";
 import { getReadCursor, setReadCursor } from "./readCursor";
 import { getResumeCursor, recordSeen } from "./reconnectBackfill";
-import type { UnreadMeasurement } from "./unreadCount";
+import { countsAsUnreadMessage, type UnreadMeasurement } from "./unreadCount";
+import { unreadRowContextFor } from "./unreadRowContext";
 
 // Per-channel scrollback store: the source of truth for messages
 // rendered in `ScrollbackPane`. Module-singleton signal store mirroring
@@ -279,7 +280,17 @@ export const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): C
   // #2037 — the content-only twins, over the SAME slice the raw counts use so
   // the two can never describe different regions.
   const unreadRows = firstUnread === -1 ? [] : rows.slice(firstUnread);
-  const contentCount = unreadRows.filter((m) => isContentKind(m.kind)).length;
+  // issue 2045 — the MESSAGES bucket asks `countsAsUnreadMessage`, not a bare
+  // `isContentKind`. This number opens the far-behind record when the PRUNE is
+  // what puts the window there, and the record's other producer — the server's
+  // `count_after_split/6` — has always excluded own-authored content
+  // (`exclude_own_authored/3`, #576/#532 A). Counting it here made the same
+  // window report a different figure depending on which door it came in by,
+  // and the two differ by little enough to look like one number.
+  const ctx = decoded
+    ? unreadRowContextFor(decoded.slug, decoded.name)
+    : { ownNick: null, casemapping: "ascii" as const, isSelfWindow: false };
+  const contentCount = unreadRows.filter((m) => countsAsUnreadMessage(m, ctx)).length;
   // issue 2071 — the EVENTS bucket, and it is NOT `unreadCount - contentCount`.
   // That subtraction is the raw remainder, and on a denoised window the raw
   // remainder is mostly rows the pane never renders. See `eventHeld`.
@@ -682,6 +693,9 @@ const exports = identityScopedStore((onIdentityChange) => {
   // keeps the newest CAP rows of the union and the loop could keep a late
   // arrival while having already dropped a newer row.
   const appendPageToScrollback = (key: ChannelKey, page: ScrollbackMessage[]): void => {
+    // issue 2045 — decoded once for the whole page: the operator's identity in
+    // this window does not change between two rows of one batch.
+    const decodedKey = decodeChannelKey(key);
     if (page.length === 0) return;
     // S20: track whether the ring cap evicted older rows so we can reset the
     // loadMore exhausted latch below. Computed inside the pure updater,
@@ -745,10 +759,21 @@ const exports = identityScopedStore((onIdentityChange) => {
         // `Grappa.PresenceFilter.Resolver`, so the population has to match on
         // both halves, and only one half can diverge.
         const memberCount = memberCountFor(key);
+        // issue 2045 — the CONTENT half asks the same predicate the seed above
+        // asks, for the same reason. Past the retention bound the record grows
+        // by what ARRIVED, so this is where a line the operator sent from
+        // ANOTHER DEVICE lands: echoed to every client, past this one's read
+        // cursor, and counted by a pane that has no idea it is its own. Fixing
+        // only the seed would have left the number right at arm-time and wrong
+        // three messages later, which is worse than being consistently wrong.
+        const arrivalCtx = decodedKey
+          ? unreadRowContextFor(decodedKey.slug, decodedKey.name)
+          : { ownNick: null, casemapping: "ascii" as const, isSelfWindow: false };
         for (const m of fresh) {
           if (m.id <= previousNewest) continue;
-          if (isContentKind(m.kind)) arrivedContent++;
-          else if (presenceRowVisible(key, memberCount, m.kind)) arrivedEvents++;
+          if (isContentKind(m.kind)) {
+            if (countsAsUnreadMessage(m, arrivalCtx)) arrivedContent++;
+          } else if (presenceRowVisible(key, memberCount, m.kind)) arrivedEvents++;
         }
         const capped = capScrollbackRing(key, next);
         evicted = capped.rows.length < next.length;

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -17,7 +17,7 @@ import { membersByChannel } from "./members";
 import { presenceRowVisible } from "./presenceFilter";
 import { getReadCursor, setReadCursor } from "./readCursor";
 import { getResumeCursor, recordSeen } from "./reconnectBackfill";
-import { countsAsUnreadMessage, type UnreadMeasurement } from "./unreadCount";
+import { countsAsUnreadEvent, countsAsUnreadMessage, type UnreadMeasurement } from "./unreadCount";
 import { unreadRowContextFor } from "./unreadRowContext";
 
 // Per-channel scrollback store: the source of truth for messages
@@ -294,8 +294,15 @@ export const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): C
   // issue 2071 — the EVENTS bucket, and it is NOT `unreadCount - contentCount`.
   // That subtraction is the raw remainder, and on a denoised window the raw
   // remainder is mostly rows the pane never renders. See `eventHeld`.
+  // issue 2045 — and the EVENTS bucket carries the same own-authored term as
+  // the content one above. `exclude_own_authored/3` is applied BEFORE the
+  // content/event grouping in `count_after_split/6`, so the server's `events`
+  // has never counted a JOIN or PART the operator caused. The two predicates
+  // compose: `countsAsUnreadEvent` is the population, `presenceRowVisible` is
+  // the per-channel UI filter (issue 2071) that the shared module must not
+  // reach for itself.
   const eventCount = unreadRows.filter(
-    (m) => !isContentKind(m.kind) && presenceRowVisible(key, memberCountFor(key), m.kind),
+    (m) => countsAsUnreadEvent(m, ctx) && presenceRowVisible(key, memberCountFor(key), m.kind),
   ).length;
 
   // #1229 — the protected region has a ceiling of its own, applied BEFORE the
@@ -773,7 +780,12 @@ const exports = identityScopedStore((onIdentityChange) => {
           if (m.id <= previousNewest) continue;
           if (isContentKind(m.kind)) {
             if (countsAsUnreadMessage(m, arrivalCtx)) arrivedContent++;
-          } else if (presenceRowVisible(key, memberCount, m.kind)) arrivedEvents++;
+          } else if (
+            countsAsUnreadEvent(m, arrivalCtx) &&
+            presenceRowVisible(key, memberCount, m.kind)
+          ) {
+            arrivedEvents++;
+          }
         }
         const capped = capScrollbackRing(key, next);
         evicted = capped.rows.length < next.length;

--- a/cicchetto/src/lib/selection.ts
+++ b/cicchetto/src/lib/selection.ts
@@ -1,5 +1,4 @@
 import { createEffect, createMemo, createSignal, on, untrack } from "solid-js";
-import { ownNickForNetwork } from "./api";
 import { token } from "./auth";
 import { casemappingForSlug } from "./casemapping";
 import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
@@ -23,6 +22,7 @@ import {
   wasLoaded,
 } from "./scrollback";
 import { countsAsUnreadEvent, type UnreadRowContext, unreadMessagesAfter } from "./unreadCount";
+import { unreadRowContextFor } from "./unreadRowContext";
 import {
   HOME_WINDOW_NAME,
   HOME_WINDOW_SLUG,
@@ -427,7 +427,6 @@ const exports = identityScopedStore((onIdentityChange) => {
     // CONTENT from the count (see the content-row loop below). Read reactively
     // so a NICK change / login re-runs the count. Per-key resolution uses
     // `networkBySlug(slug)` inside the loop (a nick is per-network).
-    const me = user();
 
     const result: Record<ChannelKey, Computed> = {};
 
@@ -489,18 +488,14 @@ const exports = identityScopedStore((onIdentityChange) => {
       // #576 — the per-network own nick for this key's network. A nick is
       // per-network (`net.nick`), so resolve it per key; null when the
       // network isn't known yet (nickEquals is null-safe → no exclusion).
-      const net = networkBySlug(decoded.slug);
-      const ownNick = net ? ownNickForNetwork(net, me) : null;
-      // The own-nick SELF window (pane keyed to your own nick) is the ONE
-      // window where own content is legitimate payload — a note-to-self —
-      // so it is NOT excluded there (#396). Mirrors the server self-window
-      // carve-out in `Scrollback.exclude_own_authored/3`.
-      const casemapping = casemappingForNetwork(net?.id ?? null);
-      const ctx: UnreadRowContext = {
-        ownNick,
-        casemapping,
-        isSelfWindow: nickEquals(decoded.name, ownNick, casemapping),
-      };
+      // issue 2045 — built by the SHARED resolver, which is also what the
+      // far-behind maintenance in `scrollback.ts` now calls. It used to be
+      // assembled inline right here, and a second hand-built copy over there
+      // would have been the very drift that issue is about: two spellings of
+      // "who am I in this window" feeding two counts meant to be one number.
+      // The per-network nick, the per-network casemapping and the #396
+      // self-window carve-out all live in `unreadRowContextFor`.
+      const ctx: UnreadRowContext = unreadRowContextFor(decoded.slug, decoded.name);
       // #239 — skip rows the presence filter hides for this channel: the pane
       // never renders them, so counting them would leave a badge the operator
       // can never clear by reading. Same predicate the pane's `rows()` filter

--- a/cicchetto/src/lib/unreadRowContext.ts
+++ b/cicchetto/src/lib/unreadRowContext.ts
@@ -1,0 +1,59 @@
+// issue 2045 — ONE way to answer "who is the operator, in this window?".
+//
+// `unreadCount.ts` publishes the predicates (`countsAsUnreadMessage`,
+// `countsAsUnreadEvent`, `isOperatorOwnedRow`) and takes the answer as a
+// parameter, deliberately: it stays pure and reaches for no store. Somebody
+// still has to build that parameter, and until now exactly one caller did —
+// `selection.ts`, inline, in the middle of its per-key loop.
+//
+// 🔴 Why that had to be extracted before a SECOND caller appeared, rather
+// than copied. `far.missed` is written by two producers — the server's
+// `Scrollback.count_after_split/6` and cic's own far-behind maintenance — and
+// issue 2045 is what happens when the two answer the same question with one
+// term of difference. A second hand-built context would be the same failure
+// one level down: two spellings of "who am I here", free to drift, feeding
+// two counts that are supposed to be one number. The context is the shared
+// input, so it gets one home.
+//
+// Every field is load-bearing and none is guessable:
+//
+//   * `ownNick` is PER-NETWORK (`net.nick`), never the account name.
+//     `api.ts`'s own warning on `ownNickForNetwork` spells out why: after a
+//     NickServ ghost recovery the account is "vjt" while the IRC nick is
+//     "vjt-grappa", and substituting one for the other is the cic H3
+//     DM-misrouting root cause from the 2026-05-08 review.
+//   * `casemapping` is per-network too (#537 axis 2), so the nick MATCH folds
+//     the way that network's ircd folds.
+//   * `isSelfWindow` is the #396 carve-out: the pane keyed to your own nick is
+//     the ONE window where own content is legitimate payload (a note-to-self),
+//     so it is NOT excluded there. Mirrors the server's `self_window?` in
+//     `count_after_split/6`.
+//
+// A `null` network — not hydrated yet, or unknown slug — yields a `null`
+// nick, and `nickEquals` is null-safe, so the exclusion is simply inert until
+// the resource lands. That is the honest degradation: count everything rather
+// than guess an identity.
+
+import { ownNickForNetwork } from "./api";
+import { casemappingForNetwork } from "./isupport";
+import { networkBySlug, user } from "./networks";
+import { nickEquals } from "./nickEquals";
+import type { UnreadRowContext } from "./unreadCount";
+
+/**
+ * Resolve the operator's identity for the window `(slug, name)`.
+ *
+ * Reactive: reads the `networks` and `user` signals, so a caller inside a memo
+ * or an effect re-runs when the network resource hydrates or the identity
+ * rotates.
+ *
+ * @param slug the network slug the window belongs to.
+ * @param name the window's channel or peer-nick name, RAW (the fold happens
+ *             inside, via `nickEquals`).
+ */
+export const unreadRowContextFor = (slug: string, name: string): UnreadRowContext => {
+  const net = networkBySlug(slug);
+  const ownNick = net ? ownNickForNetwork(net, user()) : null;
+  const casemapping = casemappingForNetwork(net?.id ?? null);
+  return { ownNick, casemapping, isSelfWindow: nickEquals(name, ownNick, casemapping) };
+};

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53094,3 +53094,108 @@ spend Tab on candidate selection, and Escape cancels a composition — but it is
 a different surface with a different authority (#232 deleted every per-dialog
 Esc handler to get there, and gating the global one is not a line to slip into
 this slice). Unmeasured, named here so it is not rediscovered as new.
+<!-- entry #2045 -->
+
+---
+
+## 2026-09-11 — #2045: one definition of "unread", reached from four places
+
+`far.missed` — the number the far-behind bar renders and, since #2037 A, the
+number the sidebar's bold pill reads — had two producers that disagreed on one
+term. The server's `Scrollback.count_after_split/6` counts content kinds with
+own-authored EXCLUDED (`exclude_own_authored/3`); cic's far-behind maintenance
+counted them IN.
+
+The server's answer is the right one and it is not a #2037 preference: it is
+the definition the project already holds. A line the operator typed is read BY
+DEFINITION (#576 content), and a self-PART or a KICK they issued is an action
+they performed rather than something to catch up on (#532 A presence).
+
+**Why it surfaced now.** Before #2037 A the client path accumulated RAW row
+counts while the probe returned a split — two obviously different quantities,
+and whichever producer armed the window supplied the number. A narrowed the
+client to the content unit, so the two now agree on everything except this
+term. That is worse in one specific way, and it is the point of the issue:
+two numbers that differ by a lot are visibly two numbers, and two numbers that
+differ by three are indistinguishable from one number until somebody counts.
+
+### FOUR sites, where the issue named one
+
+The issue names `capScrollbackRing`'s `contentCount`. That line is the SEED —
+what opens the record when LOCAL EVICTION is the door into the far-behind
+state. But past the retention bound the record GROWS by what arrived, and
+`appendPageToScrollback`'s `arrivedContent` carried the same bare
+`isContentKind`. Both write `far.missed`.
+
+Fixing only the named line would have been worse than leaving it: the number
+would read correctly at arm-time and drift on the next own message —
+intermittent wrongness in place of consistent wrongness, and harder to
+diagnose. It is also the site the issue's own motivating case runs through.
+The multi-device scenario the issue calls out — lines sent from the phone
+sitting past the laptop's cursor — arrives on the laptop as a live WS append,
+which is the ACCUMULATE producer and not the seed.
+
+The remaining two sites are the events-bucket twins of the first two, and they
+are a deliberate widening past the issue's text, taken on a measurement rather
+than on symmetry: `exclude_own_authored/3` is applied to the query BEFORE the
+content/event `group_by`, so it narrows BOTH buckets. In a peer or channel
+window the server strips own content and own presence alike; in the self
+window (#396) own content survives and own PRESENCE is still stripped. So
+`far.events` had the identical divergence one line below. It also could not be
+left: with only the content half cured, `capScrollbackRing` would read
+`countsAsUnreadMessage(m, ctx)` on one line and a hand-rolled
+`!isContentKind(m.kind)` on the next, with the published sibling
+`countsAsUnreadEvent` unused beside it — a half-migration created by the fix
+rather than found by it. It is a SEPARATE commit so it can be dropped whole.
+
+### The context is shared, and that is the actual design decision
+
+The predicates were not new. `unreadCount.ts` (issue 2069) already publishes
+`countsAsUnreadMessage` / `countsAsUnreadEvent` and its moduledoc already says
+it mirrors `count_after_split/6`; the far-behind path was simply the one place
+that never asked. What is new is `lib/unreadRowContext.ts`.
+
+Those predicates take "who is the operator, in this window?" as a PARAMETER,
+so the module stays pure and reaches for no store. Until now exactly one
+caller built that parameter — `selection.ts`, inline, mid-loop. A second
+hand-built copy in `scrollback.ts` would have been this very defect one level
+down: two spellings of one identity feeding two counts that are supposed to be
+one number. So the builder was extracted first and `selection.ts` routed
+through it, and the second caller was added to the shared one. Each field is
+load-bearing: the nick is PER-NETWORK (`net.nick`, never the account name —
+see the `ownNickForNetwork` warning and the 2026-05-08 cic H3 DM-misrouting
+root cause), the casemapping is per-network (#537 axis 2), and `isSelfWindow`
+is the #396 carve-out.
+
+### The arming did not move
+
+What puts a window far behind is still "a row at/after the cursor left the
+store" (#2037 A), as true of a row the operator typed as of anyone else's.
+Only the DISPLAYED quantity narrows. Nothing in this change touches
+`unreadDropped`, `unreadHeld` or the bound they are compared against.
+
+### The import cycle was MEASURED, not read
+
+The issue reported `scrollback.ts → networks.ts` as cycle-free and said so
+honestly: "a static read of the imports, not a build". It was verified with a
+build before any of the cure was written — `tsc --noEmit && vite build` green
+with the edge present, `grep -ci circular` on the build log returning 0 against
+a positive control returning 1, and the eleven co-initialising suites (503
+tests) green with no TDZ `ReferenceError`. An ESM cycle bites at module-init
+and not at compile, so the runtime leg is the one that mattered.
+
+### What this does not claim
+
+- **No production measurement.** The size of the effect is bounded by the
+  operator's own content sitting past their own read cursor. Nobody has read
+  that off a real instance; "small in the common case, unbounded in principle"
+  is the issue's estimate and it stays an estimate.
+- **No e2e.** The evidence is unit-level, against a fake server whose
+  `countMessagesAfter` implements `exclude_own_authored/3` including the #396
+  carve-out — a model of the query, not the query.
+- **The fixture caught itself once, and that is worth recording.** A first
+  version chose arrival authorship by SKIPPING ids whose author did not match,
+  which left the fake server counting rows the client was never handed: the
+  client then read LOWER than the server, the opposite of the defect. The two
+  control arms are what surfaced it. Authorship now lives in one map read by
+  both sides, so the oracle cannot describe a log the client did not get.


### PR DESCRIPTION
Addresses issue 2045.

## The defect

`far.missed` — the far-behind bar's number and, since #2037 A, the sidebar
pill's — has two producers that disagree on one term.

| producer | own-authored |
|---|---|
| `Scrollback.count_after_split/6` (server) | **excluded** (`exclude_own_authored/3`) |
| cic's far-behind maintenance | **included** |

The server is right, and not as a #2037 preference — it is the definition the
project already holds. Own content is read BY DEFINITION (#576); a self-PART or
a KICK you issued is an action you performed (#532 A).

Before #2037 A the client accumulated RAW counts against a split from the
probe: two obviously different quantities. A narrowed the client to the content
unit, so now they agree on everything but this term — **and that is worse**.
Two numbers that differ by a lot are visibly two numbers; two that differ by
three are indistinguishable from one number until somebody counts.

## 🔴 Four sites, where the issue names one

The issue names `capScrollbackRing`'s `contentCount` — the SEED, what opens the
record when LOCAL EVICTION is the door in. But past the retention bound the
record **grows by what arrived**, and `appendPageToScrollback`'s
`arrivedContent` carried the same bare `isContentKind`. Both write
`far.missed`.

Fixing only the named line would have been **worse than leaving it**: correct
at arm-time, drifting on the next own message — intermittent wrongness
replacing consistent wrongness. It would also have missed the issue's own
motivating case. The multi-device scenario (lines sent from the phone sitting
past the laptop's cursor) reaches the laptop as a **live append** — the
accumulate producer, not the seed.

The other two sites are the `far.events` twins. That is a **deliberate widening
past the issue's text, in its own commit so it drops whole** — see below.

## The design decision: one shared context

The predicates already existed. `unreadCount.ts` publishes
`countsAsUnreadMessage` / `countsAsUnreadEvent` and its moduledoc already says
it mirrors `count_after_split/6`; the far-behind path was the one place that
never asked.

What is new is `lib/unreadRowContext.ts`. Those predicates take *"who is the
operator, in this window?"* as a parameter so they stay pure — and until now
exactly one caller built it, inline, mid-loop in `selection.ts`. **A second
hand-built copy would have been this very defect one level down**: two
spellings of one identity feeding two counts meant to be one number. So the
builder was extracted first, `selection.ts` routed through it, and the new
caller added to the shared one.

Every field is load-bearing: the nick is PER-NETWORK (`net.nick`, never the
account name — the `ownNickForNetwork` warning, and the 2026-05-08 cic H3
DM-misrouting root cause), the casemapping is per-network (#537 axis 2), and
`isSelfWindow` is the #396 carve-out.

## The arming did not move

Per #2037 A: what puts a window far behind is still *"a row at/after the cursor
left the store"*, as true of a row the operator typed as of anyone else's. Only
the displayed quantity narrows. `unreadDropped` / `unreadHeld` / the bound are
untouched.

## The cycle was MEASURED, not read

The issue said `scrollback.ts → networks.ts` is cycle-free and was explicit
that this was *"a static read of the imports, not a build"*. Verified with a
build **before writing any of the cure**:

- `tsc --noEmit && vite build` → **rc=0** with the edge present;
- `grep -ci circular` on the build log → **0**, against a positive control
  returning **1**;
- the eleven co-initialising suites → **503 tests green**, no TDZ
  `ReferenceError`.

An ESM cycle bites at module-init, not at compile, so the runtime leg is the
one that mattered.

## The events widening, and why it is separable

`exclude_own_authored/3` is applied to the query **BEFORE** the content/event
`group_by`, so it narrows **both** buckets: in a peer/channel window own
content and own presence alike, in the self window (#396) own content survives
and own presence is still stripped. So `far.events` had the identical
divergence one line below.

It also could not be left half-done: with only the content half cured,
`capScrollbackRing` would read `countsAsUnreadMessage(m, ctx)` on one line and
a hand-rolled `!isContentKind(m.kind)` on the next, the published sibling
unused beside it — a half-migration *created by the fix*. Commit
`0ab931c07` is that half alone and drops cleanly.

## 🔴 What I refuse to claim

- **No production measurement.** How big this is in the field is bounded by the
  operator's own content past their own cursor. Nobody read that off a real
  instance; "small in the common case, unbounded in principle" is the issue's
  estimate and it stays an estimate.
- **No e2e, no real browser.** The evidence is unit-level against a fake server
  that *models* `exclude_own_authored/3` — a model of the query, not the query.
- **The fixture lied once, and the controls caught it.** A first version chose
  arrival authorship by SKIPPING ids whose author did not match, so the fake
  server counted rows the client was never handed and the client read **LOWER**
  than the server — the opposite of the defect. Authorship now lives in one map
  read by both sides. Recorded in DESIGN_NOTES because the failure looked like
  a product finding.
- **I did not verify the server half.** `exclude_own_authored/3` is read, not
  exercised; no Elixir test was run (this branch touches no server code, and
  COMPILE is not mine).

## Tests — TDD, with live negative controls

Nine arms in `farBehindOwnAuthored.test.ts`, oracle = **the server's own answer
for the cursor the store currently holds**, never a literal.

Red first: **3 failed / 3 passed** for the content half (the 3 green being the
controls), then **2 failed / 7 passed** when the events arms landed. The
controls that pass on *both* sides are what say the cure moved the client
toward the server rather than muting a bucket:

- peer content still counts, peer presence still counts;
- the SELF window counts own CONTENT and still strips own PRESENCE — the
  sharpest arm, since a cure passing `isSelfWindow` uniformly fails it;
- `OWN_NICK` is deliberately **not** the account name, so a fix matching on
  `displayNick` fails too.

## Gates

Run whole from the worktree root, rc to a file, never through a pipe.

| gate | rc |
|---|---|
| `scripts/bun.sh run check` (5 stages) | **0** |
| `scripts/bun.sh run test` — 351 files, 7039 tests | **0** |
| `scripts/design-notes-gate.sh` — *1 new entry heading, separator and marker present* | **0** |

⚠️ **Base note:** this branch forked at `b58caf1a9`; `origin/main` has since
moved to `b89137773`. DESIGN_NOTES is `merge=union` and both sides append, so a
rebase wants `scripts/union-rebase.sh` rather than a bare `git rebase`. The
markers differ (`#2041` on main, `#2045` here), so the shared-prefix collapse
the convention exists to prevent does not apply.

cic-only — no STACK or COMPILE lane taken.