### PR TITLE
fix: own rows never self-highlight — the sender half the render port never had

### DIFF
--- a/cicchetto/src/MentionsWindow.tsx
+++ b/cicchetto/src/MentionsWindow.tsx
@@ -1,6 +1,6 @@
 import { type Component, createMemo, For, Show } from "solid-js";
 import { highlightPatterns } from "./lib/highlightList";
-import { matchesWatchlist } from "./lib/mentionMatch";
+import { isMentionRow } from "./lib/mentionMatch";
 import { formatTimestamp } from "./lib/timeFormat";
 import { MircBody } from "./MircText";
 import NickText from "./NickText";
@@ -154,8 +154,9 @@ const MentionsWindow: Component<Props> = (props) => {
               <For each={group.rows}>
                 {(row) => {
                   // #370 — own nick ∪ custom /hilight patterns (shared source).
-                  const isHighlight = () =>
-                    matchesWatchlist(row.body, props.ownNick, highlightPatterns());
+                  // issue 1481 — via the row-level rule, so a row the operator
+                  // authored is not highlighted back at them here either.
+                  const isHighlight = () => isMentionRow(row, props.ownNick, highlightPatterns());
 
                   return (
                     <button

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -35,7 +35,7 @@ import { type InviteAckEntry, inviteAckBySlug } from "./lib/inviteAck";
 import { chantypesForNetwork, prefixForNetwork } from "./lib/isupport";
 import { jumpToUnreadRequest } from "./lib/jumpToUnreadCommand";
 import { membersByChannel } from "./lib/members";
-import { matchesWatchlist } from "./lib/mentionMatch";
+import { isMentionRow } from "./lib/mentionMatch";
 import {
   mentionJumpTargetId,
   mentionsBelowViewport,
@@ -103,11 +103,12 @@ import WhowasCard from "./WhowasCard";
 // `ComposeBox.tsx`. This pane is now compose-free; the parent layout
 // composes ScrollbackPane + ComposeBox vertically.
 //
-// Mention highlight (P4-1, extended #370): privmsg lines whose `body`
-// word-boundary case-insensitive-matches the operator's own nick OR a custom
-// /hilight pattern get the .scrollback-mention class. The matcher reads
-// `networks.user()` for the nick and `highlightList.highlightPatterns()` for
-// the keyword list — the SAME `matchesWatchlist` source the notify path uses.
+// Mention highlight (P4-1, extended #370, issue 1481): privmsg lines from
+// SOMEBODY ELSE whose `body` word-boundary case-insensitive-matches the
+// operator's own nick OR a custom /hilight pattern get the
+// .scrollback-mention class. The matcher reads `networks.user()` for the nick
+// and `highlightList.highlightPatterns()` for the keyword list — the SAME
+// `isMentionRow` source the notify path folds.
 //
 // C5.0 (UX-5 BJ rewrite — 2026-05-19): own-nick JOIN auto-focus.
 // When the operator's own nick has a JOIN row in scrollback for this
@@ -158,10 +159,10 @@ import WhowasCard from "./WhowasCard";
 // for the logged-in nick so op-gated items are correctly enabled/disabled.
 //
 // C7.7 / #370: Watchlist highlight rendering — PRIVMSG / NOTICE / ACTION
-// lines where `matchesWatchlist(body, ownNick, highlightPatterns())` is true
-// get .scrollback-highlight class. The watchlist is own nick ∪ the custom
+// lines where `isMentionRow(msg, ownNick, highlightPatterns())` is true get
+// .scrollback-highlight class. The watchlist is own nick ∪ the custom
 // /hilight keyword list (highlightList.ts), mirroring the server SSOT
-// `Grappa.Mentions.mentioned?/3`.
+// `Grappa.Mentions.mention_row?/3`; issue 1481 added the own-row conjunct.
 
 export type Props = {
   networkSlug: string;
@@ -1168,22 +1169,22 @@ const ScrollbackLine: Component<{
   onNickContextMenu: (nick: string, e: MouseEvent) => void;
   onJoinChannel: (channel: string) => void;
 }> = (props) => {
-  // #370 — a mention is now own nick ∪ custom highlight patterns (the same
-  // set the server counts as a mention, and the same `matchesWatchlist`
-  // predicate the notify path uses). A privmsg matching a /hilight word gets
-  // the exact `.scrollback-mention` treatment an own-nick mention gets.
+  // #370 — a mention is own nick ∪ custom highlight patterns; a privmsg
+  // matching a /hilight word gets the exact `.scrollback-mention` treatment
+  // an own-nick mention gets. issue 1481 — and never a row this operator
+  // AUTHORED: `isMentionRow` carries the own-row conjunct the notify port has
+  // had since #532 C, so the two ports agree on the sender axis too.
   const isMention = () =>
-    props.msg.kind === "privmsg" &&
-    matchesWatchlist(props.msg.body, props.userNick, highlightPatterns());
+    props.msg.kind === "privmsg" && isMentionRow(props.msg, props.userNick, highlightPatterns());
 
   // C7.2: muted — presence/event kinds are visually de-emphasized.
   const isMuted = () => PRESENCE_KINDS.has(props.msg.kind);
 
-  // C7.7 / #370: highlight — content kinds where body matches the watchlist
-  // (own nick ∪ custom highlight patterns).
+  // C7.7 / #370: highlight — content kinds where the row mentions the
+  // operator (own nick ∪ custom highlight patterns, own rows excluded).
   const isHighlight = () =>
     !PRESENCE_KINDS.has(props.msg.kind) &&
-    matchesWatchlist(props.msg.body, props.userNick, highlightPatterns());
+    isMentionRow(props.msg, props.userNick, highlightPatterns());
 
   const handlers: NickHandlers = {
     onNickClick: props.onNickClick,

--- a/cicchetto/src/__tests__/MentionsWindow.test.tsx
+++ b/cicchetto/src/__tests__/MentionsWindow.test.tsx
@@ -230,6 +230,29 @@ describe("MentionsWindow", () => {
     expect(rows[0]?.classList.contains("scrollback-highlight")).toBe(true);
   });
 
+  // issue 1481 — the render port's third site. The bundle itself no longer
+  // carries own rows (the server-side `mention_row?/3` drops them), but the
+  // class is decided here, so the guard has to hold on the row it is handed.
+  it("does not highlight a row the operator authored", () => {
+    const bundle = makeBundle({ messages: [{ ...MSG0, sender: "vjt", body: "vjt: prova" }] });
+    render(() => (
+      <MentionsWindow bundle={bundle} ownNick="vjt" onMentionClicked={vi.fn()} onClose={vi.fn()} />
+    ));
+
+    const rows = screen.getAllByTestId("mentions-row");
+    expect(rows[0]?.classList.contains("scrollback-highlight")).toBe(false);
+  });
+
+  it("still highlights the SAME body from a peer (issue 1481 control)", () => {
+    const bundle = makeBundle({ messages: [{ ...MSG0, sender: "alice", body: "vjt: prova" }] });
+    render(() => (
+      <MentionsWindow bundle={bundle} ownNick="vjt" onMentionClicked={vi.fn()} onClose={vi.fn()} />
+    ));
+
+    const rows = screen.getAllByTestId("mentions-row");
+    expect(rows[0]?.classList.contains("scrollback-highlight")).toBe(true);
+  });
+
   it("does not highlight when ownNick is null", () => {
     render(() => (
       <MentionsWindow

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -4148,6 +4148,64 @@ describe("ScrollbackPane", () => {
     });
   });
 
+  // issue 1481 — the own-row step the notify port has had since #532 C.
+  // BOTH classes are asserted here, because both `isMention` and
+  // `isHighlight` decided from the body alone; and `.scrollback-mention` is
+  // what the below-the-fold mention badge reads off the DOM
+  // (`readMentionGeom` → `mentionsBelowViewport`), so it inherits this and
+  // does not need a guard of its own.
+  describe("own rows never self-highlight (issue 1481)", () => {
+    const ownRow = (body: string, sender: string) => ({
+      id: 1,
+      network: "freenode",
+      channel: "#grappa",
+      server_time: 1_700_000_000_000,
+      kind: "privmsg" as const,
+      sender,
+      body,
+      meta: {},
+    });
+
+    it("own PRIVMSG naming own nick gets NEITHER class", () => {
+      setUserNick("vjt");
+      setScrollback({ "freenode #grappa": [ownRow("vjt: prova", "vjt")] });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const line = screen.getByTestId("scrollback-line");
+      expect(line.classList.contains("scrollback-mention")).toBe(false);
+      expect(line.classList.contains("scrollback-highlight")).toBe(false);
+    });
+
+    it("own PRIVMSG carrying a /hilight word gets neither either", () => {
+      setUserNick("vjt");
+      setHighlightPatternsForTest(["deploy"]);
+      setScrollback({ "freenode #grappa": [ownRow("the deploy is done", "vjt")] });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const line = screen.getByTestId("scrollback-line");
+      expect(line.classList.contains("scrollback-mention")).toBe(false);
+      expect(line.classList.contains("scrollback-highlight")).toBe(false);
+    });
+
+    it("the sender fold is ASCII — a row sent as VJT is still own", () => {
+      setUserNick("vjt");
+      setScrollback({ "freenode #grappa": [ownRow("note to self, vjt", "VJT")] });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const line = screen.getByTestId("scrollback-line");
+      expect(line.classList.contains("scrollback-mention")).toBe(false);
+      expect(line.classList.contains("scrollback-highlight")).toBe(false);
+    });
+
+    it("a PEER row with the SAME body still gets both classes", () => {
+      // Positive control for the three arms above: identical body, different
+      // sender. Without it they could pass on a broken render path.
+      setUserNick("vjt");
+      setScrollback({ "freenode #grappa": [ownRow("vjt: prova", "alice")] });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const line = screen.getByTestId("scrollback-line");
+      expect(line.classList.contains("scrollback-mention")).toBe(true);
+      expect(line.classList.contains("scrollback-highlight")).toBe(true);
+    });
+  });
+
   // CP13 — :notice rows with meta.severity === "error" (server-routed
   // failure-class numerics) get the .scrollback-notice-error class so
   // they render red. Non-error severity (or missing meta) → no class,

--- a/cicchetto/src/__tests__/mentionMatch.test.ts
+++ b/cicchetto/src/__tests__/mentionMatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isMentionableSender, matchesWatchlist } from "../lib/mentionMatch";
+import { isMentionableSender, isMentionRow, isOwnRow, matchesWatchlist } from "../lib/mentionMatch";
 
 // #370 — `matchesWatchlist` is the SINGLE client-side match predicate for
 // the in-message visual highlight (ScrollbackPane `.scrollback-mention` /
@@ -213,5 +213,62 @@ describe("isMentionableSender — a robot cannot mention you (#1674)", () => {
 
   it("only ever subtracts — an unclassifiable sender stays mentionable", () => {
     expect(isMentionableSender("")).toBe(true);
+  });
+});
+
+// issue 1481 — the OWN-ROW half, and the row-level rule the three RENDER
+// sites fold. The notify port has had this step since #532 C / #868; the
+// render port decided from the body alone, so your own line naming your own
+// nick highlighted itself back at you.
+describe("isOwnRow — sender identity, ASCII fold (issue 1481)", () => {
+  it("is true for the operator's own sender, whatever the case", () => {
+    expect(isOwnRow("vjt", "vjt")).toBe(true);
+    expect(isOwnRow("VJT", "vjt")).toBe(true);
+    expect(isOwnRow("vjt", "VJT")).toBe(true);
+  });
+
+  it("is false for anybody else", () => {
+    expect(isOwnRow("alice", "vjt")).toBe(false);
+  });
+
+  it("folds A-Z only — a bracket twin is a DIFFERENT person on bahamut", () => {
+    expect(isOwnRow("foo[1]", "foo{1}")).toBe(false);
+  });
+
+  it("is false when the own nick is not resolved yet", () => {
+    expect(isOwnRow("vjt", null)).toBe(false);
+  });
+});
+
+describe("isMentionRow — sender conjunct AND body match (issue 1481)", () => {
+  it("a peer naming you is a mention", () => {
+    expect(isMentionRow({ sender: "alice", body: "hey vjt" }, "vjt", [])).toBe(true);
+  });
+
+  it("your OWN line naming your own nick is not", () => {
+    expect(isMentionRow({ sender: "vjt", body: "vjt: prova" }, "vjt", [])).toBe(false);
+  });
+
+  it("your own line carrying a /hilight word is not either", () => {
+    expect(isMentionRow({ sender: "vjt", body: "the deploy is done" }, "vjt", ["deploy"])).toBe(
+      false,
+    );
+  });
+
+  it("the sender fold is ASCII — an own line sent as VJT is still yours", () => {
+    expect(isMentionRow({ sender: "VJT", body: "note to self, vjt" }, "vjt", [])).toBe(false);
+  });
+
+  it("a peer line that names nobody is still not a mention", () => {
+    expect(isMentionRow({ sender: "alice", body: "hello world" }, "vjt", [])).toBe(false);
+  });
+
+  it("an unresolved own nick leaves the patterns deciding", () => {
+    // `ownNick` null → no row can be "own", and `matchesWatchlist` skips the
+    // falsy term, so a /hilight word still fires. Same posture as
+    // `matchesWatchlist`'s own null-nick arm above.
+    expect(isMentionRow({ sender: "alice", body: "the deploy is done" }, null, ["deploy"])).toBe(
+      true,
+    );
   });
 });

--- a/cicchetto/src/lib/mentionMatch.ts
+++ b/cicchetto/src/lib/mentionMatch.ts
@@ -5,13 +5,17 @@
 // list, NOT a special case — every term is matched the same way (word-boundary,
 // case-insensitive). Mirror of the server SSOT `Grappa.Mentions.mentioned?/3`.
 //
-// #370 — ONE predicate feeds EVERY client sink so notify-match and
-// visual-match can never diverge again:
+// #370 — ONE BODY predicate feeds EVERY client sink:
 //   - in-message visual highlight (ScrollbackPane `.scrollback-mention` /
 //     `.scrollback-highlight`, MentionsWindow),
 //   - the live in-app beep + optimistic desktop-title bump (subscribe.ts),
 // and is kept in parity with the client push mirror (pushTriggers.shouldNotify,
 // a drift-guard tested against the shared server truth-table, no live caller).
+//
+// #370 read that as "the two ports can never diverge again" and it was too
+// strong: a body predicate cannot answer a SENDER question. They diverged on
+// exactly that axis until issue 1481 — see `isOwnRow` / `isMentionRow` below,
+// which are the sender half and the row-level rule the render sinks fold.
 // The server owns the remaining sinks (OS push + sidebar count) via the same
 // `mentioned?/3` source. Before #370 the visual path and the live beep only
 // ever matched the own nick, so a /hilight word fired the (server-side)
@@ -23,6 +27,7 @@
 // escape covers the cases that would otherwise blow up the RegExp constructor.
 
 import { mircPlainText } from "./mircFormat";
+import { nickEquals } from "./nickEquals";
 import { isServerSender, isServicesSender } from "./servicesSender";
 
 // #1786 — the anchor is conditional on the term's OWN edge, and that is a fix
@@ -96,3 +101,44 @@ export const matchesWatchlist = (
 // sender stays mentionable and the other conjuncts decide it.
 export const isMentionableSender = (sender: string): boolean =>
   !isServicesSender(sender) && !isServerSender(sender);
+
+// issue 1481 — "is this row MINE?", and the single client spelling of it.
+// Mirror of `Grappa.Push.Triggers.own_row?/2` (#532 C).
+//
+// Decided by sender IDENTITY, never by window shape: an OUTBOUND DM is
+// persisted with `channel = peer` (only an INBOUND one carries `channel =
+// own_nick`), so a shape test misroutes it and the operator's own watchlist
+// then runs over the operator's own body.
+//
+// #1861 — pinned to `"ascii"`, deliberately, and this is now the ONE place
+// that pin lives on the client. Both consumers are faithful transcriptions
+// of SERVER predicates whose every fold is the arity-1
+// `Identifier.canonical_target/1` (`own_row?/2`, `WindowCounts.mention_row?/3`).
+// Folding harder here than the server folds would make cic disagree with the
+// server's own answer on an rfc1459 network. When the server's mention folds
+// become network-aware, this moves WITH them, not before.
+export const isOwnRow = (sender: string, ownNick: string | null): boolean =>
+  nickEquals(sender, ownNick, "ascii");
+
+// issue 1481 — the ROW-level mention rule the RENDER port folds: the sender
+// conjunct AND the body match, asked as one question so the three render
+// sites cannot answer it three different ways.
+//
+// The render port used to call `matchesWatchlist` bare, from
+// `ScrollbackPane`'s `isMention` + `isHighlight` and from `MentionsWindow`.
+// Three open-coded copies of half a rule is exactly how this port drifted
+// from the notify one, which has excluded own rows since #532 C — so your own
+// line naming your own nick highlighted itself back at you (reported twice on
+// IRC, by alk and by Mezmerize). `.scrollback-mention` is also what the
+// below-the-fold mention badge reads off the DOM (`readMentionGeom` →
+// `mentionsBelowViewport`), so that sink inherits this and needs no guard.
+//
+// Mirror of the server's `Grappa.Mentions.mention_row?/3` MINUS its
+// `mentionable_sender?/1` conjunct: the render port has never subtracted
+// services or the server, and #1674 scoped that axis to the badge and the OS
+// push. Left as-is deliberately — a separate decision, not this one.
+export const isMentionRow = (
+  row: { readonly sender: string; readonly body: string | null },
+  ownNick: string | null,
+  patterns: string[],
+): boolean => !isOwnRow(row.sender, ownNick) && matchesWatchlist(row.body, ownNick, patterns);

--- a/cicchetto/src/lib/mentionScroll.ts
+++ b/cicchetto/src/lib/mentionScroll.ts
@@ -7,21 +7,25 @@
 // falls back to the plain snap-to-bottom gesture.
 //
 // ScrollbackPane owns the DOM read (offsetTop per `.scrollback-line`, the
-// `.scrollback-mention` class = a mention per `matchesWatchlist` = own nick ∪
-// /hilight keywords, #370 — same set the server counts as a mention); this
+// `.scrollback-mention` class = a mention per `isMentionRow` = a row somebody
+// ELSE sent matching own nick ∪ /hilight keywords, #370 + issue 1481); this
 // module owns the below-the-fold DECISION so it can be unit-tested without a
 // real layout (jsdom reports 0 for every geometry). Scope is the
 // `.scrollback-mention` class (privmsg lines matching the watchlist); the
 // broader `.scrollback-highlight` class (the same match set across all content
 // kinds) is not what the badge tracks.
+//
+// Reading the CLASS rather than re-deciding is what makes the badge inherit
+// every change to the rule for free — issue 1481's own-row conjunct landed
+// here without a line of code in this file.
 
 export type ScrollbackLineGeom = {
   // Server message id (data-msg-id) — the jump target key.
   id: number;
   // offsetTop within the scroll container, in px.
   top: number;
-  // true when the line carries `.scrollback-mention` (watchlist match:
-  // own nick ∪ /hilight keywords, #370).
+  // true when the line carries `.scrollback-mention` (watchlist match from
+  // another sender: own nick ∪ /hilight keywords, #370 + issue 1481).
   isMention: boolean;
 };
 

--- a/cicchetto/src/lib/mentions.ts
+++ b/cicchetto/src/lib/mentions.ts
@@ -29,10 +29,15 @@ import { selectedChannel } from "./selection";
 // its count so a returning operator sees the activity.
 //
 // Note: the per-row `.scrollback-mention` highlight (ScrollbackPane) is a
-// client-side render decision (`matchesWatchlist` = own nick ∪ /hilight
-// patterns, #370) — deterministic per-row, not a count, with no
-// cross-tab/reconnect consistency problem. It matches the SAME set the
-// server counts as a mention. Only the COUNT moved server-side.
+// client-side render decision (`isMentionRow` = own nick ∪ /hilight patterns,
+// minus own rows) — deterministic per-row, not a count, with no
+// cross-tab/reconnect consistency problem. Only the COUNT moved server-side.
+//
+// It used to claim the render set was the SAME set the server counts. That
+// was false — issue 1481 measured it — and it is still not identical after
+// the fix: the server's `mention_row?/3` also subtracts service- and
+// server-originated rows (#1674), which the render port has never done. The
+// two agree on the body match and on own rows; the services axis is open.
 //
 // Identity-scoped via identityScopedStore reset (dup-A3 close).
 

--- a/cicchetto/src/lib/pushTriggers.ts
+++ b/cicchetto/src/lib/pushTriggers.ts
@@ -25,8 +25,8 @@
 import { type MessageKind, NOTIFY_KINDS } from "./api";
 import { type ChannelKey, canonicalChannel } from "./channelKey";
 import { conversationMuteKey, isConversationMuted } from "./conversationMute";
-import { isMentionableSender, matchesWatchlist } from "./mentionMatch";
-import { asciiFold, nickEquals } from "./nickEquals";
+import { isMentionableSender, isOwnRow, matchesWatchlist } from "./mentionMatch";
+import { asciiFold } from "./nickEquals";
 import type { NotificationPrefs } from "./userSettings";
 
 // Minimal structural shape the predicate needs — a subset of the wire
@@ -73,23 +73,22 @@ export function shouldNotify(
   // convention as `wireNarrow.ts`.
   if (!NOTIFY_KINDS.has(message.kind as MessageKind)) return false;
 
-  // #532 C, #868 — "is this row mine?" decided by sender IDENTITY, and asked
-  // BEFORE the window-shape test below. An OUTBOUND DM is persisted with
-  // `channel = peer` (only an INBOUND one carries `channel = own_nick`), so
-  // the shape test misroutes it to the channel branch, where the operator's
-  // own highlight patterns run over the operator's own body — self-notifying
-  // on every outgoing message that happens to contain their nick. The server
-  // has had this step since #532 C (`triggers.ex` `own_row?/2`); this port
-  // did not, and the shared fixture had no row that could see the gap.
+  // #532 C, #868 — "is this row mine?" asked BEFORE the window-shape test
+  // below, because an OUTBOUND DM is persisted with `channel = peer` (only an
+  // INBOUND one carries `channel = own_nick`): the shape test misroutes it to
+  // the channel branch, where the operator's own highlight patterns run over
+  // the operator's own body. The server has had this step since #532 C
+  // (`triggers.ex` `own_row?/2`); this port did not, and the shared fixture
+  // had no row that could see the gap.
   //
-  // #1861 — pinned to `"ascii"`, deliberately. This whole predicate is a
-  // faithful transcription of the SERVER's `Push.Triggers`, and every fold
-  // over there is the arity-1 `Identifier.canonical_target/1` (`own_row?/2`,
-  // `dm?/2`, the two allow-lists). Folding harder here than the server folds
-  // would make cic's in-app notification decision disagree with the push the
-  // server actually sends on an rfc1459 network. When the server's triggers
-  // become network-aware, this moves WITH them, not before.
-  if (nickEquals(message.sender, ownNick, "ascii")) return false;
+  // issue 1481 — the predicate itself now lives in `mentionMatch.isOwnRow`,
+  // shared with the RENDER port, which was missing the same step. The
+  // POSITION stays local to this file: here it gates the whole notification
+  // (it outranks the mute and both branches), whereas over there it is one
+  // conjunct of the mention rule. Same question, two places to ask it — one
+  // spelling, so they cannot answer differently. The `"ascii"` pin and its
+  // rationale (#1861) travelled with it.
+  if (isOwnRow(message.sender, ownNick)) return false;
 
   // Fold BOTH sides, mirroring the server's `dm?/2`. The `channel` KEY is
   // folded at the persist boundary (`Message.canonicalize_channel/1`, #537)

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53771,3 +53771,89 @@ cannot tell a missing event from a socket that is delivering nothing.
 - **The two absolving tests, re-run on this tree.** The COMPILE lane was
   held elsewhere; candidate 2's absolution rests on the code path read plus
   two existing tests read, not on a green run taken here.
+<!-- entry #1481 -->
+
+---
+
+## 2026-09-11 — #1481: one question, two ports, and the sender half the render port never had
+
+Type your own nick into your own message and cicchetto highlighted your own
+line back at you. Reported on IRC by alk (*"perche' deve hilightarmi il
+messaggio se scrivo io stesso il mio nick"*), then again by Mezmerize on a
+self-hosted 1.5.5 who read it as a regression, live-repro included.
+
+### What the two ports actually disagreed about
+
+The NOTIFY port has excluded own rows since #532 C, on both sides:
+`Push.Triggers.should_notify?/5` asks `own_row?/2` as step 0, and
+`pushTriggers.ts` mirrors it. The RENDER port asked
+`matchesWatchlist(body, ownNick, patterns)` — **a BODY predicate, which cannot
+answer a SENDER question** — from three places and never looked at who sent
+the row: `ScrollbackPane`'s `isMention` and `isHighlight`, and
+`MentionsWindow`. Server-side the same hole sat in
+`Mentions.aggregate_mentions/6`, so the away digest handed the operator their
+own lines back.
+
+Three open-coded halves of one rule is not bad luck, it is the mechanism.
+`WindowCounts` already carried a private `mention_row?/3` whose FIRST conjunct
+is exactly the missing step; the rule simply had to be remembered in four
+places and was remembered in two. #370's own header had written the stronger
+claim — that ONE predicate made divergence impossible — and it was too strong
+for exactly this reason.
+
+### The shape of the cure: one predicate per port, not a fourth copy
+
+Server: `mention_row?/3` is **promoted out of `Grappa.WindowCounts` into
+`Grappa.Mentions`**, which already owns both conjuncts it composes
+(`mentionable_sender?/1`, `matches?/2`) and whose moduledoc already claimed to
+be where every server-side mention fold goes. The private copy goes away in
+the same commit; the two counting doors and `aggregate_mentions/6` now fold the
+one rule, so the badge, the away bundle and the OS push cannot mean three
+different things by "mention". The pre-folded `own_folded` parameter is kept
+verbatim from the copy that moved — the counting doors hoist the fold out of
+their loops over a capped tail, and `aggregate_mentions/6` folds once before
+its filter for the same reason.
+
+Client: `isMentionRow` in `mentionMatch.ts`, built on `isOwnRow`, which
+`pushTriggers.ts` now folds too. That leaves ONE client spelling of "is this
+row mine", and the `"ascii"` pin (#1861) travelled with it — one place to
+change when the server's mention folds become network-aware.
+
+**`Push.Triggers.own_row?/2` and its cic twin deliberately keep their
+POSITION.** Over there the question gates the WHOLE notification: it outranks
+the per-conversation mute and both branches. Here it is one conjunct of the
+mention rule. Same question, two positions in two decision trees — merging
+them would have moved the step, which is a behaviour change nobody asked for.
+
+### The below-the-fold badge needed no guard, and that is asserted
+
+`readMentionGeom` reads `.scrollback-mention` straight off the DOM and
+`mentionsBelowViewport` counts it, so the badge inherits any change to the
+class. Reading the class rather than re-deciding is what buys that. The
+ScrollbackPane arms assert the CLASS itself, with a peer row carrying the SAME
+body as the positive control — so the inheritance is measured, not assumed.
+
+### What is still divergent, named rather than quietly widened
+
+After this the render set and the server's count agree on the body match and
+on own rows. They are still **not identical**: the server's `mention_row?/3`
+also subtracts service- and server-originated rows (#1674), an axis the render
+port has never had. `mentions.ts` used to assert the two sets were the same;
+that sentence was false before this change and would be false after it, so it
+is replaced by one that names the remaining gap. Closing that axis is a
+separate call — #1674 scoped it to the badge and the push on purpose, and
+widening it here would change what a NickServ line looks like in scrollback
+without anyone deciding to.
+
+### The "new in 1.5.5" reading, and what was NOT measured
+
+The regression reading is not supported by the code: `isMention` and
+`isHighlight` carried no sender conjunct in either 1.5.4 or the tip this was
+built on, and the last change to that block predates the first tag. Three
+candidate explanations for why it may nonetheless look new to a reporter
+(the `mircPlainText` projection, `termAnchors`, or simply having started to
+quote lines carrying his own nick) were **deduced by the issue's author and
+explicitly not measured** — they are not cited here as causes, and the cure
+does not depend on which, if any, is true. No repro was built in a real
+browser; the e2e lane was not held, and this defect is fully decidable at the
+unit layer on both ports.

--- a/lib/grappa/mentions.ex
+++ b/lib/grappa/mentions.ex
@@ -95,11 +95,14 @@ defmodule Grappa.Mentions do
       that window over-counted identically (measured under #1674).
 
   Every server-side "is this row a mention" fold composes THIS with
-  `matches?/2`: `Grappa.WindowCounts.mention_row?/3` (the badge, both the
-  per-window and the bulk cold-load door), `aggregate_mentions/6` (the C8
-  mentions-while-away bundle) and `Grappa.Push.Triggers.mention_match?/4`
-  (the OS push). A new mention fold MUST go through it or the badge and
-  the notification start disagreeing again.
+  `matches?/2`, and two of the three do it through `mention_row?/3` below:
+  `Grappa.WindowCounts` (the badge, both the per-window and the bulk
+  cold-load door) and `aggregate_mentions/6` (the C8 mentions-while-away
+  bundle). `Grappa.Push.Triggers.mention_match?/4` composes the pair
+  directly, because its own-row step sits higher in its decision tree
+  (`own_row?/2` outranks the mute and both branches). A new mention fold
+  MUST go through `mention_row?/3` or the badge and the notification start
+  disagreeing again.
   """
 
   use Boundary,
@@ -129,10 +132,12 @@ defmodule Grappa.Mentions do
   Messages are returned in `server_time ASC` order (chronological).
 
   Non-content-bearing kinds (`:join`, `:part`, `:quit`, etc.) are
-  excluded — they never carry a body to match against. Service- and
-  server-originated rows are excluded too (`mentionable_sender?/1`,
-  #1674): a NickServ confirmation naming you is not a mention, and the
-  away bundle must agree with the badge that counted it.
+  excluded — they never carry a body to match against. Rows the subject
+  AUTHORED are excluded (issue 1481), and so are service- and
+  server-originated ones (#1674): a NickServ confirmation naming you is
+  not a mention, your own line naming yourself is not one either, and the
+  away bundle must agree with the badge that counted it. Both exclusions
+  arrive through the shared `mention_row?/3`.
 
   The DB query step uses the `messages_user_id_network_id_channel_server_time_index`
   composite index. The in-memory regex step filters the (typically small)
@@ -163,11 +168,13 @@ defmodule Grappa.Mentions do
       |> order_by([m], asc: m.server_time, asc: m.id)
       |> Repo.all()
 
-    # Step 2: in-memory word-boundary regex filter.
+    # Step 2: in-memory row-level filter through the shared `mention_row?/3`.
     # Compile all pattern regexes once before the loop — avoids
-    # re-compilation per row × per pattern.
+    # re-compilation per row × per pattern — and fold the own nick once for
+    # the same reason.
     compiled = build_matchers([own_nick | watchlist_patterns])
-    Enum.filter(rows, &(mentionable_sender?(&1.sender) and body_matches?(&1.body, compiled)))
+    own_folded = Identifier.canonical_target(own_nick)
+    Enum.filter(rows, &mention_row?(&1, own_folded, compiled))
   end
 
   # ---------------------------------------------------------------------------
@@ -213,6 +220,41 @@ defmodule Grappa.Mentions do
   @spec mentionable_sender?(sender :: term()) :: boolean()
   def mentionable_sender?(sender) do
     not (Identifier.services_sender?(sender) or Identifier.server_sender?(sender))
+  end
+
+  @doc """
+  The ROW-level mention rule — the ONE fold every server-side mention
+  counter composes, so the badge, the OS push and the away bundle cannot
+  mean three different things by "mention".
+
+  Three conjuncts, each subtractive:
+
+    1. **not own-sent** — you cannot mention yourself. Decided by sender
+       IDENTITY, folded through the ASCII nick SSOT (#121/#525), never by
+       window shape: an OUTBOUND DM carries `channel = peer`, so a shape
+       test misroutes it and the operator's own watchlist then runs over
+       the operator's own body (`Push.Triggers.own_row?/2`, #532 C).
+    2. **a sender that CAN mention you** — no service, no server
+       (`mentionable_sender?/1`, #1674).
+    3. **the body match itself** (`matches?/2`, the shared matchers).
+
+  `own_folded` is the own nick ALREADY folded via
+  `Identifier.canonical_target/1` — the callers hoist that fold out of
+  their loops, alongside the matcher compilation.
+
+  This used to be a private copy in `Grappa.WindowCounts`, which meant the
+  rule held for the badge and not for `aggregate_mentions/6`: an away
+  digest handed the operator their own lines back (issue 1481). It lives
+  here now because this module is the SSOT for both of the other two
+  conjuncts. A new mention fold MUST go through it.
+  """
+  @spec mention_row?(%{sender: String.t(), body: String.t() | nil}, String.t(), matchers()) ::
+          boolean()
+  def mention_row?(%{sender: sender, body: body}, own_folded, matchers)
+      when is_binary(own_folded) and is_list(matchers) do
+    Identifier.canonical_target(sender) != own_folded and
+      mentionable_sender?(sender) and
+      matches?(body, matchers)
   end
 
   @typedoc """

--- a/lib/grappa/window_counts.ex
+++ b/lib/grappa/window_counts.ex
@@ -30,7 +30,9 @@ defmodule Grappa.WindowCounts do
       `sender` through the ASCII nick SSOT (#121/#525), and so are
       service- / server-originated rows (`Mentions.mentionable_sender?/1`,
       #1674 — a NickServ login confirmation is not a highlight). One
-      row-level rule, `mention_row?/3`, serves BOTH counting doors. Bounded by
+      row-level rule, `Mentions.mention_row?/3`, serves BOTH counting doors
+      here AND the away bundle (issue 1481 moved it next to the two
+      predicates it composes). Bounded by
       `@mention_scan_cap` — the same bounded-tail strategy
       `Grappa.Push.BadgeCount` uses (SQLite has no `REGEXP`, so the
       match runs in-memory over a capped content tail).
@@ -260,29 +262,6 @@ defmodule Grappa.WindowCounts do
     end
   end
 
-  # The ONE row-level mention rule (#1674). Both counting doors fold THIS —
-  # the per-window `count_mentions/6` and the bulk `count_tail_mentions/3` —
-  # so the badge cannot mean two different things depending on which one
-  # answered. It used to be two byte-identical closures, and #1674 is what a
-  # rule applied per-door instead of per-rule costs: the sender exclusion
-  # would have had to be remembered twice.
-  #
-  # Three conjuncts, each subtractive:
-  #   1. not own-sent — you cannot mention yourself (fold `sender` through
-  #      the ASCII nick SSOT, #121/#525; never a bare downcase);
-  #   2. a sender that CAN mention you — no service, no server (#1674);
-  #   3. the body match itself (`Mentions.matches?/2`, the shared matchers).
-  @spec mention_row?(
-          %{sender: String.t(), body: String.t() | nil},
-          String.t(),
-          Mentions.matchers()
-        ) :: boolean()
-  defp mention_row?(%{sender: sender, body: body}, own_folded, matchers) do
-    Identifier.canonical_target(sender) != own_folded and
-      Mentions.mentionable_sender?(sender) and
-      Mentions.matches?(body, matchers)
-  end
-
   # Mention count over a pre-fetched capped content tail (#396 bulk path).
   # `nil` own_nick → nothing to match, so no mentions.
   @spec count_tail_mentions(
@@ -295,7 +274,7 @@ defmodule Grappa.WindowCounts do
   defp count_tail_mentions(tail, own_nick, matchers) do
     own = Identifier.canonical_target(own_nick)
 
-    Enum.count(tail, &mention_row?(&1, own, matchers))
+    Enum.count(tail, &Mentions.mention_row?(&1, own, matchers))
   end
 
   # No configured nick on this network → `count_tail_mentions/3` answers 0
@@ -304,8 +283,8 @@ defmodule Grappa.WindowCounts do
   defp slug_matchers(nil, _), do: []
   defp slug_matchers(own_nick, patterns), do: Mentions.matchers(own_nick, patterns)
 
-  # Counts unread content rows that mention the subject, per `mention_row?/3`.
-  # Bounded by the scan cap.
+  # Counts unread content rows that mention the subject, per
+  # `Mentions.mention_row?/3`. Bounded by the scan cap.
   @spec count_mentions(
           Subject.t(),
           integer(),
@@ -323,7 +302,7 @@ defmodule Grappa.WindowCounts do
 
     subject
     |> Scrollback.unread_content_tail(network_id, channel, after_id, own_nick, @mention_scan_cap)
-    |> Enum.count(&mention_row?(&1, own, matchers))
+    |> Enum.count(&Mentions.mention_row?(&1, own, matchers))
   end
 
   # Severity ladder — mention > message > event > none.

--- a/test/grappa/mentions_test.exs
+++ b/test/grappa/mentions_test.exs
@@ -318,6 +318,93 @@ defmodule Grappa.MentionsTest do
     end
   end
 
+  describe "aggregate_mentions/6 — own rows (issue 1481)" do
+    test "a row the subject authored naming their own nick is not aggregated", %{
+      user: u,
+      network: net
+    } do
+      insert!(
+        msg(u, net,
+          sender: "vjt",
+          body: "vjt: prova",
+          server_time: @away_start + 10
+        )
+      )
+
+      assert Mentions.aggregate_mentions(u.id, net.id, @away_start, @away_end, [], "vjt") == []
+    end
+
+    test "the exclusion folds ASCII — an own row sent as VJT is still own", %{
+      user: u,
+      network: net
+    } do
+      insert!(
+        msg(u, net,
+          sender: "VJT",
+          body: "vjt reminder to self",
+          server_time: @away_start + 10
+        )
+      )
+
+      assert Mentions.aggregate_mentions(u.id, net.id, @away_start, @away_end, [], "vjt") == []
+    end
+
+    test "an own row carrying a /hilight word is not aggregated either", %{user: u, network: net} do
+      # Keyed on the SENDER, so it covers the custom-pattern half of the
+      # watchlist and not just the own nick — same shape as the #1674 arm.
+      insert!(
+        msg(u, net,
+          sender: "vjt",
+          body: "the deploy is done",
+          server_time: @away_start + 10
+        )
+      )
+
+      assert Mentions.aggregate_mentions(u.id, net.id, @away_start, @away_end, ["deploy"], "vjt") ==
+               []
+    end
+
+    test "a peer row spelling the same body IS still aggregated", %{user: u, network: net} do
+      # Positive control for the three above: identical body, different
+      # sender. If this went red the arms above would be passing vacuously.
+      m =
+        insert!(
+          msg(u, net,
+            sender: "alice",
+            body: "vjt: prova",
+            server_time: @away_start + 10
+          )
+        )
+
+      result = Mentions.aggregate_mentions(u.id, net.id, @away_start, @away_end, [], "vjt")
+      assert Enum.map(result, & &1.id) == [m.id]
+    end
+  end
+
+  describe "mention_row?/3 — the promoted row-level rule (issue 1481)" do
+    # The three conjuncts, one arm each, over the pre-folded own nick the
+    # counting doors hoist out of their loops.
+    test "own row is not a mention" do
+      refute Mentions.mention_row?(%{sender: "VJT", body: "vjt ping"}, "vjt", Mentions.matchers("vjt", []))
+    end
+
+    test "a service naming you is not a mention" do
+      refute Mentions.mention_row?(
+               %{sender: "NickServ", body: "Password accepted for vjt."},
+               "vjt",
+               Mentions.matchers("vjt", [])
+             )
+    end
+
+    test "a peer naming you is" do
+      assert Mentions.mention_row?(%{sender: "alice", body: "vjt ping"}, "vjt", Mentions.matchers("vjt", []))
+    end
+
+    test "a peer NOT naming you is not" do
+      refute Mentions.mention_row?(%{sender: "alice", body: "hello world"}, "vjt", Mentions.matchers("vjt", []))
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Property test: in-memory regex gate matches Elixir Regex directly
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses issue 1481.

Type your own nick into your own message and cicchetto highlighted your own
line back at you — `.scrollback-mention`, `.scrollback-highlight`, a row in
the mentions window, a tick on the below-the-fold mention badge, and the
away digest. Reported on IRC by alk, then again by Mezmerize.

## The asymmetry

The NOTIFY port has excluded own rows since #532 C, on both sides
(`Push.Triggers.should_notify?/5` step 0, `pushTriggers.ts` step 2). The
RENDER port asked `matchesWatchlist(body, ownNick, patterns)` — a BODY
predicate, which cannot answer a SENDER question — from three places and
never looked at who sent the row. Server-side, `aggregate_mentions/6` had
the same hole.

Four open-coded halves of one rule is the mechanism, not bad luck:
`WindowCounts` already carried a private `mention_row?/3` whose FIRST
conjunct is exactly the missing step, so the rule had to be remembered in
four places and was remembered in two.

## Shape of the cure — a shared predicate per port, not a fourth copy

**Server.** `mention_row?/3` is promoted out of `Grappa.WindowCounts` into
`Grappa.Mentions`, which already owns both conjuncts it composes
(`mentionable_sender?/1`, `matches?/2`). The private copy goes away in the
same commit; both counting doors and `aggregate_mentions/6` now fold the one
rule. Net **-21 lines** in `window_counts.ex`.

**Client.** `isMentionRow` in `mentionMatch.ts`, built on `isOwnRow`, which
`pushTriggers.ts` folds too — one client spelling of "is this row mine", and
the `"ascii"` pin (#1861) travelled with it.

`Push.Triggers.own_row?/2` and its cic twin keep their POSITION on purpose:
there the question gates the whole notification (it outranks the mute and
both branches); here it is one conjunct of the mention rule. Merging them
would have moved the step.

The below-the-fold badge needed no guard — it reads the class off the DOM
(`readMentionGeom` → `mentionsBelowViewport`). That is asserted rather than
assumed: the ScrollbackPane arms check the CLASS, with a peer row carrying
the SAME body as the positive control.

## Deliberately unchanged, and named

After this the render set and the server's count agree on the body match and
on own rows, but are still **not identical**: the server also subtracts
service- and server-originated rows (#1674), an axis the render port has
never had. `mentions.ts` used to assert the two sets were the same — false
before this change and still false after, so the sentence is replaced by one
naming the gap instead of quietly widening the rule here.

The "new in 1.5.5" reading is not supported by the code (no sender conjunct
in either 1.5.4 or the tip). The three candidate explanations in the issue
were deduced and explicitly not measured; nothing here depends on them.

## Gates

| gate | result |
|---|---|
| `scripts/check.sh` | rc=0 — compile+Boundary, format, credo --strict, sobelow, **7290 tests / 0 failures**, dialyzer `done (passed successfully)`, docs, both wire gates, 764 bats / 0 not-ok |
| `scripts/bun.sh run check` | rc=0 — 5/5 stages (lock drift, test location, biome, tsc src, tsc e2e) |
| `scripts/bun.sh run test` | rc=0 — 351 files, **7068 tests / 0 failures** |
| `scripts/design-notes-gate.sh` | rc=0 — *1 new entry heading(s), separator and marker present* |

Every new assertion was seen RED first: 7 Elixir failures (3 of them the real
defect, 4 the not-yet-promoted predicate) and 14 vitest failures, with the
peer-sent positive controls green on both sides throughout.

Wire shape untouched, so no `protocol_version` bump and no `wire_pin` move —
`mix grappa.wire_pin --check` is green inside `check.sh`.

`e2e` was NOT run (lane not held). Checked by reading instead: the two specs
that assert these classes (`issue370-custom-highlight-visual`,
`issue188-mentions-panel-polish`) send every asserted line from a PEER, so
neither is on the changed axis.
