### PR TITLE
fix(2046): serve the channel directory from one read, and name the three empties

### DIFF
--- a/cicchetto/e2e/tests/channel-directory.spec.ts
+++ b/cicchetto/e2e/tests/channel-directory.spec.ts
@@ -8,7 +8,9 @@
 //   3. Selecting the $list window fires NO GET /messages request
 //      (grappa-irc#81: kindHasScrollback("list") === false).
 //   4. Typing in the search box filters results to matching channels
-//      (server-side query re-GET; server returns only matching entries).
+//      (server-side query re-GET; server returns only matching entries), and
+//      a term matching NOTHING renders the issue-2046 `no_results` line with
+//      the snapshot's capture time still on screen.
 //   5. Clicking a channel's join control adds it to the sidebar AND
 //      foregrounds its window (#244 — a user-initiated directory tap now
 //      JOINs and selects the new window, amending #125's no-auto-open).
@@ -152,9 +154,30 @@ test("channel-directory — browse, no /messages fetch (#81 guard), search filte
     await expect(peerRow).toBeVisible({ timeout: 5_000 });
     await expect(bofhRow).toBeHidden({ timeout: 5_000 });
 
+    // (4b) issue 2046 — a search that matches NOTHING is its own state on
+    // the wire (`no_results`), and the pane must say so. Before this the
+    // server answered `empty` — the same value it used for "this network was
+    // never LISTed" — and the pane rendered a blank box. Asserted here
+    // against the real bahamut snapshot rather than a fixture, because the
+    // half that matters is the second one: the capture time must SURVIVE the
+    // miss. A `never` here would mean the envelope forgot the snapshot the
+    // search just ran against, which is the same class of lie as the skew
+    // this issue is about.
+    await page.locator(".directory-search").fill("zzz-no-such-channel-2046");
+    const emptyLine = page.locator(".directory-empty");
+    await expect(emptyLine).toHaveText(/no channels match/i, { timeout: 5_000 });
+    await expect(peerRow).toBeHidden({ timeout: 5_000 });
+    await expect(page.locator(".directory-captured-at")).not.toHaveText(/never/i, {
+      timeout: 5_000,
+    });
+
     // Clear the filter so all rows are back before the join step.
     await page.locator(".directory-search").fill("");
     await expect(bofhRow).toBeVisible({ timeout: 5_000 });
+    // The empty line is not a fixture of the pane: with rows back it is gone.
+    // Without this the assertion above would also pass on a pane that printed
+    // it unconditionally.
+    await expect(emptyLine).toHaveCount(0);
 
     // (5) One-click join: assert PEER_CHANNEL is not yet in the sidebar,
     // click its join control, then assert the sidebar gains an entry

--- a/cicchetto/src/DirectoryPane.tsx
+++ b/cicchetto/src/DirectoryPane.tsx
@@ -523,7 +523,14 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
   // a page GET, and the store's latch only spans the gap before that GET
   // lands. Read by all three affordances below so they cannot disagree about
   // whether the pane is busy.
-  const busy = () => status() === "refreshing" || isRefreshPending(props.networkSlug);
+  //
+  // Issue 2046 — the server half is `loading`, which replaced `refreshing`
+  // and is NARROWER by construction: it means a capture is running AND there
+  // is nothing earlier to show. A re-capture over an existing snapshot no
+  // longer reports busy through `status` at all, because the server keeps
+  // serving the old list; that gap is exactly what the store's latch spans,
+  // so the OR below is what still makes the button honest during a refresh.
+  const busy = () => status() === "loading" || isRefreshPending(props.networkSlug);
 
   const onSearchInput = (e: Event) => {
     const val = (e.currentTarget as HTMLInputElement).value;
@@ -547,8 +554,33 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
   const capturedAt = () => {
     const p = page();
     if (!p) return null;
-    if (p.captured_at === null) return p.status === "refreshing" ? "refreshing…" : "never";
+    if (p.captured_at === null) return p.status === "loading" ? "loading…" : "never";
     return timeAgo(p.captured_at);
+  };
+
+  // Issue 2046 — the copy for an empty list, and WHICH empty it is. The three
+  // states the server now separates were one `empty` before, so the pane had
+  // nothing to say and said nothing: a search matching no channel rendered as
+  // a blank box under "0 channels / never", indistinguishable from a network
+  // that had never been LISTed.
+  //
+  // `fresh` / `stale` deliberately fall through to null: an empty page under
+  // a real snapshot is a cursor that has run past the end of a list the user
+  // can still see above it, and a "no channels" line under visible rows would
+  // be the new lie.
+  const emptyCopy = (): string | null => {
+    const p = page();
+    if (!p || p.entries.length > 0) return null;
+    switch (p.status) {
+      case "loading":
+        return "Fetching the channel list…";
+      case "unknown":
+        return "No channel list yet.";
+      case "no_results":
+        return "No channels match your search.";
+      default:
+        return null;
+    }
   };
 
   return (
@@ -670,6 +702,13 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
                     exhausted. */}
                 <Show when={p().next_cursor !== null}>
                   <div class="directory-sentinel" aria-hidden="true" ref={attachSentinel} />
+                </Show>
+                <Show when={emptyCopy()}>
+                  {(copy) => (
+                    <div class="directory-empty muted" role="status">
+                      {copy()}
+                    </div>
+                  )}
                 </Show>
                 <Show when={isLoadingMore(props.networkSlug)}>
                   <div class="directory-loading-more muted" role="status">

--- a/cicchetto/src/__tests__/DirectoryPane.test.tsx
+++ b/cicchetto/src/__tests__/DirectoryPane.test.tsx
@@ -152,9 +152,28 @@ const STALE_PAGE: DirectoryPage = {
   status: "stale",
 };
 
-const REFRESHING_PAGE: DirectoryPage = {
+// Issue 2046 — `loading` is what `refreshing` became, and it is narrower:
+// the server only sends it when a capture is running AND there is no earlier
+// snapshot to serve. So the fixture drops the entries and the stamp with the
+// status; a `loading` page carrying rows is a shape the server cannot emit.
+const LOADING_PAGE: DirectoryPage = {
   ...FRESH_PAGE,
-  status: "refreshing",
+  entries: [],
+  total: 0,
+  captured_at: null,
+  status: "loading",
+};
+
+const UNKNOWN_PAGE: DirectoryPage = {
+  ...LOADING_PAGE,
+  status: "unknown",
+};
+
+const NO_RESULTS_PAGE: DirectoryPage = {
+  ...FRESH_PAGE,
+  entries: [],
+  total: 0,
+  status: "no_results",
 };
 
 import DirectoryPane, { PULL_MAX_OFFSET_PX, pulledOffset, timeAgo } from "../DirectoryPane";
@@ -541,12 +560,24 @@ describe("DirectoryPane", () => {
       });
     });
 
-    it("is disabled and relabeled when status is 'refreshing'", () => {
-      directoryPageMock.mockReturnValue(REFRESHING_PAGE);
+    it("is disabled and relabeled when status is 'loading'", () => {
+      directoryPageMock.mockReturnValue(LOADING_PAGE);
       render(() => <DirectoryPane networkSlug={SLUG} />);
 
       const btn = screen.getByRole("button", { name: /refreshing/i });
       expect(btn).toBeDisabled();
+    });
+
+    // The other side of the narrowing, and the reason the latch still
+    // matters: a re-capture over an existing snapshot keeps serving `fresh`,
+    // so `status` alone would leave the button enabled through the whole
+    // thing. Asserted here so a later "simplification" that drops the latch
+    // in favour of the server field reds.
+    it("is NOT disabled by a status a re-capture over a live snapshot produces", () => {
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      expect(screen.getByRole("button", { name: /^refresh$/i })).toBeEnabled();
     });
 
     // #1445 — the gap the server field cannot cover. `status` only changes
@@ -680,6 +711,52 @@ describe("DirectoryPane", () => {
 
       const staleEl = container.querySelector(".directory-stale");
       expect(staleEl).toBeNull();
+    });
+  });
+
+  // Issue 2046 — the three states that used to be one `empty`, and the copy
+  // that tells them apart. Before this the pane rendered NOTHING for an empty
+  // list, so "your search matched no channel" and "this network has never
+  // been LISTed" looked identical: a blank box under "0 channels / never".
+  describe("empty-list copy per status (issue 2046)", () => {
+    it("says the search found nothing, and keeps the snapshot's stamp", () => {
+      directoryPageMock.mockReturnValue(NO_RESULTS_PAGE);
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      expect(container.querySelector(".directory-empty")?.textContent).toMatch(
+        /no channels match/i,
+      );
+      // The stamp survives a search miss — the list it searched was real.
+      expect(container.querySelector(".directory-captured-at")?.textContent).not.toMatch(/never/i);
+    });
+
+    it("says a capture is on the way when there is nothing earlier to show", () => {
+      directoryPageMock.mockReturnValue(LOADING_PAGE);
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      expect(container.querySelector(".directory-empty")?.textContent).toMatch(/fetching/i);
+      expect(container.querySelector(".directory-captured-at")?.textContent).toMatch(/loading/i);
+    });
+
+    it("says there is no list yet when nobody is capturing one", () => {
+      directoryPageMock.mockReturnValue(UNKNOWN_PAGE);
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      expect(container.querySelector(".directory-empty")?.textContent).toMatch(
+        /no channel list yet/i,
+      );
+      expect(container.querySelector(".directory-captured-at")?.textContent).toMatch(/never/i);
+    });
+
+    // The negative control, and it is the case the copy must NOT claim: a
+    // page with rows is not empty, whatever else it says. Without it every
+    // assertion above would also pass on a pane that printed the line
+    // unconditionally.
+    it("prints no empty-list line when the page has rows", () => {
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      expect(container.querySelector(".directory-empty")).toBeNull();
     });
   });
 

--- a/cicchetto/src/__tests__/channelDirectory.test.ts
+++ b/cicchetto/src/__tests__/channelDirectory.test.ts
@@ -84,7 +84,7 @@ describe("channelDirectory store", () => {
       next_cursor: null,
       total: 7,
       captured_at: null,
-      status: "refreshing",
+      status: "loading",
     });
     await loadDirectory("libera");
     spy.mockClear();
@@ -109,12 +109,12 @@ describe("channelDirectory store", () => {
   test("onDirectoryFailed re-GETs the current view", async () => {
     const spy = vi
       .spyOn(api, "listDirectory")
-      .mockResolvedValue(makePage({ total: 0, status: "empty" }));
+      .mockResolvedValue(makePage({ total: 0, status: "unknown" }));
     await loadDirectory("freenode");
     spy.mockClear();
     await onDirectoryFailed("freenode");
     expect(spy).toHaveBeenCalledOnce();
-    expect(directoryPage("freenode")?.status).toBe("empty");
+    expect(directoryPage("freenode")?.status).toBe("unknown");
   });
 
   test("setQuery threads q into the api call", async () => {
@@ -210,7 +210,7 @@ describe("channelDirectory store", () => {
 
   test("isRefreshPending spans exactly the gap — false, true after the POST, false once a page lands", async () => {
     vi.spyOn(api, "refreshDirectory").mockResolvedValue(undefined);
-    vi.spyOn(api, "listDirectory").mockResolvedValue(makePage({ status: "refreshing" }));
+    vi.spyOn(api, "listDirectory").mockResolvedValue(makePage({ status: "loading" }));
 
     // The pre-state, asserted rather than assumed: without it a latch that
     // was ALWAYS true would read the same at the second assertion.

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -616,7 +616,10 @@ export type ChannelEntry = NetworksWireChannelJson;
 
 // Mirror of `GrappaWeb.DirectoryController.index/2` wire shape.
 // `status` indicates the staleness of the captured list; `captured_at` is
-// null when no list has been captured yet (status "empty"). `next_cursor`
+// null exactly when no capture has COMPLETED — statuses "unknown" (nothing
+// captured, nothing on the way) and "loading" (a capture is streaming and
+// there is no earlier list to show). A search that matches nothing inside a
+// real snapshot is "no_results" and DOES carry the stamp. `next_cursor`
 // is null on the final page.
 // `featured` (#85) is true when the channel is in its network's
 // enabled `network_featured_channels` set — re-derived server-side on

--- a/cicchetto/src/lib/channelDirectory.ts
+++ b/cicchetto/src/lib/channelDirectory.ts
@@ -132,9 +132,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
 
   // #1445 — the latch stands down on the first page write for this slug after
   // the POST, whatever that page says: from that moment the store holds
-  // fresher information than the latch does. A `refreshing` status hands the
+  // fresher information than the latch does. A `loading` status hands the
   // signal over to `status` itself; a terminal one means the capture already
-  // finished. Deliberately NO timer backstop — the only case one would guard
+  // finished — or, since issue 2046, that a previous snapshot is being served
+  // while the new capture runs, which is a page like any other.
+  // Deliberately NO timer backstop — the only case one would guard
   // is a 202 followed by no ping at all, not even `directory_failed`, and a
   // stale timer releasing the NEXT latch early costs more than that case is
   // worth. The bound is stated instead: a pane close (resetDirectory) or an
@@ -202,8 +204,10 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   const isLoadingMore = (slug: string): boolean => loadingMore()[slug] ?? false;
 
   // #1445 — true across the POST→first-page-write gap. The pane ORs it with
-  // `status === "refreshing"` to get one honest "busy": neither half covers
-  // the whole re-capture on its own.
+  // `status === "loading"` to get one honest "busy": neither half covers the
+  // whole re-capture on its own, and since issue 2046 the server half only
+  // fires when there is no earlier snapshot to serve — so on a re-capture
+  // this latch is the ONLY thing that reports busy.
   const isRefreshPending = (slug: string): boolean => refreshPending()[slug] ?? false;
 
   // #677 — fetch the NEXT keyset page and APPEND. No-op when: no token, no

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -165,7 +165,16 @@ let _socket: Socket | null = null;
 // `{messages: count, events: 0}` when the pair is absent, which is exactly the
 // pre-#2037 number in the pre-#2037 place, so this bundle still serves an
 // older server.
-export const CLIENT_PROTOCOL_VERSION = 16;
+//
+// 17 (issue 2046) — the channel-directory `status` union is re-spelled:
+// `empty` and `refreshing` are gone, `no_results`, `unknown` and `loading`
+// take their place. Unlike every bump before it this one is NOT additive, so
+// the direction of the break is worth naming: this bundle cannot read a
+// pre-17 server's directory page either — `wireSchema` rejects `empty` just
+// as an old bundle rejects `loading`. `MIN_SERVER_PROTOCOL_VERSION` still
+// stays at 9, deliberately: raising it would refuse the whole socket over one
+// broken pane, and the two ship together anyway.
+export const CLIENT_PROTOCOL_VERSION = 17;
 
 // #193 — force the correct WS scheme from the page origin, absolutely.
 //

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -15,7 +15,13 @@ export const ADMISSION_FLOW = [
 ] as const;
 export type AdmissionFlow = (typeof ADMISSION_FLOW)[number];
 
-export const CHANNEL_DIRECTORY_STATUS = ["fresh", "stale", "empty", "refreshing"] as const;
+export const CHANNEL_DIRECTORY_STATUS = [
+  "fresh",
+  "stale",
+  "no_results",
+  "unknown",
+  "loading",
+] as const;
 export type ChannelDirectoryStatus = (typeof CHANNEL_DIRECTORY_STATUS)[number];
 
 export const IRCAUTH_FSMAUTH_METHOD = [

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -13236,6 +13236,15 @@ button.home-pane-network-title:hover .home-pane-network-slug {
   text-align: center;
 }
 
+/* issue 2046 — the empty-list line: which KIND of empty the server reported
+   (no search hits / no list yet / a capture on the way). Same metrics as the
+   load-more line above; it occupies the same place in the same box. */
+.directory-empty {
+  padding: 0.5rem 1rem;
+  font-size: 0.85em;
+  text-align: center;
+}
+
 .directory-row {
   margin: 0;
   padding: 0;

--- a/config/config.exs
+++ b/config/config.exs
@@ -304,12 +304,14 @@ config :grappa, :vhost_ptr_cache,
 # uses to label a snapshot :fresh vs :stale (48h, matching the sliding
 # scrollback horizon). refresh_timeout_ms bounds a single LIST refresh
 # before it's declared failed; progress_throttle_ms rate-limits the
-# directory_progress pings; ingest_batch is the streamed-322 flush size.
+# directory_progress pings. `ingest_batch` is GONE with the mid-stream
+# flush it sized (issue 2046): the capture is written once, at the 323, and
+# the only chunking left is the SQLite variable-limit one that lives with
+# the schema in `Grappa.ChannelDirectory`.
 config :grappa, Grappa.ChannelDirectory,
   ttl_ms: 48 * 60 * 60 * 1000,
   refresh_timeout_ms: 60_000,
-  progress_throttle_ms: 1_000,
-  ingest_batch: 200
+  progress_throttle_ms: 1_000
 
 # Themes (#75). `image_fetcher` is the fetch-by-URL implementation read ONCE at
 # boot into `:persistent_term` by `Grappa.Themes.boot/0` and resolved lock-free

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53480,3 +53480,142 @@ entries that record the old behaviour are history and are not rewritten.
 - **Whether the ring-cap route fires in production at all.** Unchanged from
   the issue: it needs a live burst past the retention cap on a window with a
   non-null cursor, and nobody has read that off a real instance.
+<!-- entry #2046 -->
+
+---
+
+## 2026-09-11 — #2046: the directory answers from one read, and says which kind of empty it is
+
+`ChannelDirectory.list/3` built one payload from three unsynchronised reads, so
+a capture landing between them produced `status: "empty", total: 0` beside five
+entries — measured off a production trace in the issue. vjt's ruling has three
+parts: defer the persistence to the end of the LIST, take the total and the
+page from the SAME read, and split the one `empty` into three named states.
+
+### The measurement the ruling asked for, and it went the other way from the hope
+
+The ruling flagged that part 1 might make part 2 **superfluous**: if nothing is
+written until the 323, a reader during a capture sees the previous snapshot
+whole, so where would the skew come from? Reported as a structural reading, not
+a measurement, with an explicit instruction to measure and report the direction
+found.
+
+**It does not.** The deferral moves the write, it does not make it atomic: the
+323 still performs a delete followed by inserts, and three reads still straddle
+it. `channel_directory_test.exs` carries the demonstration as a PAIR — a control
+that fires the same interleave BETWEEN two `list/3` calls and shows the two
+instants disagree (`total: 5` beside 3 rows, the shape the trace reported), and
+the subject test that fires it from inside a telemetry handler DURING the read
+and asserts `total == length(entries)`. The interleave is fired from Ecto's own
+`[:grappa, :repo, :query]` event, which is emitted synchronously in the calling
+process, so the write lands between one statement of the reader and the next
+with no production seam, no sleep and no second process. The subject test
+asserts the harness fired before it asserts the outcome: without that, a
+`total == length(entries)` that holds because nothing moved is a mirror.
+
+So part 2 was written. `total` is now a `count(*) over ()` on the page's own
+statement, and `captured_at` rides the page rows.
+
+### `:refreshing` was dead, and it is gone rather than commented
+
+`status_of(nil, _, _) -> :refreshing` meant "rows present, `captured_at` still
+NULL", which only existed because the ingest wrote mid-stream and stamped
+later. `replace/3` stamps at INSERT, so a row without a stamp cannot exist —
+the clause was unreachable, not deprecated. Deleted, with `replace_start/2`,
+`ingest/3`, `finalize/2`, the `{:ingest, rows}` action, `DirectoryIngest`'s
+batch field, `drain/1`, and the `ingest_batch` config key that sized a flush
+that no longer happens.
+
+### The deterministic defect: the incoherence is real, the consequence was not
+
+The issue records a second defect: a search matching nothing mid-refresh reads
+`:empty`, and `DirectoryController.index/2` arms a refresh on every `:empty`,
+so — the claim goes — a search miss KILLS the capture in flight. The first half
+is true and is cured here (a search miss is now `:no_results`, and only
+`:unknown` arms). **The second half is false, and was false before this
+slice.** `handle_call(:refresh_directory, …)` matches an in-flight run in an
+EARLIER clause than the one that sends LIST: a second request while a capture
+is streaming is a pure `{:error, :already_refreshing}` that touches neither the
+wire nor the tracker nor the buffer. `directory_test.exs` now asserts the
+buffer survives the rejected call, rather than the return value alone.
+
+What the auto-arm COULD do, before the deferral, was nuke an orphaned partition
+left by a watchdog abort — and after the deferral even that is gone, because
+the arm writes nothing until its own 323.
+
+### The two questions the ruling left open
+
+**1. The default for `total` / `captured_at` when the filtered set is empty.**
+A statement that returns no rows carries no window value, so the envelope is
+asked for separately in exactly that case: one row of the same subquery when a
+CURSOR ran past the end (exact total, real stamp), and `{0, max(captured_at)}`
+over the unfiltered partition when the search genuinely matched nothing. The
+second read is what keeps a search miss reporting WHEN the list it searched was
+captured. Its cost is stated rather than hidden: on that one path the two
+values come from two instants, and a capture landing between them can only ever
+flip an EMPTY page between `:no_results` and `:unknown` — there are no entries
+for the numbers to contradict.
+
+**2. Which scope owns the count in `status_of/3`.** The count stays
+SEARCH-scoped, as it always was, and the stamp stays SNAPSHOT-scoped. That
+combination is what makes the discriminant work: a non-nil stamp beside
+`total == 0` can only be a search that matched nothing.
+
+### The query is NOT an argument to `status_of/4`, and that is a deliberate refusal
+
+The ruling names the presence of the query as the discriminant between "no
+results" and "no list yet", and the brief for this slice read that as a
+signature change carrying `q` down to `status_of/3`. It is not needed. With the
+stamp snapshot-scoped and the count search-scoped, `%DateTime{} + total == 0`
+is REACHABLE ONLY with a query present — an absent `q` counts the whole
+partition, which is non-empty whenever a stamp exists. Passing `q` would
+re-state a fact the two arguments already carry, and it would be WEAKER: it
+would label a search typed before the first capture as `no_results` when the
+truth is `loading`. The signature that shipped is
+`status_of(captured_at, total, refreshing?, ttl_ms)`.
+
+### `:loading` needs a fact the table cannot hold
+
+With persistence deferred, a running capture leaves every row as it found it,
+so `:loading` and `:unknown` are the same rows. The in-flight fact lives in
+`Session.Server` and reaches the read as a required `:refreshing?` opt, via
+`Grappa.Session.directory_refreshing?/2` — the sibling of `casemapping/2`, same
+reason, same "no live session means the honest default" posture.
+
+**The ORDER of the controller's two reads is load-bearing and is the reason
+`replace/3` needs no transaction.** `directory_refreshing?/2` is a call into
+the session, so it queues behind the 323 handler that performs the write. A
+reader that asks FIRST therefore sees either the old snapshot whole (capture
+still streaming) or the new one (write committed) — never the delete-then-
+insert gap. Swapping the two lines hands the gap back, and the payload it
+produces is `:unknown`, the one status that arms a re-capture.
+
+### The wire bump is the first that is not additive
+
+`protocol_version` 16 → 17. `empty` and `refreshing` LEAVE the closed
+`status` union; `no_results`, `unknown` and `loading` enter it. This is not the
+#1626 field-removal carve-out — every key stays where it was — it is a closed
+set of VALUES changing, which the additive-only rule never spoke to. Measured
+consequence, both directions: cic's generated `wireSchema` rejects a `status`
+outside its enum, so a pre-17 bundle throws away every directory page a v17
+server sends, and this bundle cannot read a pre-17 server's either.
+`min_protocol_version` stays at 1 deliberately — raising it would 426 the whole
+socket over one broken pane, and the two ship together.
+
+### Not measured, not claimed
+
+* **No magnitude for the RAM the buffer costs.** The price was accepted by
+  ruling; a few thousand rows per session running a LIST is the shape, not a
+  measurement.
+* **No magnitude for the write burst.** `replace/3` is a delete plus
+  `ceil(n/500)` inserts on one connection; nothing here times it, and the chunk
+  size is a SQLite variable-limit constraint (32766 vars, 8 per row), not a
+  tuned number.
+* **Nothing about the original trace is re-explained.** The issue lists three
+  candidate readings for why `captured_at` stayed null for 15 s across 14
+  polls; this slice cures a defect visible in the payload and in the source,
+  and does not claim to have identified which reading produced that artefact.
+* **The `no_results`-vs-`loading` edge on a first visit.** A search typed
+  before any capture has completed reads `loading`, because the stamp decides
+  before the query does. That is the honest answer, and it is also the only
+  arrangement of these two branches with no wrong case.

--- a/lib/grappa/channel_directory.ex
+++ b/lib/grappa/channel_directory.ex
@@ -227,8 +227,10 @@ defmodule Grappa.ChannelDirectory do
         total: fragment("count(*) over ()")
       })
 
+    paged = from(r in subquery(inner))
+
     rows =
-      from(r in subquery(inner))
+      paged
       |> order_for(sort)
       |> apply_cursor(sort, cursor)
       |> limit(^(limit + 1))
@@ -247,14 +249,26 @@ defmodule Grappa.ChannelDirectory do
   end
 
   @spec envelope([map()], Ecto.Query.t(), Ecto.Query.t()) :: {non_neg_integer(), DateTime.t() | nil}
-  defp envelope([%{total: total, captured_at: captured_at} | _], _inner, _base),
+  defp envelope([%{total: total, captured_at: captured_at} | _], _, _),
     do: {total, captured_at}
 
   defp envelope([], inner, base) do
-    case Repo.one(from(r in subquery(inner), limit: 1)) do
+    one_row = from(r in subquery(inner), limit: 1)
+
+    case Repo.one(one_row) do
       %{total: total, captured_at: captured_at} -> {total, captured_at}
-      nil -> {0, Repo.one(from(e in base, select: max(e.captured_at)))}
+      nil -> {0, snapshot_stamp(base)}
     end
+  end
+
+  # The partition's stamp, read WITHOUT the search: the one value the page
+  # cannot supply when it comes back empty, and the one that separates "your
+  # search found nothing in a real list" from "there is no list".
+  @spec snapshot_stamp(Ecto.Query.t()) :: DateTime.t() | nil
+  defp snapshot_stamp(base) do
+    base
+    |> select([e], max(e.captured_at))
+    |> Repo.one()
   end
 
   defp maybe_search(query, nil), do: query
@@ -306,11 +320,11 @@ defmodule Grappa.ChannelDirectory do
   # beside `total == 0` can only be a search that matched nothing — a `q`
   # parameter would be re-stating a fact these two already carry.
   @spec status_of(DateTime.t() | nil, non_neg_integer(), boolean(), integer()) :: status()
-  defp status_of(nil, _total, true, _ttl_ms), do: :loading
-  defp status_of(nil, _total, false, _ttl_ms), do: :unknown
-  defp status_of(%DateTime{}, 0, _refreshing?, _ttl_ms), do: :no_results
+  defp status_of(nil, _, true, _), do: :loading
+  defp status_of(nil, _, false, _), do: :unknown
+  defp status_of(%DateTime{}, 0, _, _), do: :no_results
 
-  defp status_of(%DateTime{} = captured_at, _total, _refreshing?, ttl_ms) do
+  defp status_of(%DateTime{} = captured_at, _, _, ttl_ms) do
     age_ms = DateTime.diff(DateTime.utc_now(), captured_at, :millisecond)
     if age_ms <= ttl_ms, do: :fresh, else: :stale
   end

--- a/lib/grappa/channel_directory.ex
+++ b/lib/grappa/channel_directory.ex
@@ -2,13 +2,38 @@ defmodule Grappa.ChannelDirectory do
   @moduledoc """
   Per-`(subject, network)` discovery snapshot of an upstream `LIST`.
 
-  Lifecycle (driven by `Session.Server` during a refresh):
-  `replace_start/2` (nuke) -> `ingest/3` (batched insert of streamed
-  322 rows) -> `finalize/2` (stamp `captured_at` on 323). Reads via
-  `list/3` (server-side sort/search/keyset-page + `status` + `total`).
-  TTL is injected (`opts[:ttl_ms]`) — never read from app env at runtime.
-  `ttl_ms/0` is the canonical source callers (e.g. the REST controller)
-  pass as that `:ttl_ms` opt.
+  Lifecycle: ONE write, at the END of the refresh — `replace/3` nukes the
+  prior snapshot and inserts the whole capture already stamped (issue
+  2046). Reads via `list/3` (server-side sort/search/keyset-page +
+  `status` + `total`). TTL is injected (`opts[:ttl_ms]`) — never read from
+  app env at runtime. `ttl_ms/0` is the canonical source callers (e.g. the
+  REST controller) pass as that `:ttl_ms` opt.
+
+  ## Persistence is DEFERRED, and that is the load-bearing property
+
+  Until issue 2046 the ETL wrote WHILE the stream arrived: `replace_start/2`
+  nuked at the moment `LIST` hit the wire, `ingest/3` flushed every 200
+  rows, and `finalize/2` stamped `captured_at` on the 323. A reader landing
+  in that window saw a partition that was neither the old snapshot nor the
+  new one — half of a capture, carrying no stamp.
+
+  `Session.Server` now buffers the whole capture in memory and hands it over
+  once, so **the partition holds the PREVIOUS snapshot, whole, for the
+  entire duration of a refresh**. Three consequences, stated because a later
+  edit can take them away without any test noticing:
+
+    * a truncated refresh (the watchdog, a session crash) no longer destroys
+      what was there — it writes nothing at all;
+    * `captured_at` is stamped at INSERT, so a row without a stamp cannot
+      exist. Every row of a partition carries the SAME stamp, which is why
+      `list/3` reads the snapshot's `captured_at` off the page rows instead
+      of spending a second query on `max(captured_at)`;
+    * a stamp therefore means "a capture COMPLETED", never "a capture
+      touched this partition" — the discriminant every `status` branch
+      below rests on.
+
+  The price, accepted by ruling: RAM for the buffer — a few thousand rows
+  per session that is running a `LIST`.
   """
   use Boundary,
     top_level?: true,
@@ -39,7 +64,7 @@ defmodule Grappa.ChannelDirectory do
   def ttl_ms, do: @ttl_ms
 
   @type ingest_row :: %{name: String.t(), topic: String.t() | nil, user_count: integer()}
-  @type status :: :fresh | :stale | :empty | :refreshing
+  @type status :: :fresh | :stale | :no_results | :unknown | :loading
   @type sort :: :users | :name
   @type page :: %{
           entries: [%{name: String.t(), topic: String.t() | nil, user_count: integer()}],
@@ -51,72 +76,67 @@ defmodule Grappa.ChannelDirectory do
 
   @default_limit 100
 
-  @doc """
-  Nukes all entries for `(subject, network_id)` to begin a fresh `LIST` snapshot.
+  # A whole capture arrives as one list, and one `INSERT` cannot carry it:
+  # SQLite caps a statement at `SQLITE_MAX_VARIABLE_NUMBER` (32766 on the
+  # bundled engine) and `Entry` spends 8 of them per row, so ~4095 rows is
+  # the wall — under a Libera-sized LIST (tens of thousands of channels), not
+  # over it. This is a STORAGE constraint, not a tuning knob: it belongs here
+  # with the schema whose column count sets it, and NOT in config, where the
+  # old `ingest_batch` sat while it meant "how often to flush mid-stream".
+  @insert_chunk 500
 
-  Called by `Session.Server` at the start of a new upstream LIST run, before
-  any `ingest/3` calls. Safe to call on an empty table.
+  @doc """
+  Replaces the whole `(subject, network_id)` snapshot with `rows`, stamped
+  `captured_at = now` at insert.
+
+  Called ONCE by `Session.Server` on the 323 RPL_LISTEND, with everything
+  the capture buffered. `rows == []` is a legitimate capture — a network
+  that answered `LIST` with no channels — and leaves the partition empty,
+  which `list/3` reports as `:unknown`: an empty snapshot and a snapshot
+  that never happened are the same observation, and saying so is honest.
+
+  Not wrapped in a transaction, deliberately. The delete and the chunked
+  inserts run back to back on one connection, and the gap between them is
+  invisible through the REST door because `DirectoryController.index/2`
+  asks the session whether a capture is in flight BEFORE it reads — that
+  call queues behind this very write on the session's mailbox, so a reader
+  either sees the old snapshot (capture still streaming) or the new one
+  (write already committed). See the controller for the full ordering
+  argument.
   """
-  @spec replace_start(Subject.t(), integer()) :: :ok
-  def replace_start({_, _} = subject, network_id) when is_integer(network_id) do
+  @spec replace(Subject.t(), integer(), [ingest_row()]) :: :ok
+  def replace({_, _} = subject, network_id, rows) when is_integer(network_id) and is_list(rows) do
+    now = DateTime.truncate(DateTime.utc_now(), :second)
+
     {_, _} =
       Entry
       |> Subject.subject_where(subject)
       |> where([e], e.network_id == ^network_id)
       |> Repo.delete_all()
 
+    rows
+    |> Enum.chunk_every(@insert_chunk)
+    |> Enum.each(fn chunk ->
+      {_, _} = Repo.insert_all(Entry, Enum.map(chunk, &entry_attrs(&1, subject, network_id, now)))
+    end)
+
     :ok
   end
 
-  @doc """
-  Bulk-inserts a batch of 322 rows into the snapshot for `(subject, network_id)`.
-
-  Called repeatedly by `Session.Server` as the upstream LIST stream arrives.
-  Each row must carry `name`, `user_count`, and optionally `topic`.
-  `captured_at` is left `nil` until `finalize/2` stamps it.
-  """
-  @spec ingest(Subject.t(), integer(), [ingest_row()]) :: :ok
-  def ingest({_, _} = subject, network_id, rows) when is_integer(network_id) and is_list(rows) do
-    now = DateTime.truncate(DateTime.utc_now(), :second)
-
-    entries =
-      Enum.map(rows, fn r ->
-        Subject.put_subject_id(
-          %{
-            network_id: network_id,
-            name: r.name,
-            topic: Map.get(r, :topic),
-            user_count: r.user_count,
-            captured_at: nil,
-            inserted_at: now,
-            updated_at: now
-          },
-          subject
-        )
-      end)
-
-    {_, _} = Repo.insert_all(Entry, entries)
-    :ok
-  end
-
-  @doc """
-  Stamps `captured_at = now()` on every entry for `(subject, network_id)`.
-
-  Called by `Session.Server` on receipt of the upstream 323 (end-of-list).
-  A non-nil `captured_at` is the TTL anchor — `list/3` uses it to derive
-  `:fresh` vs `:stale` status.
-  """
-  @spec finalize(Subject.t(), integer()) :: :ok
-  def finalize({_, _} = subject, network_id) when is_integer(network_id) do
-    now = DateTime.truncate(DateTime.utc_now(), :second)
-
-    {_, _} =
-      Entry
-      |> Subject.subject_where(subject)
-      |> where([e], e.network_id == ^network_id)
-      |> Repo.update_all(set: [captured_at: now])
-
-    :ok
+  @spec entry_attrs(ingest_row(), Subject.t(), integer(), DateTime.t()) :: map()
+  defp entry_attrs(row, subject, network_id, now) do
+    Subject.put_subject_id(
+      %{
+        network_id: network_id,
+        name: row.name,
+        topic: Map.get(row, :topic),
+        user_count: row.user_count,
+        captured_at: now,
+        inserted_at: now,
+        updated_at: now
+      },
+      subject
+    )
   end
 
   @doc """
@@ -127,29 +147,65 @@ defmodule Grappa.ChannelDirectory do
     * `:ttl_ms` (required) — freshness window in milliseconds; used to derive
       `status` (`:fresh` if `captured_at` is within TTL, `:stale` otherwise).
       **The anchor is second-precision** (`Entry`'s `captured_at` is
-      `:utc_datetime`, so `finalize/2` truncates), so the derived age
+      `:utc_datetime`, so `replace/3` truncates), so the derived age
       OVERSTATES the true age by up to 999 ms and never understates it: a
       snapshot is born up to a second old. A window comparable to that
       granularity therefore answers by the clock rather than by the data —
-      `ttl_ms: 1_000` read immediately after `finalize/2` yields `:fresh` or
+      `ttl_ms: 1_000` read immediately after `replace/3` yields `:fresh` or
       `:stale` depending on where in the wall-clock second the stamp landed
       (#713). Production is clear of it by five orders of magnitude
       (`ttl_ms/0` is 48h). This is a documented floor and NOT a runtime
       rejection, deliberately — see #713 in `docs/DESIGN_NOTES.md` for why a
       sub-granularity guard would have rejected two legitimate callers and
       still not have caught the case that prompted the question.
+    * `:refreshing?` (required) — whether a capture is in flight for this
+      `(subject, network)` RIGHT NOW. Not derivable from the table: with
+      persistence deferred, a running capture writes nothing, so the rows say
+      exactly what they said before it started. It is the only thing that
+      separates `:loading` from `:unknown`, and the caller owns it because
+      the fact lives in `Session.Server`, not here.
     * `:sort` — `:users` (default, descending user count then ascending name) or
       `:name` (ascending name).
     * `:q` — case-insensitive substring filter applied to both `name` and `topic`.
     * `:limit` — page size (default #{@default_limit}).
     * `:cursor` — opaque keyset cursor returned in `next_cursor` of a prior page.
 
-  Returns a `t:page/0` map with `entries`, `next_cursor`, `total`, `captured_at`,
-  and `status` (`:empty | :refreshing | :fresh | :stale`).
+  Returns a `t:page/0` map with `entries`, `next_cursor`, `total`,
+  `captured_at`, and `status`.
+
+  ## One statement, so `total` cannot contradict `entries`
+
+  `total` is a `count(*) over ()` window ON THE PAGE'S OWN STATEMENT, and
+  `captured_at` rides the page rows. That is the whole cure for issue 2046:
+  the three values used to come from three round trips, and a capture
+  landing between them produced payloads like `total: 0` beside five
+  entries — self-contradictory, and read by cic's pane as "0 channels /
+  never" over a populated list.
+
+  The window sits INSIDE a subquery and the keyset cursor is applied
+  OUTSIDE it. That ordering is load-bearing: window functions are evaluated
+  after `WHERE`, so a cursor inside would count "the rows from here on"
+  and `total` would shrink page by page — exact on page 1 and wrong on
+  every other, the failure mode a per-page count was rejected for.
+
+  ## When the page comes back empty
+
+  A statement that returns no rows carries no window value either, so the
+  envelope is asked for separately in exactly that case, and only then:
+
+    * the filtered set is non-empty but the CURSOR is past its end (the
+      snapshot changed under a scroll) — one row of the same subquery still
+      answers with the exact `total` and the stamp;
+    * the filtered set really is empty — `total` is 0 by construction, and
+      the stamp is read from the partition so that a search matching
+      nothing still reports WHEN the list it searched was captured. Without
+      that read a search miss would render as "never" and, worse, as
+      `:unknown`, which is the state the controller arms a re-capture on.
   """
   @spec list(Subject.t(), integer(), keyword()) :: page()
   def list({_, _} = subject, network_id, opts) when is_integer(network_id) do
     ttl_ms = Keyword.fetch!(opts, :ttl_ms)
+    refreshing? = Keyword.fetch!(opts, :refreshing?)
     sort = Keyword.get(opts, :sort, :users)
     q = Keyword.get(opts, :q)
     limit = Keyword.get(opts, :limit, @default_limit)
@@ -160,26 +216,45 @@ defmodule Grappa.ChannelDirectory do
       |> Subject.subject_where(subject)
       |> where([e], e.network_id == ^network_id)
 
-    total = base |> maybe_search(q) |> Repo.aggregate(:count, :id)
-    captured_at = base |> select([e], max(e.captured_at)) |> Repo.one()
-
-    rows =
+    inner =
       base
       |> maybe_search(q)
+      |> select([e], %{
+        name: e.name,
+        topic: e.topic,
+        user_count: e.user_count,
+        captured_at: e.captured_at,
+        total: fragment("count(*) over ()")
+      })
+
+    rows =
+      from(r in subquery(inner))
       |> order_for(sort)
       |> apply_cursor(sort, cursor)
       |> limit(^(limit + 1))
       |> Repo.all()
 
     {page_rows, next_cursor} = paginate(rows, limit, sort)
+    {total, captured_at} = envelope(rows, inner, base)
 
     %{
       entries: Enum.map(page_rows, &%{name: &1.name, topic: &1.topic, user_count: &1.user_count}),
       next_cursor: next_cursor,
       total: total,
       captured_at: captured_at,
-      status: status_of(captured_at, total, ttl_ms)
+      status: status_of(captured_at, total, refreshing?, ttl_ms)
     }
+  end
+
+  @spec envelope([map()], Ecto.Query.t(), Ecto.Query.t()) :: {non_neg_integer(), DateTime.t() | nil}
+  defp envelope([%{total: total, captured_at: captured_at} | _], _inner, _base),
+    do: {total, captured_at}
+
+  defp envelope([], inner, base) do
+    case Repo.one(from(r in subquery(inner), limit: 1)) do
+      %{total: total, captured_at: captured_at} -> {total, captured_at}
+      nil -> {0, Repo.one(from(e in base, select: max(e.captured_at)))}
+    end
   end
 
   defp maybe_search(query, nil), do: query
@@ -221,13 +296,21 @@ defmodule Grappa.ChannelDirectory do
     end
   end
 
-  defp encode_cursor(%Entry{user_count: c, name: n}, :users), do: Base.url_encode64("#{c}\t#{n}")
-  defp encode_cursor(%Entry{name: n}, :name), do: Base.url_encode64(n)
+  defp encode_cursor(%{user_count: c, name: n}, :users), do: Base.url_encode64("#{c}\t#{n}")
+  defp encode_cursor(%{name: n}, :name), do: Base.url_encode64(n)
 
-  defp status_of(nil, 0, _), do: :empty
-  defp status_of(nil, _, _), do: :refreshing
+  # The stamp answers "is there a completed snapshot", the count answers
+  # "did this search find anything in it", and the in-flight flag separates
+  # the two ways of having nothing. Note what is NOT an argument here: the
+  # QUERY. `total` is search-scoped and the stamp is not, so a non-nil stamp
+  # beside `total == 0` can only be a search that matched nothing — a `q`
+  # parameter would be re-stating a fact these two already carry.
+  @spec status_of(DateTime.t() | nil, non_neg_integer(), boolean(), integer()) :: status()
+  defp status_of(nil, _total, true, _ttl_ms), do: :loading
+  defp status_of(nil, _total, false, _ttl_ms), do: :unknown
+  defp status_of(%DateTime{}, 0, _refreshing?, _ttl_ms), do: :no_results
 
-  defp status_of(%DateTime{} = captured_at, _, ttl_ms) do
+  defp status_of(%DateTime{} = captured_at, _total, _refreshing?, ttl_ms) do
     age_ms = DateTime.diff(DateTime.utc_now(), captured_at, :millisecond)
     if age_ms <= ttl_ms, do: :fresh, else: :stale
   end

--- a/lib/grappa/channel_directory/wire.ex
+++ b/lib/grappa/channel_directory/wire.ex
@@ -26,7 +26,8 @@ defmodule Grappa.ChannelDirectory.Wire do
 
   @doc """
   Render a `ChannelDirectory.page()` to the JSON wire envelope. The
-  `status` atom (`:fresh | :stale | :empty | :refreshing`) passes
+  `status` atom (`:fresh | :stale | :no_results | :unknown | :loading`)
+  passes
   through UNCHANGED — Jason stringifies it at the JSON edge (identical
   bytes to the former `Atom.to_string/1`), so the typed contract keeps
   the closed `ChannelDirectory.status()` union and
@@ -45,7 +46,7 @@ defmodule Grappa.ChannelDirectory.Wire do
   """
   @spec index_payload(ChannelDirectory.page(), MapSet.t(String.t())) :: index_payload()
   def index_payload(%{captured_at: ca, status: status} = page, featured_names)
-      when status in [:fresh, :stale, :empty, :refreshing] do
+      when status in [:fresh, :stale, :no_results, :unknown, :loading] do
     %{
       entries: Enum.map(page.entries, &mark_featured(&1, featured_names)),
       next_cursor: page.next_cursor,

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -359,7 +359,45 @@ defmodule Grappa.Protocol do
   # to the old behaviour instead of breaking. cic's
   # `CLIENT_PROTOCOL_VERSION` moves 15 → 16 in lockstep because it says what
   # cic SPEAKS, not what it requires.
-  @protocol_version 16
+  #
+  # v17 (issue 2046) — the channel-directory `status` union is re-spelled:
+  # `empty` and `refreshing` OUT, `no_results`, `unknown` and `loading` IN.
+  #
+  # 🔴 This is the FIRST bump that is not purely additive, and it is NOT the
+  # #1626 field-removal carve-out either — that one is about taking a field
+  # off a payload, and every key here stays exactly where it was. What moved
+  # is the set of VALUES a closed union may carry, which the additive rule
+  # never covered: it speaks of frame kinds, event types and fields.
+  # `status` is a closed set by construction (`gen_wire_types` renders it as
+  # a TS literal union and `wireSchema` as a runtime enum), so a value can
+  # only ever be added by widening it and removed by narrowing it.
+  #
+  # The two that left could not be kept, and this is the measured half:
+  # `refreshing` MEANT "rows present, `captured_at` still NULL", a state that
+  # only existed because the ingest wrote mid-stream. With persistence
+  # deferred there is no such row — the stamp is written WITH the row — so
+  # the clause was not deprecated, it was unreachable, and it went out under
+  # the standing "less code" order rather than being left to lie. `empty`
+  # conflated three answers (search matched nothing / never captured /
+  # capture in flight) and the ruling names all three separately; keeping it
+  # as a synonym for one of them would have shipped two spellings of the
+  # same state, which is the half-migration this codebase forbids.
+  #
+  # What an OLD bundle does, stated rather than assumed: cic's generated
+  # `wireSchema` rejects a `status` outside its enum, so a pre-v17 bundle
+  # throws away every directory page a v17 server sends. That is a real
+  # break for exactly one pane, it is why the number moves, and it is why
+  # `min_protocol_version` is the axis to watch if we ever have to serve
+  # both — see below.
+  #
+  # @min_protocol_version STAYS at 1, deliberately, and the reasoning is
+  # the uncomfortable one. A client below v17 IS degraded — its directory
+  # pane breaks — but raising the floor would 426 it out of the WS
+  # handshake entirely, taking away every OTHER surface to protect one. A
+  # broken pane beats a refused socket. The bundle and the server ship
+  # together on this deploy, so the window in which a v16 bundle meets a
+  # v17 server is a cache miss away from closing.
+  @protocol_version 17
   @min_protocol_version 1
 
   @doc "The protocol version the server currently speaks."
@@ -370,7 +408,7 @@ defmodule Grappa.Protocol do
   # alongside `@protocol_version`; the spec doubles as the bump tripwire,
   # and now that the bump is routine the tripwire is what keeps it from
   # being done half-way.
-  @spec version() :: 16
+  @spec version() :: 17
   def version, do: @protocol_version
 
   @doc """

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -428,10 +428,12 @@ defmodule Grappa.Session do
   Triggers an upstream `LIST` channel-directory refresh on the live
   session for `(subject, network_id)` (#84).
 
-  The Session.Server puts `LIST` on the wire, nukes the prior
-  `Grappa.ChannelDirectory` snapshot, and arms a watchdog timer; the
-  streamed 321/322/323 numerics repopulate the snapshot (captured by a
-  later task). Returns `:ok` once the refresh is in flight.
+  The Session.Server puts `LIST` on the wire and arms a watchdog timer;
+  the streamed 321/322/323 numerics buffer the capture in memory, and the
+  323 replaces the `Grappa.ChannelDirectory` snapshot in one write. Nothing
+  is nuked when the refresh starts (issue 2046) — the prior snapshot stays
+  servable for the whole capture, and a stalled one leaves it untouched.
+  Returns `:ok` once the refresh is in flight.
 
   Distinct from the `call_session/*` facades: a missing session pid maps
   to `{:error, :not_connected}` (not `:no_session`) — the directory
@@ -449,6 +451,29 @@ defmodule Grappa.Session do
       nil -> {:error, :not_connected}
       pid -> GenServer.call(pid, :refresh_directory)
     end
+  end
+
+  @doc """
+  Is a channel-directory `LIST` capture streaming for `(subject,
+  network_id)` right now? (issue 2046)
+
+  Sibling of `casemapping/2` and `statusmsg_sigils/2`, and there for the
+  same reason: a stateless read at the web edge needs a fact only the live
+  session holds. Since the #2046 deferral a running capture writes nothing,
+  so the table cannot distinguish "no snapshot, one is on the way" from "no
+  snapshot, nobody asked" — this is the distinction, and
+  `Grappa.ChannelDirectory.list/3` takes it as `:refreshing?`.
+
+  No live session means no capture: `false`, never an error. The same
+  answer covers a dead pid and a timed-out call, and it is the honest one —
+  a capture nobody is running is not in flight. The cost of being wrong is
+  bounded to a first-visit pane reading `unknown` instead of `loading`,
+  which arms a refresh; it is never a stale row.
+  """
+  @spec directory_refreshing?(subject(), integer()) :: boolean()
+  def directory_refreshing?(subject, network_id)
+      when is_subject(subject) and is_integer(network_id) do
+    call_session(subject, network_id, :directory_refreshing?) == true
   end
 
   @doc """

--- a/lib/grappa/session/directory_ingest.ex
+++ b/lib/grappa/session/directory_ingest.ex
@@ -17,17 +17,26 @@ defmodule Grappa.Session.DirectoryIngest do
   `run == nil` IS the "no refresh in flight" guard, exactly as
   `directory_refresh == nil` was.
 
+  ## The buffer is the whole capture (issue 2046)
+
+  It used to be a flush window: 200 rows in, 200 rows written, buffer
+  emptied, repeat. Persistence is now DEFERRED — nothing reaches the table
+  until 323 RPL_LISTEND — so the buffer accumulates the entire `LIST` and
+  `finish/1` is the only door out of it. The batch size went with the
+  mechanism: with no mid-stream write left to size, `absorb/3` appends and
+  throttles, and that is all it does. What the capture costs is now plainly
+  RAM, which is the price the ruling accepted.
+
   ## Why this one carries logic, unlike its `*Accum` siblings
 
   `WhoisAccum`, `LinksAccum` and friends are pure data drained by
-  `EventRouter`. This module also owns the batch boundary, the throttle
-  window and the row parse, because that is the whole point of the
-  extraction: before it, those decisions were reachable only by booting a
-  `Session.Server`, a fake ircd and the Repo (`directory_test.exs` is
-  `async: false` on `DataCase` for exactly that reason).
-  `directory_ingest_test.exs` drives them on plain `ExUnit.Case`,
-  `async: true`, with no process and no database — and it can only stay
-  that way while the decisions stay pure.
+  `EventRouter`. This module also owns the throttle window and the row
+  parse, because that is the whole point of the extraction: before it,
+  those decisions were reachable only by booting a `Session.Server`, a fake
+  ircd and the Repo (`directory_test.exs` is `async: false` on `DataCase`
+  for exactly that reason). `directory_ingest_test.exs` drives them on
+  plain `ExUnit.Case`, `async: true`, with no process and no database — and
+  it can only stay that way while the decisions stay pure.
 
   ## Struct, not a declared map type
 
@@ -45,11 +54,12 @@ defmodule Grappa.Session.DirectoryIngest do
 
     * the `directory_complete` total is re-read from the DB snapshot by
       `Session.Server`, NOT taken from `run.count` — the two can differ
-      the moment `ChannelDirectory.ingest/3` dedupes or upserts;
+      the moment `ChannelDirectory.replace/3` collapses duplicate names;
     * `abort/1` (the watchdog) DROPS the buffered rows and hands back
       nothing to write, so a truncated refresh never calls
-      `ChannelDirectory.finalize/2`. Flushing on timeout would change the
-      DB on every stalled refresh.
+      `ChannelDirectory.replace/3`. Under deferred persistence that is no
+      longer merely "the DB is left alone": it is what keeps the PREVIOUS
+      snapshot intact, since nothing was nuked when the run began.
   """
 
   alias Grappa.ChannelDirectory
@@ -57,7 +67,6 @@ defmodule Grappa.Session.DirectoryIngest do
   @cfg Application.compile_env(:grappa, Grappa.ChannelDirectory, [])
   @default_timeout_ms Keyword.get(@cfg, :refresh_timeout_ms, 60_000)
   @default_throttle_ms Keyword.get(@cfg, :progress_throttle_ms, 1_000)
-  @default_batch Keyword.get(@cfg, :ingest_batch, 200)
 
   defmodule Run do
     @moduledoc """
@@ -65,8 +74,9 @@ defmodule Grappa.Session.DirectoryIngest do
     `LIST` hits the wire until 323 RPL_LISTEND or the watchdog.
 
     `buffer` holds parsed rows newest-first for an O(1) prepend and is
-    reversed at flush so the ingest preserves wire order. `count` is the
-    running total across flushes, not the buffer depth. `last_emit_ms` is a
+    reversed at `finish/1` so the ingest preserves wire order. `count`
+    tracks the same rows the buffer holds and is kept separately only so a
+    progress ping costs no `length/1`. `last_emit_ms` is a
     `System.monotonic_time(:millisecond)` stamp seeded when the refresh is
     armed, and `timer` is the watchdog ref the caller must cancel on a
     clean finish.
@@ -85,15 +95,17 @@ defmodule Grappa.Session.DirectoryIngest do
   @typedoc """
   What `Session.Server` must perform, in the order handed back.
 
-  `{:ingest, rows}` is a bulk write of wire-ordered rows; `{:progress, n}`
-  is a throttled `directory_progress` ping carrying the running total.
+  One member since issue 2046 deferred the writes: `{:progress, n}`, a
+  throttled `directory_progress` ping carrying the running total. It stays
+  a list of a tagged tuple rather than collapsing to `n | nil`, because the
+  shape is what keeps the decision here and the IO at the call site — and
+  because a second action is exactly what a future ping would be.
   """
-  @type action :: {:ingest, [ChannelDirectory.ingest_row()]} | {:progress, non_neg_integer()}
+  @type action :: {:progress, non_neg_integer()}
 
   @type t :: %__MODULE__{
           timeout_ms: pos_integer(),
           throttle_ms: non_neg_integer(),
-          batch: pos_integer(),
           run: Run.t() | nil
         }
 
@@ -103,7 +115,6 @@ defmodule Grappa.Session.DirectoryIngest do
   # the #1390 slice-1 `Deps` bundle relies on.
   defstruct timeout_ms: @default_timeout_ms,
             throttle_ms: @default_throttle_ms,
-            batch: @default_batch,
             run: nil
 
   @doc """
@@ -122,8 +133,7 @@ defmodule Grappa.Session.DirectoryIngest do
 
     %__MODULE__{
       timeout_ms: Map.get(opts, :directory_refresh_timeout_ms, defaults.timeout_ms),
-      throttle_ms: Map.get(opts, :directory_progress_throttle_ms, defaults.throttle_ms),
-      batch: Map.get(opts, :directory_ingest_batch, defaults.batch)
+      throttle_ms: Map.get(opts, :directory_progress_throttle_ms, defaults.throttle_ms)
     }
   end
 
@@ -164,29 +174,23 @@ defmodule Grappa.Session.DirectoryIngest do
   @doc """
   Absorb one parsed row, returning the ingest and what to perform.
 
-  The batch flush is ordered BEFORE the progress ping, so a ping never
-  reports a count the DB has not been offered yet.
+  The row is buffered, never written: the whole capture goes to the table
+  in one `ChannelDirectory.replace/3` at `finish/1`. The count a ping
+  reports is therefore what has been RECEIVED, not what has been stored —
+  which is the honest reading of a `directory_progress` ping and the same
+  number it always carried.
   """
   @spec absorb(t(), ChannelDirectory.ingest_row(), integer()) :: {t(), [action()]}
   def absorb(%__MODULE__{run: %Run{} = run} = ingest, row, now_ms) do
     appended = %{run | buffer: [row | run.buffer], count: run.count + 1}
+    {emitted, actions} = throttle(appended, ingest.throttle_ms, now_ms)
 
-    {flushed, flush_actions} =
-      if length(appended.buffer) >= ingest.batch do
-        {rows, drained} = drain(appended)
-        {drained, [{:ingest, rows}]}
-      else
-        {appended, []}
-      end
-
-    {emitted, progress_actions} = throttle(flushed, ingest.throttle_ms, now_ms)
-
-    {%{ingest | run: emitted}, flush_actions ++ progress_actions}
+    {%{ingest | run: emitted}, actions}
   end
 
   @doc """
-  Finish a refresh: hand back the tail rows (wire order, empty when there
-  is nothing buffered) and the watchdog ref to cancel, and clear the run.
+  Finish a refresh: hand back the WHOLE capture in wire order (empty when
+  nothing was buffered) and the watchdog ref to cancel, and clear the run.
 
   Safe on an already-cleared ingest — `abort/1` leaves it in exactly that
   shape — where it yields no rows and no timer.
@@ -195,8 +199,8 @@ defmodule Grappa.Session.DirectoryIngest do
   def finish(%__MODULE__{run: nil} = ingest), do: {ingest, [], nil}
 
   def finish(%__MODULE__{run: %Run{} = run} = ingest) do
-    {rows, _} = drain(run)
-    {%{ingest | run: nil}, rows, run.timer}
+    # Buffer is newest-first; hand back wire order.
+    {%{ingest | run: nil}, Enum.reverse(run.buffer), run.timer}
   end
 
   @doc """
@@ -206,11 +210,6 @@ defmodule Grappa.Session.DirectoryIngest do
   """
   @spec abort(t()) :: t()
   def abort(%__MODULE__{} = ingest), do: %{ingest | run: nil}
-
-  # Buffer is newest-first; hand back wire order and leave the run empty.
-  @spec drain(Run.t()) :: {[ChannelDirectory.ingest_row()], Run.t()}
-  defp drain(%Run{buffer: []} = run), do: {[], run}
-  defp drain(%Run{buffer: buffer} = run), do: {Enum.reverse(buffer), %{run | buffer: []}}
 
   @spec throttle(Run.t(), non_neg_integer(), integer()) :: {Run.t(), [action()]}
   defp throttle(%Run{} = run, throttle_ms, now_ms) do

--- a/lib/grappa/session/directory_ingest.ex
+++ b/lib/grappa/session/directory_ingest.ex
@@ -121,11 +121,17 @@ defmodule Grappa.Session.DirectoryIngest do
   Build the idle ingest from `t:Grappa.Session.start_opts/0`, taking the
   struct's config defaults for anything the caller does not pin.
 
-  Same shape and same opt-key spelling as before the extraction, so a test
-  that pinned `:directory_ingest_batch` keeps working. Shaped after its
-  slice-1 sibling `Deps.from_opts/2`, but deliberately NOT strict like it:
-  these are numeric tuning knobs with real production defaults, not
-  injected capabilities whose absence is a silent no-op (#1398).
+  Same opt-key spelling as before the #1390 extraction for the two knobs
+  that remain. The third, `:directory_ingest_batch`, is GONE with the
+  mid-stream flush it sized (issue 2046) — and because this reader is
+  `Map.get`, a caller still passing it is silently IGNORED rather than
+  rejected. Stated because that is the cost of the non-strict shape below:
+  a stale plan does not crash, it just stops meaning anything.
+
+  Shaped after its slice-1 sibling `Deps.from_opts/2`, but deliberately NOT
+  strict like it: these are numeric tuning knobs with real production
+  defaults, not injected capabilities whose absence is a silent no-op
+  (#1398).
   """
   @spec from_opts(map()) :: t()
   def from_opts(opts) when is_map(opts) do

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -2078,9 +2078,11 @@ defmodule Grappa.Session.Server do
   #      timer; there's nothing to send `LIST` to.
   #   2. `run: nil` (client present) — the happy path. Put
   #      `LIST` on the wire FIRST (so a transport error short-circuits with
-  #      no DB churn), then nuke the prior snapshot, arm the watchdog, and
-  #      record the in-flight tracker. The streamed 321/322/323 capture is
-  #      Task C3; the watchdog handler is `:directory_refresh_timeout` below.
+  #      no DB churn), then arm the watchdog and record the in-flight
+  #      tracker. It touches NO row: issue 2046 deferred the whole write to
+  #      the 323, so the prior snapshot stays servable until the new one is
+  #      complete. The streamed 321/322/323 capture is Task C3; the watchdog
+  #      handler is `:directory_refresh_timeout` below.
   #   3. catch-all (`run` non-nil) — a refresh is already
   #      streaming. The run's presence IS the guard; reply
   #      `{:error, :already_refreshing}` and leave the in-flight run untouched.
@@ -2091,7 +2093,6 @@ defmodule Grappa.Session.Server do
   def handle_call(:refresh_directory, _, %{directory: %DirectoryIngest{run: nil} = ingest} = state) do
     case Client.send_line(state.client, "LIST\r\n") do
       :ok ->
-        ChannelDirectory.replace_start(state.subject, state.network_id)
         timer = Process.send_after(self(), :directory_refresh_timeout, ingest.timeout_ms)
         now = System.monotonic_time(:millisecond)
 
@@ -2104,6 +2105,20 @@ defmodule Grappa.Session.Server do
 
   def handle_call(:refresh_directory, _, state) do
     {:reply, {:error, :already_refreshing}, state}
+  end
+
+  # Issue 2046 — is a `LIST` capture streaming right now? The one fact
+  # `ChannelDirectory.list/3` cannot read off the table: with persistence
+  # deferred, a running capture leaves every row exactly as it found it, so
+  # "no snapshot AND a capture under way" (`:loading`) and "no snapshot and
+  # nobody looking" (`:unknown`) are the same rows and different answers.
+  #
+  # Answering it from the mailbox is what makes the 323 write invisible to a
+  # reader: this call queues BEHIND the handler that performs it, so a web
+  # request that asks first and reads second can never observe the partition
+  # mid-replace. `DirectoryController.index/2` owns that ordering.
+  def handle_call(:directory_refreshing?, _, state) do
+    {:reply, DirectoryIngest.in_flight?(state.directory), state}
   end
 
   # #581 — start the visitor "recover my identity" sequence (A3: ack
@@ -3501,7 +3516,10 @@ defmodule Grappa.Session.Server do
   #   * in-flight — the refresh genuinely stalled. Clear the tracker and
   #     broadcast a `directory_failed` ping so cic drops its loading
   #     affordance. The prior DB snapshot (if any) stays intact — only the
-  #     in-flight state is wiped. `network` is on the Logger allowlist and
+  #     in-flight state is wiped. That sentence was written here before it
+  #     was true: until issue 2046 the arm nuked the partition, so a stalled
+  #     refresh left the user with NO directory. Deferring the write is what
+  #     made the comment honest. `network` is on the Logger allowlist and
   #     already threaded by `Log.set_session_context/2`.
   def handle_info(:directory_refresh_timeout, %{directory: %DirectoryIngest{run: nil}} = state),
     do: {:noreply, state}
@@ -6982,11 +7000,11 @@ defmodule Grappa.Session.Server do
   #
   #   321 RPL_LISTSTART — header only, no data. No-op.
   #   322 RPL_LIST      — one channel row. Parse, accumulate into the
-  #                       in-flight buffer, flush on batch boundary, emit a
-  #                       throttled progress ping.
-  #   323 RPL_LISTEND   — flush the tail buffer, stamp `captured_at`, cancel
-  #                       the watchdog, emit `directory_complete`, clear the
-  #                       in-flight tracker.
+  #                       in-flight buffer, emit a throttled progress ping.
+  #                       Writes NOTHING (issue 2046).
+  #   323 RPL_LISTEND   — hand the WHOLE buffer to the table in one stamped
+  #                       replace, cancel the watchdog, emit
+  #                       `directory_complete`, clear the in-flight tracker.
   @spec handle_directory_numeric(321 | 322 | 323, Message.t(), t()) :: t()
   defp handle_directory_numeric(321, _, state), do: state
 
@@ -7004,47 +7022,40 @@ defmodule Grappa.Session.Server do
   end
 
   defp handle_directory_numeric(323, _, state) do
-    {ingest, tail, timer} = DirectoryIngest.finish(state.directory)
+    {ingest, rows, timer} = DirectoryIngest.finish(state.directory)
     finished = %{state | directory: ingest}
 
-    :ok = ingest_directory_rows(finished, tail)
-    :ok = ChannelDirectory.finalize(finished.subject, finished.network_id)
+    :ok = ChannelDirectory.replace(finished.subject, finished.network_id, rows)
     :ok = cancel_and_drain(timer, :directory_refresh_timeout)
 
-    # The total is re-read from the snapshot the ingest just wrote, NOT taken
-    # from the accumulator's running count: the two diverge the moment
-    # `ChannelDirectory.ingest/3` dedupes or upserts. Not a tidy-up target.
+    # The total is re-read from the snapshot just written, NOT taken from the
+    # accumulator's running count: the two diverge the moment
+    # `ChannelDirectory.replace/3` collapses duplicate names. Not a tidy-up
+    # target. `refreshing?: false` is a statement of fact, not a default —
+    # the run was cleared above, and this process is the only thing that
+    # could start another.
     broadcast_window_state(
       finished,
       SessionWire.directory_complete(
         finished.network_slug,
-        ChannelDirectory.list(finished.subject, finished.network_id, ttl_ms: 0).total
+        ChannelDirectory.list(finished.subject, finished.network_id,
+          ttl_ms: 0,
+          refreshing?: false
+        ).total
       )
     )
 
     finished
   end
 
-  # `DirectoryIngest` decides; the session performs. Order is the order the
-  # accumulator handed back — the batch write precedes the progress ping it
-  # reports, so a ping never names a count the DB has not been offered.
+  # `DirectoryIngest` decides; the session performs. One action survives the
+  # #2046 deferral — the throttled progress ping — and the split is kept for
+  # the reason it was built: the decision is testable without a process, the
+  # IO is not.
   @spec perform_directory_action(DirectoryIngest.action(), t()) :: t()
-  defp perform_directory_action({:ingest, rows}, state) do
-    :ok = ingest_directory_rows(state, rows)
-    state
-  end
-
   defp perform_directory_action({:progress, count}, state) do
     broadcast_window_state(state, SessionWire.directory_progress(state.network_slug, count))
     state
-  end
-
-  # Empty is a no-op — never round-trip an empty insert.
-  @spec ingest_directory_rows(t(), [ChannelDirectory.ingest_row()]) :: :ok
-  defp ingest_directory_rows(_, []), do: :ok
-
-  defp ingest_directory_rows(state, rows) do
-    :ok = ChannelDirectory.ingest(state.subject, state.network_id, rows)
   end
 
   # mIRC sort: highest advertised grade first, plain last. Within tier,

--- a/lib/grappa_web/controllers/directory_controller.ex
+++ b/lib/grappa_web/controllers/directory_controller.ex
@@ -8,7 +8,7 @@ defmodule GrappaWeb.DirectoryController do
   by `GrappaWeb.Plugs.ResolveNetwork` before either action runs:
 
     * `GET /networks/:network_id/directory` — server-side
-      sort/search/keyset-page over the last finalized `LIST` snapshot
+      sort/search/keyset-page over the last completed `LIST` snapshot
       (`Grappa.ChannelDirectory.list/3`), rendered through
       `ChannelDirectory.Wire.index_payload/2` (each row carries a
       `featured` flag derived from the network's current
@@ -31,10 +31,26 @@ defmodule GrappaWeb.DirectoryController do
 
   @doc """
   `GET /networks/:network_id/directory?sort=&q=&cursor=&limit=` —
-  renders a keyset-paged page of the last finalized `LIST` snapshot.
-  Auto-arms the first refresh when the snapshot is `:empty` and a live
+  renders a keyset-paged page of the last completed `LIST` snapshot.
+  Auto-arms the first refresh when the snapshot is `:unknown` and a live
   session exists (result discarded — no session / already running are
   both fine here).
+
+  ## The two reads are ORDERED, and the order is the guarantee
+
+  `directory_refreshing?/2` runs BEFORE `list/3`, always. It is a call into
+  the session, so it queues behind whatever that process is doing —
+  including the 323 handler's `ChannelDirectory.replace/3`. A reader that
+  asks first therefore sees one of two coherent worlds: the capture is
+  still streaming and the table still holds the PREVIOUS snapshot whole, or
+  the capture has landed and the table holds the new one. The delete-then-
+  insert gap inside `replace/3` is never observable from here, which is why
+  that write needs no transaction (issue 2046).
+
+  Swapping the two lines would give the gap back — `list/3` could read the
+  emptied partition, `directory_refreshing?/2` would then answer `false`
+  (the write having completed), and the payload would say `:unknown`: the
+  one status that arms a re-capture.
   """
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, params) do
@@ -43,6 +59,7 @@ defmodule GrappaWeb.DirectoryController do
 
     opts = [
       ttl_ms: ChannelDirectory.ttl_ms(),
+      refreshing?: Session.directory_refreshing?(subject, network.id),
       sort: parse_sort(params["sort"]),
       q: string_param(params, "q"),
       cursor: string_param(params, "cursor"),
@@ -51,7 +68,12 @@ defmodule GrappaWeb.DirectoryController do
 
     page = ChannelDirectory.list(subject, network.id, opts)
 
-    if page.status == :empty, do: maybe_auto_refresh(subject, network.id)
+    # `:unknown` is the ONLY arming state, and that is the cure for the
+    # incoherence #2046 recorded alongside the skew: the old trigger was
+    # `:empty`, which a search matching nothing produced just as readily as
+    # a network nobody had ever LISTed. `:no_results` now says which of the
+    # two it is, and `:loading` says a capture is already on the way.
+    if page.status == :unknown, do: maybe_auto_refresh(subject, network.id)
 
     # #85 — re-derive the featured flag from CURRENT config on every
     # fetch (on-display freshness; operator edits show up next poll).

--- a/priv/wire/shape.pin
+++ b/priv/wire/shape.pin
@@ -12,5 +12,5 @@
 # This line states the COVERAGE on purpose: widening or narrowing what
 # the digest spans is not a wire-shape change, the gate cannot tell one
 # from the other, and reading the pin is the only place a review sees it.
-protocol_version = 16
-shape_digest = sha256:cdc283e8284f409aaa12b058fd21d3d95c27eab034c3d94bcea2ca0dd11fde9a
+protocol_version = 17
+shape_digest = sha256:b651b30c24227355ad5c5c797e60bbc29f46d016bd3ddd15200c5ced37b2c81c

--- a/test/grappa/channel_directory/wire_test.exs
+++ b/test/grappa/channel_directory/wire_test.exs
@@ -27,19 +27,32 @@ defmodule Grappa.ChannelDirectory.WireTest do
   end
 
   test "nil captured_at stays nil; empty featured set marks nothing" do
-    page = %{entries: [], next_cursor: nil, total: 0, captured_at: nil, status: :empty}
-    assert %{captured_at: nil, status: :empty} = Wire.index_payload(page, MapSet.new())
+    page = %{entries: [], next_cursor: nil, total: 0, captured_at: nil, status: :unknown}
+    assert %{captured_at: nil, status: :unknown} = Wire.index_payload(page, MapSet.new())
   end
 
-  # S14: the `:fresh | :stale | :empty | :refreshing` status atom is carried
-  # in the term (the typed closed union codegen pins as a literal TS union);
-  # Jason stringifies it to identical wire bytes at the JSON edge.
-  test "status atom passes through in the term; Jason encodes it to the string on the wire" do
-    page = %{entries: [], next_cursor: nil, total: 0, captured_at: nil, status: :refreshing}
-    wire = Wire.index_payload(page, MapSet.new())
+  # S14: the `:fresh | :stale | :no_results | :unknown | :loading` status atom
+  # is carried in the term (the typed closed union codegen pins as a literal
+  # TS union); Jason stringifies it to identical wire bytes at the JSON edge.
+  # Every member is walked, not one sample: the union is what issue 2046
+  # re-spelled, and a member the guard forgot is a 500 on a live payload.
+  test "every status atom passes through in the term and encodes to its own string" do
+    for status <- [:fresh, :stale, :no_results, :unknown, :loading] do
+      page = %{entries: [], next_cursor: nil, total: 0, captured_at: nil, status: status}
+      wire = Wire.index_payload(page, MapSet.new())
 
-    assert wire.status == :refreshing
-    assert Jason.decode!(Jason.encode!(wire))["status"] == "refreshing"
+      assert wire.status == status
+      assert Jason.decode!(Jason.encode!(wire))["status"] == Atom.to_string(status)
+    end
+  end
+
+  # The negative half: the guard is a CLOSED set, so a status the union does
+  # not carry must not render at all. Without this the `when status in [...]`
+  # clause could be widened to a catch-all and nothing would notice.
+  test "a status outside the union does not render" do
+    page = %{entries: [], next_cursor: nil, total: 0, captured_at: nil, status: :refreshing}
+
+    assert_raise FunctionClauseError, fn -> Wire.index_payload(page, MapSet.new()) end
   end
 
   test "featured match folds ASCII case, not brackets (#525)" do

--- a/test/grappa/channel_directory_test.exs
+++ b/test/grappa/channel_directory_test.exs
@@ -107,16 +107,14 @@ defmodule Grappa.ChannelDirectoryTest do
     assert %{total: 501, captured_at: ca, status: :fresh} = read(s, nid, limit: 1)
     assert ca != nil
 
-    stamps =
-      Grappa.Repo.all(
-        from(e in Grappa.ChannelDirectory.Entry,
-          where: e.network_id == ^nid,
-          select: e.captured_at,
-          distinct: true
-        )
+    distinct_stamps =
+      from(e in Grappa.ChannelDirectory.Entry,
+        where: e.network_id == ^nid,
+        select: e.captured_at,
+        distinct: true
       )
 
-    assert stamps == [ca]
+    assert Grappa.Repo.all(distinct_stamps) == [ca]
   end
 
   test "no snapshot and no capture in flight -> :unknown", %{subject: s, network_id: nid} do
@@ -214,19 +212,38 @@ defmodule Grappa.ChannelDirectoryTest do
     assert %{total: 5, entries: [_, _]} = read(s, nid, limit: 2)
   end
 
-  # A cursor minted against a snapshot that has since shrunk pages past the
-  # end. The page is empty and `total` must still be the real count, or the
-  # pane would read `:no_results` at the bottom of a scroll it can see the
-  # rows of.
+  # A cursor minted against a snapshot that has since been replaced by one
+  # whose rows all sort ABOVE it. The page is empty and `total` must still be
+  # the real count, or the pane would read `:no_results` at the bottom of a
+  # scroll whose rows it can still see.
+  #
+  # The replacement is chosen, not shrunk: the `:users` cursor is
+  # `user_count < 2 or (== 2 and name > "#c2")`, so a snapshot merely SMALLER
+  # still matches its low-count rows and the page comes back non-empty — the
+  # first version of this test asserted `entries: []` and got `[#c1]`, which
+  # is the query being right. Only rows entirely above the cursor empty the
+  # page while leaving the filtered set non-empty, which is the branch under
+  # test.
   test "a cursor past the end keeps an exact total and a real status", %{
     subject: s,
     network_id: nid
   } do
     :ok = Dir.replace(s, nid, rows(5))
     %{next_cursor: cursor} = read(s, nid, limit: 4)
-    :ok = Dir.replace(s, nid, rows(2))
 
-    assert %{status: :fresh, total: 2, entries: []} = read(s, nid, cursor: cursor)
+    :ok =
+      Dir.replace(s, nid, [
+        %{name: "#c5", topic: "t5", user_count: 5},
+        %{name: "#c4", topic: "t4", user_count: 4},
+        %{name: "#c3", topic: "t3", user_count: 3}
+      ])
+
+    # `total: 3` is the discriminator: an envelope that answered 0 for every
+    # empty page would score `:no_results` here.
+    assert %{status: :fresh, total: 3, entries: [], captured_at: ca} =
+             read(s, nid, cursor: cursor)
+
+    refute ca == nil
   end
 
   describe "issue 2046 — one read, so total cannot contradict entries" do

--- a/test/grappa/channel_directory_test.exs
+++ b/test/grappa/channel_directory_test.exs
@@ -2,15 +2,17 @@ defmodule Grappa.ChannelDirectoryTest do
   @moduledoc """
   Context tests for `Grappa.ChannelDirectory` — per-`(subject, network)`
   discovery snapshot of an upstream `LIST`. Exercises the snapshot
-  lifecycle (`replace_start/2` nuke -> `ingest/3` batched insert ->
-  `finalize/2` stamp `captured_at`) and the read query `list/3`
-  (server-side sort/search/keyset-page + `status` + `total`).
+  lifecycle (`replace/3` — nuke + stamped insert, ONE write at the 323)
+  and the read query `list/3` (server-side sort/search/keyset-page +
+  `status` + `total`).
 
-  TTL is INJECTED via `opts[:ttl_ms]` — the tests pin it per-call so
-  no test reads app env. `status` is derived from `(captured_at, total,
-  ttl_ms)`: `:empty` (no snapshot), `:refreshing` (rows present but
-  `captured_at` still NULL), `:fresh` (finalised within TTL), `:stale`
-  (finalised but older than TTL).
+  TTL is INJECTED via `opts[:ttl_ms]` and the in-flight fact via
+  `opts[:refreshing?]` — the tests pin both per-call, so no test reads app
+  env and none of them needs a live session. `status` is derived from
+  `(captured_at, total, refreshing?, ttl_ms)`: `:loading` / `:unknown` (no
+  completed snapshot, with and without a capture under way),
+  `:no_results` (a snapshot exists and the search matched nothing),
+  `:fresh` / `:stale` (a snapshot, inside or outside the TTL).
 
   An injected TTL must stay clear of the storage granularity: `captured_at`
   is second-precision, so a sub-second window makes the branch depend on the
@@ -25,6 +27,8 @@ defmodule Grappa.ChannelDirectoryTest do
 
   alias Grappa.ChannelDirectory, as: Dir
 
+  @query_event [:grappa, :repo, :query]
+
   setup do
     user = Grappa.AuthFixtures.user_fixture()
     network = Grappa.AuthFixtures.network_fixture()
@@ -32,7 +36,7 @@ defmodule Grappa.ChannelDirectoryTest do
   end
 
   # `captured_at` is a `:utc_datetime` — SECOND precision (see
-  # `ChannelDirectory.Entry`) — so `finalize/2` MUST truncate, and a snapshot
+  # `ChannelDirectory.Entry`) — so `replace/3` MUST truncate, and a snapshot
   # stamped at `…:18.940` is stored as `…:18.000`, i.e. born up to 999 ms old.
   # A TTL at or below one second therefore makes `:fresh` depend on where in
   # the wall-clock second the stamp happened to land: that is the intermittent
@@ -51,17 +55,23 @@ defmodule Grappa.ChannelDirectoryTest do
 
   defp rows(n), do: for(i <- 1..n, do: %{name: "#c#{i}", topic: "t#{i}", user_count: i})
 
+  # Every read in this file is a settled one unless it says otherwise, so the
+  # two required opts are supplied here rather than repeated 20 times. A test
+  # that cares about either passes it explicitly.
+  defp read(s, nid), do: read(s, nid, [])
+
+  defp read(s, nid, opts) do
+    Dir.list(s, nid, Keyword.merge([ttl_ms: @ample_ttl_ms, refreshing?: false], opts))
+  end
+
   test "ttl_ms/0 returns the configured 48h" do
     assert Grappa.ChannelDirectory.ttl_ms() == 48 * 60 * 60 * 1000
   end
 
-  test "replace_start nukes, ingest inserts, finalize stamps captured_at", %{subject: s, network_id: nid} do
-    :ok = Dir.replace_start(s, nid)
-    :ok = Dir.ingest(s, nid, rows(3))
-    assert %{status: :refreshing, total: 3} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms)
+  test "replace inserts the capture already stamped", %{subject: s, network_id: nid} do
+    :ok = Dir.replace(s, nid, rows(3))
 
-    :ok = Dir.finalize(s, nid)
-    assert %{status: :fresh, total: 3, entries: entries, captured_at: ca} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms)
+    assert %{status: :fresh, total: 3, entries: entries, captured_at: ca} = read(s, nid)
     assert ca != nil
     assert Enum.map(entries, & &1.name) == ["#c3", "#c2", "#c1"]
   end
@@ -73,58 +83,194 @@ defmodule Grappa.ChannelDirectoryTest do
   # notice: every other case reads freshness through a window wide enough to
   # survive either precision.
   test "captured_at is stored at second precision", %{subject: s, network_id: nid} do
-    :ok = Dir.replace_start(s, nid)
-    :ok = Dir.ingest(s, nid, rows(1))
-    :ok = Dir.finalize(s, nid)
+    :ok = Dir.replace(s, nid, rows(1))
 
-    assert %{captured_at: %DateTime{microsecond: {0, 0}}} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms)
+    assert %{captured_at: %DateTime{microsecond: {0, 0}}} = read(s, nid)
   end
 
-  test "replace_start clears a prior snapshot", %{subject: s, network_id: nid} do
-    :ok = Dir.replace_start(s, nid)
-    :ok = Dir.ingest(s, nid, rows(2))
-    :ok = Dir.finalize(s, nid)
-    :ok = Dir.replace_start(s, nid)
-    :ok = Dir.ingest(s, nid, rows(1))
-    :ok = Dir.finalize(s, nid)
-    assert %{total: 1} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms)
+  test "replace clears a prior snapshot", %{subject: s, network_id: nid} do
+    :ok = Dir.replace(s, nid, rows(2))
+    :ok = Dir.replace(s, nid, rows(1))
+    assert %{total: 1} = read(s, nid)
   end
 
-  test "empty snapshot -> status :empty", %{subject: s, network_id: nid} do
-    assert %{status: :empty, total: 0, entries: []} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms)
+  # The chunk boundary is a SQLite variable-limit constraint, not a tuning
+  # knob, so the only thing worth pinning is that crossing it is invisible:
+  # one capture, one stamp, every row present. 501 crosses the 500 boundary
+  # by one — the cheapest input that exercises the second chunk at all.
+  test "a capture larger than one insert chunk lands whole and homogeneous", %{
+    subject: s,
+    network_id: nid
+  } do
+    :ok = Dir.replace(s, nid, rows(501))
+
+    assert %{total: 501, captured_at: ca, status: :fresh} = read(s, nid, limit: 1)
+    assert ca != nil
+
+    stamps =
+      Grappa.Repo.all(
+        from(e in Grappa.ChannelDirectory.Entry,
+          where: e.network_id == ^nid,
+          select: e.captured_at,
+          distinct: true
+        )
+      )
+
+    assert stamps == [ca]
+  end
+
+  test "no snapshot and no capture in flight -> :unknown", %{subject: s, network_id: nid} do
+    assert %{status: :unknown, total: 0, entries: [], captured_at: nil} = read(s, nid)
+  end
+
+  test "no snapshot and a capture in flight -> :loading", %{subject: s, network_id: nid} do
+    assert %{status: :loading, total: 0, entries: []} = read(s, nid, refreshing?: true)
+  end
+
+  # A network that answers LIST with no channels leaves nothing behind, so it
+  # is indistinguishable from one nobody ever LISTed — and `:unknown` says
+  # exactly that ("never fetched, or the server answered badly") instead of
+  # inventing a distinction the rows cannot support.
+  test "a capture of zero channels reads as :unknown, not as a snapshot", %{
+    subject: s,
+    network_id: nid
+  } do
+    :ok = Dir.replace(s, nid, [])
+    assert %{status: :unknown, total: 0, captured_at: nil} = read(s, nid)
+  end
+
+  # A snapshot that is being re-captured keeps serving: the rows are the
+  # PREVIOUS capture's, whole, and the status is the one they deserve — not
+  # `:loading`, which would hide a perfectly good list behind a spinner.
+  test "an existing snapshot outranks an in-flight capture", %{subject: s, network_id: nid} do
+    :ok = Dir.replace(s, nid, rows(2))
+    assert %{status: :fresh, total: 2, entries: [_, _]} = read(s, nid, refreshing?: true)
   end
 
   test "stale snapshot (older than ttl) -> status :stale", %{subject: s, network_id: nid} do
-    :ok = Dir.replace_start(s, nid)
-    :ok = Dir.ingest(s, nid, rows(1))
-    :ok = Dir.finalize(s, nid)
-    assert %{status: :stale} = Dir.list(s, nid, ttl_ms: @expired_ttl_ms)
+    :ok = Dir.replace(s, nid, rows(1))
+    assert %{status: :stale} = read(s, nid, ttl_ms: @expired_ttl_ms)
   end
 
   test "?q= filters by name substring (case-insensitive)", %{subject: s, network_id: nid} do
-    :ok = Dir.replace_start(s, nid)
-    :ok = Dir.ingest(s, nid, [%{name: "#elixir", topic: "", user_count: 5}, %{name: "#ruby", topic: "", user_count: 9}])
-    :ok = Dir.finalize(s, nid)
-    assert %{entries: [%{name: "#elixir"}], total: 1} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms, q: "ELIX")
+    :ok =
+      Dir.replace(s, nid, [
+        %{name: "#elixir", topic: "", user_count: 5},
+        %{name: "#ruby", topic: "", user_count: 9}
+      ])
+
+    assert %{entries: [%{name: "#elixir"}], total: 1} = read(s, nid, q: "ELIX")
+  end
+
+  # The state the old `:empty` conflated with "never fetched" — and the one
+  # that armed a fresh LIST on every keystroke that matched nothing.
+  # `captured_at` must survive it: the list the search ran against still has
+  # a capture time, and rendering "never" over a real snapshot is the same
+  # class of lie this issue is about.
+  test "a search matching nothing -> :no_results, and the stamp survives it", %{
+    subject: s,
+    network_id: nid
+  } do
+    :ok = Dir.replace(s, nid, rows(3))
+    %{captured_at: stamp} = read(s, nid)
+
+    assert %{status: :no_results, total: 0, entries: [], captured_at: ^stamp} =
+             read(s, nid, q: "nothing-matches-this")
+
+    refute stamp == nil
+  end
+
+  # Same rows, same empty page, opposite answer — the pair is what shows the
+  # discriminant is the SNAPSHOT and not the emptiness of the page.
+  test "a search matching nothing with no snapshot at all -> :loading", %{
+    subject: s,
+    network_id: nid
+  } do
+    assert %{status: :loading, total: 0} = read(s, nid, q: "nope", refreshing?: true)
   end
 
   test "sort: :name orders alphabetically", %{subject: s, network_id: nid} do
-    :ok = Dir.replace_start(s, nid)
-    :ok = Dir.ingest(s, nid, [%{name: "#b", topic: "", user_count: 9}, %{name: "#a", topic: "", user_count: 1}])
-    :ok = Dir.finalize(s, nid)
-    assert %{entries: [%{name: "#a"}, %{name: "#b"}]} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms, sort: :name)
+    :ok =
+      Dir.replace(s, nid, [
+        %{name: "#b", topic: "", user_count: 9},
+        %{name: "#a", topic: "", user_count: 1}
+      ])
+
+    assert %{entries: [%{name: "#a"}, %{name: "#b"}]} = read(s, nid, sort: :name)
   end
 
   test "keyset pagination is stable + non-overlapping", %{subject: s, network_id: nid} do
-    :ok = Dir.replace_start(s, nid)
-    :ok = Dir.ingest(s, nid, rows(5))
-    :ok = Dir.finalize(s, nid)
-    %{entries: p1, next_cursor: c1} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms, limit: 2)
-    %{entries: p2} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms, limit: 2, cursor: c1)
+    :ok = Dir.replace(s, nid, rows(5))
+    %{entries: p1, next_cursor: c1} = read(s, nid, limit: 2)
+    %{entries: p2} = read(s, nid, limit: 2, cursor: c1)
     names = Enum.map(p1 ++ p2, & &1.name)
     assert names == Enum.uniq(names)
     assert Enum.map(p1, & &1.name) == ["#c5", "#c4"]
     assert Enum.map(p2, & &1.name) == ["#c3", "#c2"]
+  end
+
+  test "total counts the filtered set, not the page", %{subject: s, network_id: nid} do
+    :ok = Dir.replace(s, nid, rows(5))
+    assert %{total: 5, entries: [_, _]} = read(s, nid, limit: 2)
+  end
+
+  # A cursor minted against a snapshot that has since shrunk pages past the
+  # end. The page is empty and `total` must still be the real count, or the
+  # pane would read `:no_results` at the bottom of a scroll it can see the
+  # rows of.
+  test "a cursor past the end keeps an exact total and a real status", %{
+    subject: s,
+    network_id: nid
+  } do
+    :ok = Dir.replace(s, nid, rows(5))
+    %{next_cursor: cursor} = read(s, nid, limit: 4)
+    :ok = Dir.replace(s, nid, rows(2))
+
+    assert %{status: :fresh, total: 2, entries: []} = read(s, nid, cursor: cursor)
+  end
+
+  describe "issue 2046 — one read, so total cannot contradict entries" do
+    # THE CONTROL, and it runs on the same data and the same interleave as
+    # the test below. It shows the two instants really do disagree: a payload
+    # assembled from a total read before the capture and entries read after
+    # it carries `total: 5` beside 3 rows — the shape the issue reported off
+    # a production trace. Without this, the assertion below is a mirror: a
+    # `total == length(entries)` that holds because nothing moved proves
+    # nothing about a read that spans a write.
+    test "control: the interleave DOES move the numbers between two reads", %{
+      subject: s,
+      network_id: nid
+    } do
+      :ok = Dir.replace(s, nid, rows(5))
+
+      before = read(s, nid)
+      :ok = Dir.replace(s, nid, rows(3))
+      later = read(s, nid)
+
+      assert before.total == 5
+      assert length(later.entries) == 3
+      refute before.total == length(later.entries)
+    end
+
+    test "a capture landing mid-read cannot skew total against entries", %{
+      subject: s,
+      network_id: nid
+    } do
+      :ok = Dir.replace(s, nid, rows(5))
+
+      fired = interleave_once(fn -> Dir.replace(s, nid, rows(3)) end)
+      page = read(s, nid)
+
+      # The harness must have fired INSIDE the read, or the case never
+      # happened and the assertion below is vacuous.
+      assert Agent.get(fired, & &1) == 1, "the interleaved capture never ran during list/3"
+
+      assert page.total == length(page.entries),
+             "total #{page.total} contradicts #{length(page.entries)} entries"
+
+      # And it must be one of the two coherent worlds, not an average of them.
+      assert page.total in [3, 5]
+    end
   end
 
   property "keyset paging visits every row exactly once (users sort)" do
@@ -132,16 +278,13 @@ defmodule Grappa.ChannelDirectoryTest do
       user = Grappa.AuthFixtures.user_fixture()
       network = Grappa.AuthFixtures.network_fixture()
       s = {:user, user.id}
-      :ok = Grappa.ChannelDirectory.replace_start(s, network.id)
 
       :ok =
-        Grappa.ChannelDirectory.ingest(
+        Grappa.ChannelDirectory.replace(
           s,
           network.id,
           for(i <- 1..n, do: %{name: "#c#{i}", topic: "", user_count: rem(i, 7)})
         )
-
-      :ok = Grappa.ChannelDirectory.finalize(s, network.id)
 
       seen = collect_all(s, network.id, nil, [])
       assert length(seen) == n
@@ -150,10 +293,47 @@ defmodule Grappa.ChannelDirectoryTest do
   end
 
   defp collect_all(s, nid, cursor, acc) do
-    %{entries: es, next_cursor: c} =
-      Grappa.ChannelDirectory.list(s, nid, ttl_ms: @ample_ttl_ms, limit: 3, cursor: cursor)
+    %{entries: es, next_cursor: c} = read(s, nid, limit: 3, cursor: cursor)
 
     acc = acc ++ Enum.map(es, & &1.name)
     if c, do: collect_all(s, nid, c, acc), else: acc
+  end
+
+  # Runs `fun` exactly once, from inside the first `channel_directory` query
+  # that follows. Ecto emits `[:grappa, :repo, :query]` SYNCHRONOUSLY in the
+  # calling process, after the query has returned its rows — so the handler
+  # runs on the test's own sandbox connection, between one statement of the
+  # caller and the next. That is the whole seam: no production hook, no
+  # sleep, no second process.
+  #
+  # Detaches BEFORE calling `fun`, or the write would re-enter its own
+  # handler. Returns an Agent holding the number of times it fired, so the
+  # caller can prove the interleave happened rather than assume it.
+  defp interleave_once(fun) do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+    handler_id = {__MODULE__, make_ref()}
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        @query_event,
+        fn _, _, metadata, _ ->
+          # Matched on the SQL text, not on `:source`: the page read selects
+          # from a SUBQUERY, and a subquery has no single source for Ecto to
+          # put in the metadata. The text is the one field that names the
+          # table in both shapes.
+          if metadata |> Map.get(:query, "") |> String.contains?("channel_directory") do
+            :telemetry.detach(handler_id)
+            Agent.update(counter, &(&1 + 1))
+            fun.()
+          end
+
+          :ok
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    counter
   end
 end

--- a/test/grappa/session/directory_ingest_test.exs
+++ b/test/grappa/session/directory_ingest_test.exs
@@ -6,7 +6,7 @@ defmodule Grappa.Session.DirectoryIngestTest do
   on plain `ExUnit.Case`: no `DataCase`, no Repo, no `Session.Server`, no
   fake ircd. Its sibling `directory_test.exs` needs all four (228 lines,
   `async: false`, 23 lines naming `start_server`/`IRCServer`) because
-  before this extraction the parse / batch / throttle decisions were only
+  before this extraction the parse / buffer / throttle decisions were only
   reachable by booting a GenServer.
 
   If a later change re-entangles those decisions with the session process,
@@ -24,13 +24,12 @@ defmodule Grappa.Session.DirectoryIngestTest do
   alias Grappa.Session.DirectoryIngest
 
   # Tunables pinned per-test rather than taken from config: the point is the
-  # decision boundary, and a config-derived batch size would make the
+  # decision boundary, and a config-derived throttle window would make the
   # assertions read as coincidence.
   defp ingest(opts) do
     DirectoryIngest.from_opts(%{
       directory_refresh_timeout_ms: Keyword.get(opts, :timeout_ms, 60_000),
-      directory_progress_throttle_ms: Keyword.get(opts, :throttle_ms, 1_000),
-      directory_ingest_batch: Keyword.get(opts, :batch, 200)
+      directory_progress_throttle_ms: Keyword.get(opts, :throttle_ms, 1_000)
     })
   end
 
@@ -68,30 +67,38 @@ defmodule Grappa.Session.DirectoryIngestTest do
     end
   end
 
-  describe "absorb/3 — the batch boundary" do
-    test "rows below the batch size buffer without an ingest action" do
-      r0 = armed([batch: 3], 0)
+  describe "absorb/3 — nothing is written mid-stream (issue 2046)" do
+    # The pin that replaces the batch-boundary block, and it is the same
+    # claim from the other side: absorbing rows produces NO write instruction
+    # at any depth. The old shape emitted `{:ingest, rows}` every 200 rows;
+    # if one ever comes back, the deferral has been undone and the previous
+    # snapshot is being nuked mid-capture again.
+    test "no depth of buffering produces a write action" do
+      r0 = armed([throttle_ms: 1_000], 0)
 
-      {r1, first} = DirectoryIngest.absorb(r0, row("#a"), 0)
-      assert first == []
+      {_, actions} =
+        Enum.reduce(1..250, {r0, []}, fn i, {run, seen} ->
+          {next, emitted} = DirectoryIngest.absorb(run, row("#c#{i}"), 0)
+          {next, seen ++ emitted}
+        end)
 
-      {_, second} = DirectoryIngest.absorb(r1, row("#b"), 0)
-      assert second == []
+      assert Enum.all?(actions, &match?({:progress, _}, &1)),
+             "absorb/3 handed back a non-progress action: #{inspect(actions)}"
     end
 
-    test "reaching the batch size emits ONE ingest action carrying wire order" do
-      r0 = armed([batch: 3], 0)
+    test "the whole capture comes out of finish/1, in wire order" do
+      r0 = armed([], 0)
 
       {r1, []} = DirectoryIngest.absorb(r0, row("#a"), 0)
       {r2, []} = DirectoryIngest.absorb(r1, row("#b"), 0)
-      {_, third} = DirectoryIngest.absorb(r2, row("#c"), 0)
+      {r3, []} = DirectoryIngest.absorb(r2, row("#c"), 0)
 
-      assert [{:ingest, rows}] = third
+      assert {_, rows, _} = DirectoryIngest.finish(r3)
       assert Enum.map(rows, & &1.name) == ["#a", "#b", "#c"]
     end
 
-    test "the running tally survives a flush — count is total, not buffer depth" do
-      r0 = armed([batch: 2, throttle_ms: 0], 0)
+    test "count tracks rows received, and the ping reports it" do
+      r0 = armed([throttle_ms: 0], 0)
 
       {r1, _} = DirectoryIngest.absorb(r0, row("#a"), 0)
       {r2, _} = DirectoryIngest.absorb(r1, row("#b"), 0)
@@ -122,19 +129,19 @@ defmodule Grappa.Session.DirectoryIngestTest do
       assert {:progress, 3} in at_2000
     end
 
-    test "the flush is ordered BEFORE the progress ping it reports" do
-      r0 = armed([batch: 1, throttle_ms: 0], 0)
+    test "a ping is the ONLY thing an absorb can ask for" do
+      r0 = armed([throttle_ms: 0], 0)
 
       {_, actions} = DirectoryIngest.absorb(r0, row("#a"), 0)
 
-      assert [{:ingest, _}, {:progress, 1}] = actions
+      assert [{:progress, 1}] = actions
     end
   end
 
   describe "finish/1" do
-    test "flushes the tail in wire order, hands back the watchdog ref, and clears the run" do
+    test "hands back the capture in wire order and the watchdog ref, and clears the run" do
       timer = make_ref()
-      r0 = DirectoryIngest.start(ingest(batch: 100), 0, timer)
+      r0 = DirectoryIngest.start(ingest([]), 0, timer)
 
       {r1, []} = DirectoryIngest.absorb(r0, row("#a"), 0)
       {r2, []} = DirectoryIngest.absorb(r1, row("#b"), 0)
@@ -144,7 +151,7 @@ defmodule Grappa.Session.DirectoryIngestTest do
       refute DirectoryIngest.in_flight?(cleared)
     end
 
-    test "an empty buffer flushes nothing — never round-trip an empty insert" do
+    test "an empty buffer hands back an empty capture" do
       assert {cleared, [], _} = DirectoryIngest.finish(armed([], 0))
       refute DirectoryIngest.in_flight?(cleared)
     end
@@ -153,11 +160,13 @@ defmodule Grappa.Session.DirectoryIngestTest do
   describe "abort/1 — the watchdog" do
     test "DROPS the buffered rows and hands back nothing to write" do
       # Behaviour pin, not tidiness. `handle_info(:directory_refresh_timeout,
-      # ...)` wipes the tracker without flushing, so rows buffered since the
-      # last batch are lost and `ChannelDirectory.finalize/2` never runs for
-      # that refresh. A version that flushed on timeout would change the DB
-      # on every truncated refresh. #1390 slice 2 preserves it deliberately.
-      r0 = armed([batch: 100], 0)
+      # ...)` wipes the tracker without flushing, so the whole capture is
+      # lost and `ChannelDirectory.replace/3` never runs for that refresh.
+      # Since issue 2046 that is also what SAVES the previous snapshot: the
+      # arm nukes nothing, so a stalled refresh leaves the last good list in
+      # place. A version that flushed on timeout would write a truncated
+      # capture over it.
+      r0 = armed([], 0)
 
       {r1, []} = DirectoryIngest.absorb(r0, row("#a"), 0)
       {r2, []} = DirectoryIngest.absorb(r1, row("#b"), 0)

--- a/test/grappa/session/directory_test.exs
+++ b/test/grappa/session/directory_test.exs
@@ -6,8 +6,12 @@ defmodule Grappa.Session.DirectoryTest do
   against the `Grappa.IRCServer` in-process TCP fake (CLAUDE.md "Mock at
   boundaries, real dependencies inside"): the LIST send, the in-flight
   guard, and the watchdog-timeout → `directory_failed` broadcast (the
-  merged C4 leg), and the streamed 321/322/323 capture → batched ingest +
+  merged C4 leg), and the streamed 321/322/323 capture → buffered ingest +
   `directory_progress` / `directory_complete` pings (C3).
+
+  Since issue 2046 it also pins the DEFERRAL, which is a claim only a live
+  session can make: a capture in flight writes nothing, so the previous
+  snapshot stays servable until the 323 replaces it in one go.
 
   `async: false` for the same reason as `Grappa.Session.ServerTest`:
   `SessionRegistry` / `SessionSupervisor` / `PubSub` are singletons.
@@ -42,17 +46,42 @@ defmodule Grappa.Session.DirectoryTest do
              IRCServer.wait_for_line(server, &String.starts_with?(&1, "LIST"), 1_000)
   end
 
-  test "a second refresh while one is in-flight returns {:error, :already_refreshing}" do
+  # The second half of this test refutes a claim issue 2046 carries: that a
+  # controller arming a refresh mid-capture "kills the capture in flight".
+  # It cannot, and it never could — the in-flight run is matched by an
+  # EARLIER clause than the one that sends LIST, so a second request is a
+  # pure rejection that touches neither the wire, the tracker, nor the
+  # buffer. The rows absorbed before it are still there afterwards, and this
+  # asserts exactly that rather than the return value alone.
+  test "a second refresh while one is in-flight is rejected AND leaves the capture intact" do
     {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
     {user, network, _} = setup_user_and_network(port)
 
-    _ = start_session_for(user, network)
+    credential = Credentials.get_credential!(user, network)
+    {:ok, base_plan} = SessionPlan.resolve(credential)
+    plan = Map.put(base_plan, :directory_progress_throttle_ms, 0)
+    {:ok, pid} = Session.start_session({:user, user.id}, network.id, plan)
+
+    on_exit(fn ->
+      _ = DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid)
+    end)
+
     :ok = IRCServer.await_handshake(server, 1_000)
+    :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
     assert :ok = Session.refresh_directory({:user, user.id}, network.id)
+    IRCServer.feed(server, ":irc.test 322 nick #elixir 1200 :The Elixir channel\r\n")
+    assert_receive %Phoenix.Socket.Broadcast{payload: %{kind: :directory_progress, count: 1}}, 1_000
 
     assert {:error, :already_refreshing} =
              Session.refresh_directory({:user, user.id}, network.id)
+
+    # `:sys.get_state` serializes after the rejected call, so the buffer read
+    # here is the state that survived it.
+    run = :sys.get_state(pid).directory.run
+    assert run != nil
+    assert Enum.map(run.buffer, & &1.name) == ["#elixir"]
+    assert run.count == 1
   end
 
   test "a refresh that never sees 323 times out, clears state, emits directory_failed" do
@@ -175,12 +204,73 @@ defmodule Grappa.Session.DirectoryTest do
     # and a ~1s window would make `:fresh` depend on where the stamp fell in
     # the wall-clock second — doubly so here, where the `assert_receive` above
     # can burn most of that second before the read (#713).
-    page = ChannelDirectory.list({:user, user.id}, network.id, ttl_ms: 60_000)
+    page =
+      ChannelDirectory.list({:user, user.id}, network.id, ttl_ms: 60_000, refreshing?: false)
+
     assert page.status == :fresh
     assert page.total == 2
     # Default sort is user_count DESC (1200 > 800), so #elixir precedes #ruby.
     # NB: list/3 always re-sorts — this asserts the sort, not insertion order.
     assert Enum.map(page.entries, & &1.name) == ["#elixir", "#ruby"]
+  end
+
+  # Issue 2046 — the deferral, asserted where it is observable: a capture
+  # that has received rows but not its 323 must have changed NOTHING. Before
+  # the deferral this same sequence left the reader with an empty partition
+  # (the arm nuked it) plus whatever had been flushed, stamped by nobody —
+  # the `:refreshing` state that no longer exists.
+  test "a capture in flight leaves the previous snapshot whole and servable" do
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+    {user, network, _} = setup_user_and_network(port)
+
+    # 0ms throttle so the first 322 emits a ping — that ping is the barrier
+    # proving the row was absorbed before the assertions below read the DB.
+    credential = Credentials.get_credential!(user, network)
+    {:ok, base_plan} = SessionPlan.resolve(credential)
+    plan = Map.put(base_plan, :directory_progress_throttle_ms, 0)
+    {:ok, pid} = Session.start_session({:user, user.id}, network.id, plan)
+
+    on_exit(fn ->
+      _ = DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid)
+    end)
+
+    :ok = IRCServer.await_handshake(server, 1_000)
+    :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+    # A first, complete capture: this is the snapshot that must survive.
+    assert :ok = Session.refresh_directory({:user, user.id}, network.id)
+    IRCServer.feed(server, ":irc.test 322 nick #elixir 1200 :The Elixir channel\r\n")
+    IRCServer.feed(server, ":irc.test 322 nick #ruby 800 :Ruby\r\n")
+    IRCServer.feed(server, ":irc.test 323 nick :End of /LIST\r\n")
+    assert_receive %Phoenix.Socket.Broadcast{payload: %{kind: :directory_complete}}, 1_000
+
+    # A second capture, deliberately left in flight after one row.
+    assert :ok = Session.refresh_directory({:user, user.id}, network.id)
+    IRCServer.feed(server, ":irc.test 322 nick #onlynew 5 :Only in the new capture\r\n")
+    assert_receive %Phoenix.Socket.Broadcast{payload: %{kind: :directory_progress, count: 1}}, 1_000
+
+    assert Session.directory_refreshing?({:user, user.id}, network.id)
+
+    mid = read_page(user, network, true)
+    assert mid.status == :fresh
+    assert Enum.map(mid.entries, & &1.name) == ["#elixir", "#ruby"]
+    assert mid.total == 2
+
+    IRCServer.feed(server, ":irc.test 323 nick :End of /LIST\r\n")
+    assert_receive %Phoenix.Socket.Broadcast{payload: %{kind: :directory_complete, total: 1}}, 1_000
+
+    refute Session.directory_refreshing?({:user, user.id}, network.id)
+
+    after_323 = read_page(user, network, false)
+    assert Enum.map(after_323.entries, & &1.name) == ["#onlynew"]
+    assert after_323.total == 1
+  end
+
+  defp read_page(user, network, refreshing?) do
+    ChannelDirectory.list({:user, user.id}, network.id,
+      ttl_ms: 60_000,
+      refreshing?: refreshing?
+    )
   end
 
   test "emits at least one directory_progress before completing" do

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -255,11 +255,14 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
-  # #1390 slice 2 — the channel-directory ETL left the session, so its three
-  # config tunables and its in-flight tracker left the top level of state with
-  # it. Same two-pin split as the `Deps` bundle above, for the same reason:
-  # forgetting to ADD the struct and forgetting to REMOVE the four loose keys
-  # are different mistakes.
+  # #1390 slice 2 — the channel-directory ETL left the session, so its config
+  # tunables and its in-flight tracker left the top level of state with it.
+  # Same two-pin split as the `Deps` bundle above, for the same reason:
+  # forgetting to ADD the struct and forgetting to REMOVE the loose keys are
+  # different mistakes. `directory_ingest_batch` stays in this list although
+  # issue 2046 deleted the knob entirely: the pin asserts the key is ABSENT
+  # from session state, and that is no less true of a tunable that no longer
+  # exists than of one that moved into the struct.
   @directory_keys ~w[directory_refresh_timeout_ms directory_progress_throttle_ms
                      directory_ingest_batch directory_refresh]a
 

--- a/test/grappa_web/controllers/directory_controller_test.exs
+++ b/test/grappa_web/controllers/directory_controller_test.exs
@@ -12,35 +12,53 @@ defmodule GrappaWeb.DirectoryControllerTest do
     {:ok, conn: put_bearer(conn, session_fixture(user).id), user: user, network: network}
   end
 
-  test "GET returns empty/refreshing with no snapshot + no live session", %{
+  test "GET with no snapshot and no live session reports unknown", %{
     conn: conn,
     network: network
   } do
     resp = conn |> get("/networks/#{network.slug}/directory") |> json_response(200)
-    assert resp["status"] in ["empty", "refreshing"]
+    assert resp["status"] == "unknown"
     assert resp["entries"] == []
     assert resp["total"] == 0
+    assert resp["captured_at"] == nil
   end
 
-  test "GET serves a finalized snapshot sorted by users", %{
+  test "GET serves a snapshot sorted by users", %{
     conn: conn,
     user: user,
     network: network
   } do
     s = {:user, user.id}
-    :ok = Dir.replace_start(s, network.id)
 
     :ok =
-      Dir.ingest(s, network.id, [
+      Dir.replace(s, network.id, [
         %{name: "#big", topic: "t", user_count: 99},
         %{name: "#small", topic: "", user_count: 1}
       ])
 
-    :ok = Dir.finalize(s, network.id)
-
     resp = conn |> get("/networks/#{network.slug}/directory") |> json_response(200)
     assert resp["status"] == "fresh"
     assert Enum.map(resp["entries"], & &1["name"]) == ["#big", "#small"]
+  end
+
+  # Issue 2046 — the wire half of the state that used to read `empty`, and
+  # the one the controller must NOT arm a re-capture on. `captured_at` comes
+  # back non-null on purpose: the search ran against a real snapshot, and
+  # rendering "never" over one is the same class of lie as the skew.
+  test "GET with a search that matches nothing reports no_results, stamp included", %{
+    conn: conn,
+    user: user,
+    network: network
+  } do
+    :ok = Dir.replace({:user, user.id}, network.id, [%{name: "#big", topic: "t", user_count: 9}])
+
+    resp =
+      conn |> get("/networks/#{network.slug}/directory?q=zzz-no-such-channel") |> json_response(200)
+
+    assert resp["status"] == "no_results"
+    assert resp["total"] == 0
+    assert resp["entries"] == []
+    assert resp["captured_at"] != nil
   end
 
   test "#85 — rows carry featured: true for channels in the network's featured set", %{
@@ -49,15 +67,13 @@ defmodule GrappaWeb.DirectoryControllerTest do
     network: network
   } do
     s = {:user, user.id}
-    :ok = Dir.replace_start(s, network.id)
 
     :ok =
-      Dir.ingest(s, network.id, [
+      Dir.replace(s, network.id, [
         %{name: "#feat", topic: "t", user_count: 9},
         %{name: "#plain", topic: "", user_count: 1}
       ])
 
-    :ok = Dir.finalize(s, network.id)
     # Operator curates "#Feat" (mixed case) — must match the "#feat" row.
     {:ok, _} = Grappa.Networks.FeaturedChannels.add_channel(network, %{name: "#Feat"})
 


### PR DESCRIPTION
Addresses issue 2046.

`ChannelDirectory.list/3` assembled one payload from three unsynchronised
reads, so a capture landing between them answered `status: "empty", total: 0`
beside five entries — measured off a production trace in the issue, and read by
cic's pane as "0 channels / never" over a populated list.

vjt's ruling has three parts, and all three are here: defer the persistence to
the end of the `LIST`, take the total and the page from the SAME read, and
split the one `empty` into three named states.

---

## 1. The measurement the ruling ordered, and it went AGAINST the hope

The ruling flagged that part 1 might make part 2 **superfluous** — if nothing
is written during a capture, a reader sees the previous snapshot whole, so
where would the skew come from? — and asked for the direction to be MEASURED,
with the answer reported whichever way it fell.

**It does not close it.** Deferring moves the write; it does not make it
atomic. The 323 is still a delete followed by inserts, and three reads still
straddle it.

The measurement is a **pair**, in `test/grappa/channel_directory_test.exs`:

| | what it does | what it shows |
|---|---|---|
| **control** | fires the interleave BETWEEN two `list/3` calls | the two instants disagree: `total: 5` beside 3 rows — the exact shape the trace reported |
| **subject** | fires the same interleave from INSIDE the read | `total == length(entries)` |

Without the control the subject is a mirror: a `total == length(entries)` that
holds because nothing moved proves nothing. The interleave rides Ecto's own
`[:grappa, :repo, :query]` event, which is emitted **synchronously in the
calling process**, so the write lands between one statement of the reader and
the next — no production seam, no `sleep`, no second process. The subject
asserts the harness **fired** before it asserts the outcome.

⇒ part 2 was written. `total` is a `count(*) over ()` on the page's own
statement; the window sits inside a subquery and the keyset cursor is applied
OUTSIDE it, so the count stays the whole filtered set instead of shrinking page
by page.

## 2. `:refreshing` was DEAD, so it is gone — proved, not assumed

`status_of(nil, _, _) -> :refreshing` meant "rows present, `captured_at` still
NULL", which existed only because the ingest wrote mid-stream and stamped
later. `replace/3` stamps at INSERT ⇒ a row without a stamp is not
constructible.

Repo-wide census of everything deleted (`lib/ test/ config/ scripts/ priv/
cicchetto/ mix.exs .github/`), classifying each hit as CODE / COMMENT / DOC,
because **a grep on a name measures text occurrences and the comments that
record a removal are exactly where that text survives**:

| deleted | text hits | as CODE | what the survivors are |
|---|---|---|---|
| `replace_start/2` | 1 | **0** | the moduledoc recording the removal |
| `ChannelDirectory.ingest/3` | 0 | **0** | — |
| `ChannelDirectory.finalize/2` | 0 | **0** | — |
| `{:ingest, rows}` action | 1 | **0** | a test comment recording the removal |
| `batch` field access | 1 | **0** | an unrelated `batch` in `notify_test` |
| `drain/1` (private ⇒ module-scoped) | 0 | **0** | — |
| `ingest_batch` config key | 2 | **0** | two comments recording the removal |
| `:directory_ingest_batch` opt | 4 | **1** | `server_test.exs:267` — an ABSENCE pin, and no producer anywhere in `lib/` |

Controls, run before any count was printed: a verb that IS alive
(`ChannelDirectory.list(`) → 5 CODE hits; an invented one
(`ChannelDirectory.frobnicate`) → 0 of any kind. The tool exits without
printing if either fails. `drain/1` was a `defp`, so its census scope is its
own module, not the repo — a repo-wide `drain(` needle matches 42 unrelated
test helpers, which is the word and not the use; the module-scoped control is a
`defp` still called there (`throttle(`, 3 hits) against an invented one (0).

One real survivor was found and cured: `from_opts/1`'s docstring still promised
that a plan pinning `:directory_ingest_batch` keeps working. It does not — and
because the reader is `Map.get`, a stale plan is silently IGNORED rather than
rejected. Now said out loud.

## 3. What I REFUSE to claim, and one place the brief was wrong

**The query is NOT an argument to `status_of/4`.** The ruling names the
presence of the query as the discriminant, and my brief read that as a
signature change carrying `q` down. It is not needed: with the stamp
snapshot-scoped and the count search-scoped, `%DateTime{} + total == 0` is
reachable ONLY with a query present — an absent `q` counts the whole partition,
which is non-empty whenever a stamp exists. Passing `q` would re-state a fact
the two arguments already carry, and it would be WEAKER: it would label a
search typed before the first capture `no_results` when the truth is `loading`.
Shipped signature: `status_of(captured_at, total, refreshing?, ttl_ms)`.

**The deterministic defect: the incoherence is real, the CONSEQUENCE is not —
and was not before this slice either.** The issue says a search miss reading
`:empty` arms a refresh which *kills the capture in flight*. False on the code:
`handle_call(:refresh_directory, …)` matches an in-flight run in an EARLIER
clause than the one that sends `LIST`, so a second request is a pure
`{:error, :already_refreshing}` touching neither wire nor tracker nor buffer.
`directory_test.exs` now asserts **the buffer survives** the rejected call
rather than only its return value. The incoherence itself IS cured: a search
miss is `:no_results`, and only `:unknown` arms.

Not claimed: any magnitude for the buffer's RAM or for the write burst; any
identification of which of the issue's three candidate readings produced the
original 15 s / 14-poll artefact.

## 4. The two questions the ruling left OPEN, answered here

**(1) The default for `total` / `captured_at` when the filtered set is empty.**
A statement returning no rows carries no window value, so the envelope is asked
for separately in exactly that case, and only then: one row of the same
subquery when a CURSOR ran past the end (exact total, real stamp), and
`{0, max(captured_at)}` over the unfiltered partition when the search genuinely
matched nothing. That second read is what keeps a search miss reporting WHEN
the list it searched was captured — without it the pane renders "never" over a
real snapshot, and reports `:unknown`, which is the one status that arms a
re-capture. Its cost, stated: on that path alone the two values come from two
instants, and a capture landing between them can only flip an EMPTY page
between `:no_results` and `:unknown` — there are no entries for the numbers to
contradict.

**(2) Which scope owns the count.** SEARCH-scoped, as it always was; the stamp
stays SNAPSHOT-scoped. That combination is what makes the discriminant
constructible at all (see §3).

## 5. Ordering is the guarantee, which is why there is no transaction

`DirectoryController.index/2` reads `Session.directory_refreshing?/2` BEFORE
the page, always. It is a call into the session, so it queues behind the 323
handler that performs the write: a reader sees either the old snapshot whole
(capture still streaming) or the new one (write committed), never the
delete-then-insert gap inside `replace/3`. Swapping the two lines hands the gap
back, and what it produces is `:unknown` — the status that arms a re-capture.
Both the controller and the context carry that argument in prose.

## 6. Wire

`protocol_version` 16 → 17. **This is the first bump that is not additive**:
`empty` and `refreshing` LEAVE the closed `status` union, `no_results`,
`unknown` and `loading` enter it. It is not the #1626 field-removal carve-out —
every key stays where it was — it is a closed set of VALUES changing, which the
additive-only rule never spoke to. Break measured in both directions: cic's
generated `wireSchema` rejects a `status` outside its enum, so a pre-17 bundle
throws away every directory page a v17 server sends, and this bundle cannot
read a pre-17 server's either. `min_protocol_version` stays at 1 deliberately —
426ing the whole socket over one broken pane is worse than the pane, and the
two ship together.

`priv/wire/shape.pin` was RED before the re-pin (`protocol pinned 16 / now 17`,
both digests printed) and GREEN after — the gate discriminating on this exact
change, not a guess. `gen_wire_types --check` was verified to discriminate too:
one character of drift in the union → `OUT OF SYNC`, rc=1; restored → `in
sync`, rc=0.

## 7. Gates

| gate | result |
|---|---|
| `scripts/mix.sh --env=dev compile --force` | **rc=0** (339 files, forced — the shared `_build` is not trusted) |
| `scripts/check.sh` | **rc=0** — credo `6912 mods/funs, found no issues`, dialyzer `done (passed successfully)`, sobelow `Total errors: 0`, doctor passed, **7282 tests, 0 failures**, bats 764 ok / 0 not-ok |
| `scripts/bun.sh run check` | **rc=0** — biome + tsc(src) + tsc(e2e) |
| `scripts/bun.sh run test` | **rc=0** — 351 files, **7050 tests passed** |
| `scripts/design-notes-gate.sh` | rc=0 — `1 new entry heading, separator and marker present` |
| `scripts/union-rebase.sh` | rc=0 — `docs/DESIGN_NOTES.md: +139 -0 — contribution intact` |
| `mix grappa.gen_wire_types --check` | rc=0, with a negative control proving it discriminates |
| `mix grappa.wire_pin --check` | rc=1 before the re-pin, rc=0 after |

**NOT run: the e2e.** The spec is written (a term matching nothing renders the
`no_results` line, and the capture time does NOT read "never"; the
clear-filter step then asserts the line is gone, so the first assertion cannot
pass on a pane that prints it unconditionally) — but the STACK lane was not
granted, so it has never been executed. Stated rather than implied.

This branch touches `config/config.exs`.

An earlier full `bun run test` reported ONE red — `compose.test.ts`, a 5 s
timeout on a synchronous assertion, in a file this branch does not touch. It
went green in isolation (279/279 in 1.5 s) and did not reproduce in the run
above. Recorded rather than quietly dropped: a load flake, not attributable to
this branch, and not something this branch cured either.

---

**Re-run after the rebase.** `origin/main` moved twice under this branch. The
first push landed `CONFLICTING / DIRTY` — GitHub does not apply `merge=union`
on its merge-ref, so a concurrent `DESIGN_NOTES` append conflicts server-side
even when the local rebase is clean, and a `CONFLICTING` PR runs no CI at all.
`scripts/union-rebase.sh` onto the new tip fixed it (`+139 -0 — contribution
intact`, both directions checked); the PR now reads `MERGEABLE`.

The only overlap between this branch and the two new main commits is
`docs/DESIGN_NOTES.md` — the union path — plus `cicchetto/src/lib/readCursor.ts`
which this branch does not touch. Every gate was nonetheless re-run on the
rebased tree, and it is the exact tree that is pushed (clean working tree,
local `HEAD` == the remote ref): `scripts/check.sh` rc=0 with the same numbers
(credo `found no issues`, doctor passed, **7282 tests / 0 failures**, sobelow
`Total errors: 0`, dialyzer `done (passed successfully)`, bats **764 ok / 0 not
ok**, `wireTypes`/`wireSchema` in sync, `shape.pin` agrees at protocol 17),
`bun run check` rc=0, `bun run test` rc=0 (7050 passed),
`design-notes-gate.sh` rc=0, and the marker re-checked unique against the NEW
tip (pos ctrl `#2052` = 1, neg ctrl = 0) with the boundary shape read off the
real file.
