### PR TITLE
cic(2053): the far-behind badge is already right — the comments were not

### DIFF
--- a/cicchetto/src/WindowBadges.tsx
+++ b/cicchetto/src/WindowBadges.tsx
@@ -100,10 +100,12 @@ const WindowBadges: Component<Props> = (props) => {
   const muted = () => isConversationMuted(notificationPrefs().muted_targets, props.channelKey);
 
   // BOTH unread badges take the treatment, not just the message one: the
-  // far-behind branch of `perChannelUnread` skips local counting wholesale
-  // and serves the frozen server seed for BOTH kinds, so both are equally
-  // stuck. The mention badge is left alone — it is server-authoritative and
-  // counted a different way (#267), so the cursor freeze does not pin it.
+  // far-behind branch of `perChannelUnread` skips local counting wholesale and
+  // serves the far-behind record's own `missed`/`events` for BOTH kinds
+  // (#2037; it displaced the server seed there), so both are equally stuck
+  // behind a frozen cursor. The mention badge is left alone — it is
+  // server-authoritative and counted a different way (#267), so the cursor
+  // freeze does not pin it.
   //
   // `role="img"` + `aria-label` on both unread badges, unconditionally. The
   // label carries the whole meaning, so the far-behind state is spoken

--- a/cicchetto/src/__tests__/WindowBadges.test.tsx
+++ b/cicchetto/src/__tests__/WindowBadges.test.tsx
@@ -78,9 +78,10 @@ describe("#888 far-behind badge treatment", () => {
 
     const msg = container.querySelector(".sidebar-msg-unread");
     const events = container.querySelector(".sidebar-events-unread");
-    // Both counts come from the frozen server seed while far behind (the
-    // memo's far-behind branch skips local counting wholesale), so both are
-    // equally stuck and both must say so.
+    // Both counts come from the frozen far-behind record while far behind
+    // (#2037; the memo's far-behind branch skips local counting wholesale and
+    // reads `missed`/`events` straight off it — the fixture above IS that
+    // record), so both are equally stuck and both must say so.
     expect(msg?.classList.contains(FAR_BEHIND_CLASS)).toBe(true);
     expect(events?.classList.contains(FAR_BEHIND_CLASS)).toBe(true);
     // The number itself is untouched — this is a treatment, not a rewrite.

--- a/cicchetto/src/__tests__/activeWindowsStep.test.ts
+++ b/cicchetto/src/__tests__/activeWindowsStep.test.ts
@@ -127,7 +127,8 @@ describe("stepActiveWindow — the resolved target is the window you are already
 //
 // Why the exit is dead, in two halves that are each correct on their own:
 //   * selection.ts's `perChannelUnread` SKIPS a far-behind window's
-//     local-derived branch, so the frozen server seed stands as its count and
+//     local-derived branch, so the far-behind record's own frozen `missed`
+//     stands as its count (#2037; the server seed before it) and
 //     `messagesUnread[key] > 0` holds wherever the pane is scrolled — which is
 //     also why the read-at-the-tail suppression is explicitly not applied to
 //     it. The window therefore never leaves `orderUnreadWindows`.
@@ -147,7 +148,7 @@ describe("stepActiveWindow — the resolved target is the window you are already
 describe("stepActiveWindow — that window is ALSO far behind (#1765)", () => {
   const arrangeCrossedState = () => {
     h.channels = [{ name: "#grappa" }];
-    // The frozen seed, not a local-row count — that IS the #693 posture.
+    // The frozen far-behind count, not a local-row count — the #693 posture.
     h.unread = { [channelKey("net", "#grappa")]: 3000 };
     h.farBehind = { [channelKey("net", "#grappa")]: { missed: 3000, resumeFrom: 100 } };
     h.selected = chan("#grappa");

--- a/cicchetto/src/__tests__/unreadBadgeAtTail.test.ts
+++ b/cicchetto/src/__tests__/unreadBadgeAtTail.test.ts
@@ -150,10 +150,10 @@ describe("#981 unread badge on the window being read at the tail", () => {
 
   // #693 — a far-behind window's cursor is FROZEN on purpose and its loaded
   // rows are the tail, deliberately disjoint from the unread region. The
-  // server-measured seed is the honest number and the operator being at the
-  // bottom of those few rows does not mean they have read the thousands
-  // above. Suppressing here would zero the one badge that cannot come back
-  // on its own.
+  // far-behind record's own server-measured count is the honest number
+  // (#2037; the seed before it) and the operator being at the bottom of those
+  // few rows does not mean they have read the thousands above. Suppressing
+  // here would zero the one badge that cannot come back on its own.
   it("keeps a FAR-BEHIND window's badge even while the pane reads its tail", async () => {
     const api = await import("../lib/api");
     vi.mocked(api.countMessagesAfter).mockResolvedValue({ gap: 3000, messages: 3000, events: 0 });

--- a/cicchetto/src/__tests__/unreadBadgeFarBehindStale.test.ts
+++ b/cicchetto/src/__tests__/unreadBadgeFarBehindStale.test.ts
@@ -336,9 +336,11 @@ describe("issue 2050 — a far-behind badge the cursor has already retired", () 
 
     // Nothing was read: the cursor sits where the absence left it, on both
     // sides. Retiring the record THAWS — it stops the badge publishing the
-    // frozen seed and hands the count back to local truth — it does not mark
-    // anything read, and an implementation that "cleared the unread" by moving
-    // the cursor would fail here rather than in some later session.
+    // record's own frozen `missed` and hands the count back to local truth
+    // (the header above: since #2037 that is the frozen number, not the seed)
+    // — it does not mark anything read, and an implementation that "cleared
+    // the unread" by moving the cursor would fail here rather than in some
+    // later session.
     expect(getReadCursor(SLUG, CHANNEL)).toBe(CAUGHT_UP_AT);
     expect(server.cursor).toBe(CAUGHT_UP_AT);
 

--- a/cicchetto/src/lib/activeWindows.ts
+++ b/cicchetto/src/lib/activeWindows.ts
@@ -293,7 +293,8 @@ function stepActiveWindow(dir: 1 | -1): void {
   // a far-behind window (#693's freeze, #1019's invariant). So on a window
   // that IS far behind, #1178's exit is as dead as the `jumpToUnread` it
   // rejected — two correct cures cancelling — and the tap moves nothing at
-  // all: the seed count cannot fall, so the button cannot hide.
+  // all: the far-behind count cannot fall (the record's own `missed` since
+  // #2037, the seed before it), so the button cannot hide.
   //
   // The two verbs partition the state exactly along `farBehindByChannel`,
   // and the comment above already says why each is dead on the other's

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -1103,7 +1103,8 @@ const exports = identityScopedStore((onIdentityChange) => {
   // rows and LOWERS the oldest loaded id, so scrolling up far enough
   // satisfies this bound. That is correct, and the reason is that clearing
   // here THAWS — it does not mark anything read. The badge stops publishing
-  // the frozen seed and goes back to LOCAL truth, which is still N if N rows
+  // this record's own frozen `missed` (#2037; NOT the seed, which it
+  // displaced) and goes back to LOCAL truth, which is still N if N rows
   // follow the cursor; the difference is that it is now a live number the
   // operator retires by reading. Re-paging the region back into the pane IS
   // closing the hole, so the far-behind apparatus has nothing left to do.
@@ -1113,8 +1114,11 @@ const exports = identityScopedStore((onIdentityChange) => {
   // That was an ARGUMENT when this shipped and is now a measurement: the last
   // arm of `unreadBadgeFarBehindStale.test.ts` scrolls the window down to a
   // cursor that never moves and pins the badge to local truth (5003) rather
-  // than to zero, to the frozen seed, or to a short count. A bound that
-  // retired one page into the scroll passed every other arm in that file.
+  // than to zero or to a short count. It can no longer say "rather than to the
+  // frozen number": since #2069 that number and local truth AGREE there, so
+  // what carries "the record retired" is the loop's own exit condition. A
+  // bound that retired one page into the scroll passed every other arm in
+  // that file.
   //
   // `measuredUnreadByChannel` (#947) is deliberately NOT cleared alongside:
   // the pane spends it only while `measured.at === cursor`, so a cursor that

--- a/cicchetto/src/lib/selection.ts
+++ b/cicchetto/src/lib/selection.ts
@@ -478,9 +478,16 @@ const exports = identityScopedStore((onIdentityChange) => {
       // WORSE truth. Its rows are the tail, deliberately disjoint from the
       // unread region, so counting them reports ~50 for a window that is
       // thousands behind — and the operator would see a small, ignorable
-      // badge for the very state the change exists to surface. The seed
-      // (server-side, cursor-anchored, and the cursor is frozen while far
-      // behind) is the honest number here, so leave it standing.
+      // badge for the very state the change exists to surface. What stands in
+      // its place is the far-behind entry written fifteen lines above, NOT the
+      // seed — this `continue` protects that write, and keeps the
+      // filter-and-count below off the largest windows in the store.
+      //
+      // 🔴 issue 2053 — this used to end "the seed is the honest number here,
+      // so leave it standing", which #2037 had already made false. A window
+      // caught up on at join carries a truthful ZERO seed and the ring cap can
+      // arm far-behind from a purely local burst, so on that sentence the
+      // badge says nothing at all — more certainly the more unread piles up.
       if (farBehind[key]) continue;
       const cursorMapKey = `${decoded.slug} ${decoded.name}`;
       const cursor = cursors[cursorMapKey] ?? 0;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53396,3 +53396,87 @@ Whether this fires in production (the issue simulated the offline POST; no
 real client was observed), the frequency, and the browser: the arms are
 store-level, in jsdom, so nothing here says the number reaches a rendered
 badge. That is the e2e's job and it has not run.
+<!-- entry #2053 -->
+
+---
+
+## 2026-09-11 — issue 2053: the badge was already right; the comment was the defect
+
+Reported: a window driven far behind by the #1229 ring cap shows NO badge at
+all while hundreds of rows are unread. `perChannelUnread` skips the local row
+count for a far-behind key, the only writers of the server seed are a join
+reply and `/me`, and for a window the operator was caught up on at join that
+seed is a truthful ZERO that nothing can raise.
+
+**It does not reproduce, and the negative is measured rather than argued.**
+
+### The measurement
+
+Bench: the real `scrollback` + `readCursor` + `selection` stores against the
+fake server the sibling suites use (`after`/`before`/`limit` honoured, the
+probe answered from the same log), on `95998369a`. The shape is the issue's
+own and not a near-miss of it — a join reply seeding `{messages: 0, events: 0}`
+at a cursor equal to the tip, then a live burst through `appendToScrollback`
+with no join, no `/me` and no reconnect anywhere near it. Mixed log, every
+fourth row a peer JOIN, so the two buckets cannot hide in each other.
+
+```
+after 400 live rows
+  far   {missed: 300, events: 100, resumeFrom: 1000}
+  seed  {messages: 0, events: 0}          <- still the truthful zero
+  rowsHeld 200
+  badge 300 / 100     server answer at the frozen cursor 300 / 100
+```
+
+Extended to 2000 rows in ten batches and then a re-select: the badge equals
+the server's own answer for the frozen cursor at every step (150, 300, 450,
+… 1500) and does not move on the re-select.
+
+**The control, on the same bench.** Delete `perChannelUnread`'s far-behind
+loop — the pre-#2037 shape, in which the seed does stand — and the same run
+reports `badge: 0` beside `far.missed: 300`. That is the issue's `{badge: 0}`
+to the digit, so the bench does discriminate and the issue did happen; it
+happened on a tree that no longer exists.
+
+### Why it stopped
+
+#2037 (`d49582c58`) merged to main at **2026-09-10 15:06:53Z**, in PR #2047.
+Issue 2053 was filed at **15:14:13Z** — seven minutes later, from a tree
+where that PR was still open, and it says so: *"a prediction from the values
+measured in my own tree, not a measurement of that branch"*. The prediction
+was right. This is that measurement, taken where it was asked for.
+
+### No new test, and the reason is a measurement too
+
+`farBehindOwnAuthored.test.ts`'s `openFarBehindByEviction` already drives the
+ring-cap route — the arm is called *"opens the record on the server's number
+when the PRUNE opens it"* — and its oracle is the server's answer, not a
+literal. Under the control above it goes RED, together with eight other arms
+across four files; the unmutated set is green. A second file asserting the
+same property on a seed of 0 instead of 50 would be a duplicate of a landed
+test, so there is none.
+
+### What shipped instead
+
+Ten comments, in eight files, still said in the present tense that a
+far-behind badge publishes the seed. One of them is the line the issue quotes
+and it ended *"the seed … is the honest number here, so leave it standing"* —
+follow it and you rebuild the reported defect exactly. `scrollback.ts`'s own
+docblock on the record already stated the truth, so the repair is to make the
+other ten agree with it rather than to invent a story.
+
+Left alone deliberately: the `issue1765` e2e header and the "Pre-2069 this
+line ALSO said" aside in `unreadBadgeFarBehindStale.test.ts` narrate a PAST
+state in the past tense and were accurate on their dates; the DESIGN_NOTES
+entries that record the old behaviour are history and are not rewritten.
+
+### Not measured
+
+- **The rendered pill on this route, in a real browser.** `issue1229`'s e2e
+  reaches the ring-cap arm and asserts the in-pane BAR; `issue2037`'s asserts
+  the sidebar pill but arms far-behind through the reload/probe route. The
+  crossing of the two — ring-cap arm, sidebar pill, real server — has no spec,
+  and this slice did not open one, there being no defect to pin.
+- **Whether the ring-cap route fires in production at all.** Unchanged from
+  the issue: it needs a live burst past the retention cap on a window with a
+  non-null cursor, and nobody has read that off a real instance.


### PR DESCRIPTION
Addresses issue 2053.

## TL;DR

**It does not reproduce on `main`.** #2037 (`d49582c58`) closed it as a side
effect seven minutes before the issue was filed, exactly as the issue's own
"Note on the open PR" predicted from another tree. This PR is that prediction
turned into a measurement, plus the repair of the ten comments that still tell
the old story — one of them the line the issue quotes.

No behaviour changes. No new test.

## The measurement

Real `scrollback` + `readCursor` + `selection` stores against the fake server
the sibling suites use (`after`/`before`/`limit` honoured, the probe answered
from the same log), on `95998369a`, in the issue's exact shape: a join reply
seeding `{messages: 0, events: 0}` at a cursor equal to the tip, then a live
burst through `appendToScrollback` — no join, no `/me`, no reconnect anywhere
near it. Mixed log (every fourth row a peer JOIN) so the two buckets cannot
hide inside each other.

```
after 400 live rows
  far   {missed: 300, events: 100, resumeFrom: 1000}
  seed  {messages: 0, events: 0}          <- still the truthful zero
  rowsHeld 200
  badge 300 / 100      server answer at the frozen cursor  300 / 100
```

Extended to 2000 rows in ten batches, then a re-select: the badge equals the
server's own answer at every step (150, 300, 450 … 1500) and does not move on
the re-select.

## The control

Delete `perChannelUnread`'s far-behind loop — the pre-#2037 shape, where the
seed does stand — and the same bench reports `badge: 0` beside
`far.missed: 300`. That is the issue's `{badge: 0}` to the digit: the bench
discriminates, and the reported defect was real on the tree it was measured on.

## Why no new test

`farBehindOwnAuthored.test.ts`'s arm *"opens the record on the server's number
when the PRUNE opens it"* already drives the ring-cap route, and its oracle is
the server's answer rather than a literal. Under the same control it goes RED,
together with eight other arms across four files; the unmutated set is green
(351 files). A second file asserting the same property with a seed of 0 instead
of 50 would duplicate a landed test.

## What actually shipped

Ten comments in eight files still said, in the present tense, that a far-behind
badge publishes the SERVER SEED. `scrollback.ts`'s own docblock on the record
already said the true thing (*"`selection.ts` reads THIS field for a far-behind
key rather than the seed"*); these ten contradicted it. The one in
`selection.ts` sits on the accused line and ended *"the seed … is the honest
number here, so leave it standing"* — follow that sentence and you rebuild the
reported defect, because a window caught up on at join carries a truthful ZERO
seed and the ring cap arms far-behind with no join and no `/me` in sight.

Deliberately left alone: the `issue1765` e2e header and the *"Pre-2069 this line
ALSO said"* aside in `unreadBadgeFarBehindStale.test.ts` narrate a PAST state in
the past tense and were accurate on their dates; the DESIGN_NOTES entries that
record the old behaviour are history.

## Not measured

- **The rendered sidebar pill on this route, in a real browser.** `issue1229`'s
  e2e reaches the ring-cap arm and asserts the in-pane BAR; `issue2037`'s
  asserts the sidebar pill but arms far-behind through the reload/probe route.
  The crossing of the two has no spec, and this slice did not open one — there
  is no defect to pin, and it would cost a stack lane.
- **Whether the ring-cap route fires in production at all.** Unchanged from the
  issue.

## Gates

- `scripts/bun.sh run check` — 5 stages, 0 failed
- `scripts/bun.sh run test` — 351 files passed
- `scripts/design-notes-gate.sh origin/main` — 1 new entry, separator + marker present
- `scripts/union-rebase.sh origin/main` — `docs/DESIGN_NOTES.md: +84 -0 — contribution intact`