### PR TITLE
fix(2052): make the join reply forward-only, like the module already said

### DIFF
--- a/cicchetto/src/__tests__/readCursor.test.ts
+++ b/cicchetto/src/__tests__/readCursor.test.ts
@@ -280,6 +280,62 @@ describe("readCursor", () => {
       expect(getReadCursor("freenode", "#grappa")).toBe(42);
       await p;
     });
+
+    // issue 2052 — the optimistic advance is deliberately NOT reverted on a
+    // failed POST (see the long comment above it: a naive revert clobbers a
+    // concurrent forward advance). That leaves the local cursor legitimately
+    // AHEAD of the server, which is the state a stretch offline produces. The
+    // module's stated invariant is that only the authoritative
+    // `applyReadCursorSet` WS echo moves the cursor backward — but the
+    // join-reply door landed the server's value unconditionally, so the next
+    // rejoin rewound the cursor to the stale server number and every row the
+    // operator had already read counted as unread again.
+    //
+    // Driven through the real transport (a failing `fetch`), not by mutating
+    // the signal: the divergence has to be PRODUCED by the documented no-revert
+    // rule, or the test pins an arrangement the code cannot reach.
+    it("a rejoin does not rewind the optimistic advance left ahead by a failed POST", async () => {
+      const { setReadCursor, getReadCursor, applyJoinReply, clearReadCursors } = await import(
+        "../lib/readCursor"
+      );
+      clearReadCursors();
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      // The server's cursor, hydrated by the first join. It does not move
+      // below: the POST fails.
+      const serverCursor = 1000;
+      applyJoinReply("freenode", "#grappa", serverCursor);
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 503 })));
+
+      // The operator reads to the tail while offline. Local advances; the
+      // server keeps 1000 because nothing landed.
+      await setReadCursor("tok", "freenode", "#grappa", 1010);
+      expect(getReadCursor("freenode", "#grappa")).toBe(1010);
+
+      // Resume: `subscribe.ts` rejoins the per-channel topic and hands us the
+      // reply's cursor — still the stale 1000.
+      applyJoinReply("freenode", "#grappa", serverCursor);
+      expect(getReadCursor("freenode", "#grappa")).toBe(1010);
+    });
+
+    // The discriminating half. "Forward-only" must not degrade into "the join
+    // reply is ignored": a reply carrying a HIGHER id — a peer device settled
+    // further ahead while this tab was away — is exactly what the rejoin
+    // refresh exists to deliver, and it still has to land.
+    it("a rejoin still adopts a join reply that is AHEAD of the local cursor", async () => {
+      const { setReadCursor, getReadCursor, applyJoinReply, clearReadCursors } = await import(
+        "../lib/readCursor"
+      );
+      clearReadCursors();
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      applyJoinReply("freenode", "#grappa", 1000);
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 503 })));
+      await setReadCursor("tok", "freenode", "#grappa", 1010);
+
+      applyJoinReply("freenode", "#grappa", 1200);
+      expect(getReadCursor("freenode", "#grappa")).toBe(1200);
+    });
   });
 
   it("clearReadCursors removes every entry from the signal map", async () => {

--- a/cicchetto/src/lib/readCursor.ts
+++ b/cicchetto/src/lib/readCursor.ts
@@ -8,7 +8,9 @@
 //      login via `applyMeEnvelope/1` — cold-load bulk hydration.
 //   2. Phoenix Channel join reply (`%{read_cursor: <id_or_nil>}`) per
 //      per-channel topic via `applyJoinReply/3` — refresh on every
-//      reconnect/rejoin.
+//      reconnect/rejoin, FORWARD-ONLY since issue 2052 (it used to land
+//      the reply unconditionally, which made a resume after a failed POST
+//      rewind this device's cursor to the server's stale value).
 //   3. `read_cursor_set` typed WS event on the per-channel topic via
 //      `applyReadCursorSet/3` — cross-device live sync (device A
 //      settles, device B reflects).
@@ -70,6 +72,25 @@ const cacheKey = (networkSlug: string, channel: string): string =>
 
 const [cursors, setCursors] = moduleRoot(() => createSignal<Record<string, number>>({}));
 
+// The forward-only rule, in one place because two doors owe it: the
+// optimistic advance in `setReadCursor` and the join-reply refresh in
+// `applyJoinReply`. Both mean the same thing — "adopt this id only if it is
+// ahead of what we hold" — and the module's contract above names exactly ONE
+// path that may move a cursor backward (`applyReadCursorSet`, the
+// authoritative WS echo). Returning `prev` UNCHANGED on a no-op is
+// load-bearing, not tidiness: a rebuilt-but-equal object wakes every cursor
+// consumer for nothing (the same reason `renameReadCursorChannel` bails early
+// on a pure re-casing).
+const advanceOnly = (
+  prev: Record<string, number>,
+  key: string,
+  next: number,
+): Record<string, number> => {
+  const cur = prev[key];
+  if (cur !== undefined && next <= cur) return prev;
+  return { ...prev, [key]: next };
+};
+
 /**
  * Returns the stored read-cursor `last_read_message_id` for
  * `(networkSlug, channel)`, or `null` if none is known. Tracked by
@@ -129,6 +150,31 @@ export const applyMeEnvelope = (envelope: Record<string, Record<string, number>>
  * server's "no cursor for this (subject, network, channel)" answer
  * never overwrites a hydrated value. Called from `subscribe.ts` on
  * every successful per-channel join (initial + post-reconnect).
+ *
+ * **Forward-only** (issue 2052). It used to land the reply's id
+ * unconditionally, which made this a second door that moves a cursor
+ * BACKWARD — contradicting this module's own contract, which names
+ * `applyReadCursorSet` as the only one. The visible cost was a badge that
+ * came back after every resume: `setReadCursor` leaves the local cursor
+ * optimistically ahead when its POST fails (deliberately — see the
+ * no-revert argument at that call site), which is exactly what a stretch
+ * offline produces, and the next rejoin then rewound to the server's stale
+ * value and re-counted every already-read row as unread.
+ *
+ * A reply that is AHEAD still lands: that is what the rejoin refresh is
+ * FOR (a peer device settled further while this tab was away), and the
+ * server's own write is monotonic, so a reply below what we hold cannot be
+ * a deliberate regression. `Grappa.ReadCursor`'s moduledoc says so
+ * outright — `set/4` clamps backward moves, and deliberate mark-as-unread
+ * "has no caller today … when the feature ships it gets its OWN explicit
+ * path". When it does, it arrives with a broadcast and lands here through
+ * `applyReadCursorSet`, which is where a backward move belongs.
+ *
+ * Known and accepted: a cross-identity `/me` that seeded a HIGHER cursor
+ * for a window can no longer be corrected downward by this door
+ * (`networks.ts`'s #818 note). That path is guarded by `identityMoved/1`
+ * and the `on(token)` purge; trading it for the resume flicker is the
+ * deliberate call, not an oversight.
  */
 export const applyJoinReply = (
   networkSlug: string,
@@ -136,7 +182,7 @@ export const applyJoinReply = (
   cursor: number | null,
 ): void => {
   if (cursor === null) return;
-  setCursors((prev) => ({ ...prev, [cacheKey(networkSlug, channel)]: cursor }));
+  setCursors((prev) => advanceOnly(prev, cacheKey(networkSlug, channel), cursor));
 };
 
 /**
@@ -244,11 +290,7 @@ export const setReadCursor = async (
   // now be an optimistic one during the narrow cold-load-before-hydration
   // window; pre-existing race shape, see that effect's comment.
   const optimisticKey = cacheKey(networkSlug, channel);
-  setCursors((prev) => {
-    const cur = prev[optimisticKey];
-    if (cur !== undefined && messageId <= cur) return prev;
-    return { ...prev, [optimisticKey]: messageId };
-  });
+  setCursors((prev) => advanceOnly(prev, optimisticKey, messageId));
   const url = `/networks/${encodeURIComponent(networkSlug)}/channels/${encodeURIComponent(channel)}/read-cursor`;
   const res = await fetch(url, {
     method: "POST",

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53325,3 +53325,74 @@ judgement call inside this slice.
 * **The issue's cost figure is not re-measured.** The 69-of-78 residual is
   taken from 2037's instrument as filed; this file measures reachability, not
   cost.
+<!-- entry #2052 -->
+
+---
+
+## 2026-09-11 — #2052: the join reply was a second door that moved the cursor backward, and the module had already said there was only one
+
+`readCursor.ts`'s `applyJoinReply/3` landed the per-channel join reply's
+cursor unconditionally. After a POST that failed — which is what a stretch
+offline produces — the next rejoin rewound this device's cursor to the
+server's stale value and every already-read row counted as unread again: the
+badge came back on every resume, then cleared the moment the operator read.
+
+### The fork the issue posed collapsed on a measurement, so nothing was ruled
+
+The issue offered forward-only (`max(local, reply)`) against last-write-wins
+and declined to choose, on the grounds that *"last-write-wins is also what
+makes a deliberate server-side cursor reset land at all."* **There is no
+deliberate server-side cursor reset.** `Grappa.ReadCursor`'s own moduledoc
+says it outright: `set/4` is monotonic, *"cic is already forward-only
+locally; the server is the single authoritative regressor"*, and
+**deliberate mark-as-unread "has no caller today — no cic surface, no REST
+verb … when the feature ships it gets its OWN explicit path"**. The one
+backward writer, `force_set/4`, has exactly one caller — `TestReadCursor
+Controller`, on a route `Mix.env() in [:dev, :test]` compile-gates out of the
+release — and it broadcasts, so it lands through `applyReadCursorSet`
+anyway. A reply BELOW what this device holds therefore cannot be a
+deliberate regression; it can only be a device that wrote and did not land.
+
+### This is drift repair, not a new policy
+
+The module had already declared the invariant in two places — *"the ONLY
+path that lands a peer's set (or a backward move)"* and *"only that
+authoritative WS path moves the cursor backward"* — while a third door
+quietly did it. The rule now has ONE name, `advanceOnly/3`, shared by the
+join-reply arm and `setReadCursor`'s optimistic advance, which had the same
+predicate written out. It returns `prev` UNCHANGED on a no-op: a
+rebuilt-but-equal object wakes every cursor consumer for nothing, the same
+reason `renameReadCursorChannel` bails early on a pure re-casing.
+
+A reply that is AHEAD still lands — that is what the rejoin refresh is FOR,
+and the paired test says so; "forward-only" degrading into "the join reply
+is ignored" is the mutant that test exists to kill.
+
+### What forward-only gives up, named rather than discovered later
+
+`networks.ts`'s #818 note describes a cross-identity `/me` seeding a HIGHER
+cursor on a window; this door can no longer correct that downward. That path
+is guarded by `identityMoved/1` and readCursor's `on(token)` purge, and
+trading it for the resume flicker is the deliberate call.
+
+### `applyMeEnvelope` is the same SHAPE and deliberately not cured
+
+It replaces the whole map, so it can also land a server value over a local
+optimistic one. It is not the same defect and not left alone by omission:
+**it is not on the resume path.** Measured — `refetchUser()`'s callers are
+`HomePane` (connect-a-network), `BootErrorBoundary` (retry) and five
+read-after-write settings mutations in `lifecycle.ts`; the socket reconnect
+triggers none of them, and `reconnectBackfill.ts` only READS the cursor. An
+alarm was raised here that five `refetchUser()` calls sat on resume, and the
+measurement killed it. Its full-replace is also load-bearing — a stale entry
+from a prior session would mask a cleared cursor — so a forward-only merge
+there would break the contract it exists to hold. The reload-after-a-failed-
+write case remains what `readCursor.ts` already documents and accepts:
+already-read rows re-surface as unread once.
+
+### Not measured
+
+Whether this fires in production (the issue simulated the offline POST; no
+real client was observed), the frequency, and the browser: the arms are
+store-level, in jsdom, so nothing here says the number reaches a rendered
+badge. That is the e2e's job and it has not run.


### PR DESCRIPTION
`applyJoinReply/3` landed the per-channel join reply's cursor unconditionally, so a rejoin after a failed POST rewound this device's cursor to the server's stale value and re-counted every already-read row as unread — the badge coming back on every resume.

Addresses issue 2052.

## The fork the issue posed collapsed, so nothing was taken to a ruling

The issue offered forward-only (`max(local, reply)`) against last-write-wins and declined to choose, because *"last-write-wins is also what makes a deliberate server-side cursor reset land at all."*

**There is no deliberate server-side cursor reset.** Measured in the server's own source:

* `Grappa.ReadCursor`'s moduledoc: `set/4` is **monotonic**, *"cic is already forward-only locally; the server is the single authoritative regressor"*, and deliberate mark-as-unread *"has **no caller today** — no cic surface, no REST verb … when the feature ships it gets its OWN explicit path"*.
* The one backward writer, `force_set/4`, has **exactly one caller** — `TestReadCursorController`, on a route the router compile-gates behind `Mix.env() in [:dev, :test]`, so the release does not contain it. And it **broadcasts**, so even in dev it lands through `applyReadCursorSet`.

A reply BELOW what this device holds therefore cannot be a deliberate regression; it can only be a device that wrote and did not land.

## This is drift repair, not a new policy

`readCursor.ts` already declared the invariant, twice — *"the ONLY path that lands a peer's set (or a backward move)"* and *"only that authoritative WS path moves the cursor backward"* — while a third door quietly did it. The rule now has one name, `advanceOnly/3`, shared with `setReadCursor`'s optimistic advance, which had the same predicate written out longhand. It returns `prev` **unchanged** on a no-op: a rebuilt-but-equal object wakes every cursor consumer for nothing (same reason `renameReadCursorChannel` bails on a pure re-casing).

## The tests, and the mutant the second one kills

Both drive the divergence through the **real transport** (a failing `fetch`), not by poking the signal — the local-ahead state has to be PRODUCED by the module's documented no-revert rule, or the test pins an arrangement the code cannot reach.

* `a rejoin does not rewind the optimistic advance left ahead by a failed POST` — **RED before** (`expected 1000 to be 1010`), green after.
* `a rejoin still adopts a join reply that is AHEAD of the local cursor` — the discriminator. It passes both before and after, so "forward-only" cannot degrade into "the join reply is ignored", which is what the rejoin refresh exists to deliver.

## Given up knowingly

A cross-identity `/me` that seeded a **higher** cursor on a window can no longer be corrected downward by this door (`networks.ts`'s #818 note). That path is guarded by `identityMoved/1` and readCursor's `on(token)` purge; trading it for the resume flicker is the deliberate call, named here rather than discovered later.

## One site or two: `applyMeEnvelope` is the same SHAPE and deliberately not cured

It replaces the whole map, so it too can land a server value over a local optimistic one. It is left alone **on an argument, not by omission**:

* **It is not on the resume path.** Measured: `refetchUser()`'s callers are `HomePane` (connect-a-network), `BootErrorBoundary` (retry), and five read-after-write settings mutations in `lifecycle.ts`. The socket reconnect triggers none of them, and `reconnectBackfill.ts` only READS the cursor.
* Its full replace is load-bearing — a stale entry from a prior session would mask a cleared cursor — so a forward-only merge there breaks the contract it exists to hold.
* The reload-after-a-failed-write case stays what `readCursor.ts` already documents and accepts: already-read rows re-surface as unread once.

🔎 **A retraction of my own:** I flagged those five `lifecycle.ts` `refetchUser()` calls as a suspected second resume door. The measurement killed it — they are settings writes. Recorded in DESIGN_NOTES so nobody re-derives the alarm.

## Gates

| gate | result |
|---|---|
| `bun.sh run test` (full cic unit suite) | **351 files / 7047 tests, 0 failed**, `rc=0` |
| `bun.sh run check` | **5 stages ran, 0 failed**, `rc=0` (lock drift, test location, biome src+e2e, tsc src, tsc e2e) |
| `scripts/design-notes-gate.sh` | `rc=0` — 1 new entry heading, separator and marker present |
| closing-keyword scan | 0 hits, with a **positive control** that returns 1 and a negative that returns 0 |

No `mix`, no `check.sh`, no e2e: those need a lane and w2 holds both.

## What I refuse to claim

* **That this fires in production.** The issue simulated the offline POST; no real client was observed. Unchanged by this PR.
* **The frequency.** No claim that it is deterministic, nor that it is rare.
* **That the number reaches a rendered badge.** Every arm here is store-level in jsdom. The badge is a pure function of the cursor and is covered elsewhere, but **no e2e has run against this change** — see below.

## Lane request

An e2e is warranted (the change is user-visible) and looks constructible without route-mocking, because `context.setOffline(true)` reproduces the issue's scenario faithfully: read to tail → offline → switch away (the leave-arm POST fails for real) → online (socket reconnects, rejoin delivers the stale cursor) → assert the badge stays 0. It needs the STACK lane. Not written yet — asking before taking.
