### PR TITLE
cic(2055): scope the trailing-queue invariant to the door it guards

### DIFF
--- a/cicchetto/src/lib/networks.ts
+++ b/cicchetto/src/lib/networks.ts
@@ -218,6 +218,29 @@ const exports = identityScopedStore((onIdentityChange) => {
   // that flight ends. The invariant that matters is "a refetch requested
   // after the last state change is answered after it", and one trailing run
   // gives that without turning a burst of N events into N round-trips.
+  //
+  // THAT INVARIANT IS SCOPED TO THIS DOOR — it is NOT a property of
+  // `networks()` (issue 2055, measured 2026-09-11 against the real modules).
+  // The resource is keyed on `user`, so a `refetchUser()` resolving mid-flight
+  // moves the SOURCE and starts a second load the queue never sees; that load
+  // claims Solid's promise pointer and the in-flight answer is discarded, just
+  // as it was before this cure. Measured on the literal adjacent pair in
+  // `HomePane.tsx` (`refetchUser(); refetchNetworks();`): the store sequence
+  // observed for the slug collapses to ["connected", "connected"] and the
+  // park is gone.
+  //
+  // WHY THAT IS NOT AN OPEN DEFECT, and what would make it one. The SNAPSHOT
+  // survives — the source-driven request leaves AFTER the discarded one, so
+  // the winning answer is the fresher one; what is lost is a TRANSITION, and
+  // that only bites a consumer deriving one from this sample. Since 2059 the
+  // sole such consumer is selection.ts's bucket D on a WS gap, and that path
+  // never reaches this door: `resumeResync` and `subscribe.ts`'s socket-edge
+  // arm call `refetchNetworks` + `refetchChannels`, never `refetchUser`. The
+  // routes that DO reach it (HomePane's attach; the identity / profile /
+  // avatar / password doors in `lifecycle.ts`) all have the event feed
+  // carrying the transition instead. It takes BOTH conditions at once and no
+  // route holds them today — a new caller pairing `refetchUser()` with a
+  // refetch whose payload carries a state change would be the first.
   let refetchInFlight = false;
   let refetchPending = false;
   const runNetworksRefetch = async (): Promise<void> => {


### PR DESCRIPTION
Comment only. One file, 23 lines, all of them `//`, zero deletions, zero
behaviour change. Verified with a filter that was itself controlled: the
same filter reports 37 non-comment additions on `077814a8f` (a commit
known to add real code) and 0 here.

## Why this exists

The slice was a triage of issue 2055 — "cic drops the /reconnect
park->Home redirect when the bounce legs' network refetches overlap".

**It does not reproduce.** Both cures that issue proposes landed under
2059 on 2026-09-10T21:07:18Z: `cd18b7c6e` (bucket D observes the park
from the event) and `d55c2843f` (the trailing refetch queue). Nothing is
cured here and nothing needed to be.

That verdict was established, not deduced from the commit messages:

* **Two mutants on the committed bench, falling on DIFFERENT arms**, so
  the two cures are pinned independently and neither masks the other.
  Unplugging `noteConnectionState` turns the redirect arm red with
  `expected 'azzurra' to be '$home'` — the issue's own symptom, not a
  TypeError. Restoring the pre-2059 `refetchNetworks()` turns the
  back-to-back arm red with `expected 'parked' to be 'failing'`.
* **The issue's arm table reproduced literally** on a throwaway probe
  over the real modules: under the pre-2059 shape every figure comes
  back, including the ones the issue states as prose rather than numbers
  (arm C's "one GET only, second swallowed" = 2 calls against 3). On
  main, none of them. The probe was deleted; it duplicated the
  committed back-to-back arm's guard line and a duplicate is not
  coverage.

## What the comment says

While measuring, one sentence in `networks.ts` turned out to be false as
written. It claims the invariant "a refetch requested after the last
state change is answered after it". That is true of the
`refetchNetworks()` door — which the queue does guard — and false of
`networks()`. The resource is keyed on `user`, so a `refetchUser()`
resolving mid-flight moves the SOURCE and starts a second load the queue
never sees; that load claims Solid's promise pointer and the in-flight
answer is discarded exactly as it was before the cure. Measured at the
literal adjacent pair in `HomePane.tsx` (`refetchUser();
refetchNetworks();` on consecutive lines): the observed store sequence
collapses to `["connected", "connected"]` and the park is gone.

The limit is written NEXT TO the invariant, not in place of it. The door
the queue guards keeps its promise; only the generalisation goes.

## Why no issue was filed for that mechanism

The comment says this too, because a reader who finds a live mechanism
and no issue is owed the reason. The SNAPSHOT survives — the
source-driven request leaves after the discarded one, so the fresher
answer wins. What is lost is a TRANSITION, and that bites only a
consumer deriving one from this sample. Since 2059 the sole such
consumer is bucket D on a WS gap, and that path never reaches this door:
`resumeResync` and `subscribe.ts`'s socket-edge arm call
`refetchNetworks` + `refetchChannels` and never `refetchUser`. The
routes that do reach it (HomePane's attach; the identity / profile /
avatar / password doors in `lifecycle.ts`) carry the transition on the
event feed instead. It takes both conditions at once and no route holds
them today.

## Gates

* `bun.sh run check` — rc=0, 5/5 stages ok (lock drift, test location,
  biome src+e2e, tsc src, tsc e2e).
* `bun.sh run test` — rc=0, 351 files, 7047 tests, all passing.
* Rebased onto `b0bbe6564`; neither of the two commits that landed while
  this was measured touches `networks.ts`, `selection.ts`, `userTopic.ts`
  or the bench, so the measurement holds on this base.

## Not claimed

* That CI going green proves the cure. Six consecutive green integration
  runs on main since it landed, with the spec confirmed executing
  (`✓ 210 … reconnect-bounces-network.spec.ts:56:1 (1.5s)`, against 6.8s
  when it failed) — corroboration, weighed low against an intermittent
  that fired 18 times in a month. The evidence carrying the verdict is
  the mutants and the arm table.
* That sightings 17 and 18 shared the mechanism. Their dates were
  established (both precede the cure; 18 was confirmed by reading its
  shard log, not attributed by spec name), their traces were not read.
* That the source-door mechanism never bites. Today's routes were
  enumerated; every future consumer of `networks()` was not.

No DESIGN_NOTES entry, deliberately: the rationale belongs at the call
site a reader reaches for, and a second copy is one more thing to keep
in step.

Addresses issue 2055. Reconciliation of that issue against 2059 is the
orchestrator's, not touched here.