### PR TITLE
cicchetto: selectable notification sound, shipped silent (issue 1480)

### DIFF
--- a/cicchetto/e2e/tests/issue1480-notification-sound-preset.spec.ts
+++ b/cicchetto/e2e/tests/issue1480-notification-sound-preset.spec.ts
@@ -1,0 +1,132 @@
+// #1480 — the notification sound is a chosen preset, and the shipped choice
+// is SILENCE.
+//
+// `ux-6-l-foreground-push-beep.spec.ts` covers the beep DECISION (which
+// events alert, which do not) and, since this issue, opts in first so its
+// positive arms stay reachable and its negative arm stays honest. This spec
+// covers the axis that issue added: WHICH sound, whether the shipped state is
+// silence, and whether a choice survives the server round-trip.
+//
+// The oracle is the same production seam — `window.__lastBeepAt`, stamped by
+// `playBeep` on the attempt — and it is exactly as good as the fact that
+// `none` returns BEFORE the stamp. A silent preset that still ticked the seam
+// would make the first test below unfalsifiable, which is why that ordering
+// is asserted in `beep.test.ts` too and mutation-checked there.
+//
+// The default arm is deliberately NOT a bare "nothing happened" assertion: it
+// waits for the mention to be persisted server-side AND to reach cic's
+// scrollback first, so a green means "the alert path ran and chose not to
+// sound", never "the message never arrived".
+
+import { loginAs, openSettingsSection, selectChannel } from "../fixtures/cicchettoPage";
+import { assertMessagePersisted, partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const PEER_NICK = "s1480-mentioner";
+const MENTION_CHANNEL = "#s1480-mention";
+
+async function readLastBeepAt(page: import("@playwright/test").Page): Promise<number | null> {
+  return await page.evaluate(
+    () => (window as unknown as { __lastBeepAt?: number }).__lastBeepAt ?? null,
+  );
+}
+
+async function typeVerb(page: import("@playwright/test").Page, verb: string): Promise<void> {
+  await page.locator(".compose-box textarea").fill(verb);
+  await page.locator(".compose-box textarea").press("Enter");
+}
+
+test("a subject who chose no sound is NOT beeped by a mention (the shipped state)", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+
+  const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  try {
+    await peer.join(MENTION_CHANNEL);
+    await typeVerb(page, `/join ${MENTION_CHANNEL}`);
+    await selectChannel(page, NETWORK_SLUG, MENTION_CHANNEL, { ownNick: specNick() });
+    // Look away, so the mention lands on a NON-focused window: this is the
+    // exact configuration that beeps once a preset is chosen, which is what
+    // makes the silence attributable to the preset and not to the focus gate.
+    await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+
+    const body = `${specNick()}: default should stay silent`;
+    peer.privmsg(MENTION_CHANNEL, body);
+
+    // The alert path really ran: the row exists server-side, and cic rendered
+    // it. Without these two the null below would be indistinguishable from a
+    // message that never arrived.
+    await assertMessagePersisted({
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      channel: MENTION_CHANNEL,
+      sender: peer.nick,
+      body,
+    });
+    await selectChannel(page, NETWORK_SLUG, MENTION_CHANNEL, { ownNick: specNick() });
+    await expect(page.locator(".scrollback").getByText(body, { exact: false })).toHaveCount(1, {
+      timeout: 10_000,
+    });
+
+    expect(await readLastBeepAt(page)).toBeNull();
+  } finally {
+    await peer.disconnect("1480 default done");
+    await partChannel(vjt.token, NETWORK_SLUG, MENTION_CHANNEL).catch(() => {});
+  }
+});
+
+test("a chosen preset survives a reload, and the drawer shows what was chosen", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+
+  // The confirmation beep is the barrier: `/beep` plays the preset only after
+  // its PUT resolves, so a stamp means the server has the value.
+  await typeVerb(page, "/beep icq");
+  await expect.poll(async () => await readLastBeepAt(page), { timeout: 5_000 }).not.toBeNull();
+
+  // A reload throws away every in-memory signal, so what the picker reads
+  // afterwards came back over the wire — which is the acceptance bar ("the
+  // choice persists across reload, and across devices on the same account";
+  // a second device is the same round-trip and is not reachable from here).
+  await page.reload();
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+  await openSettingsSection(page, "push");
+
+  await expect(page.getByTestId("pref-notification-sound")).toHaveValue("icq", {
+    timeout: 10_000,
+  });
+});
+
+test("bare /beep opens the picker, and /beep off puts it back to silence", async ({ page }) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+
+  await typeVerb(page, "/beep chime");
+  await expect.poll(async () => await readLastBeepAt(page), { timeout: 5_000 }).not.toBeNull();
+
+  // The bare form is a deep-link, not a no-op: it must land on the page that
+  // holds the picker, and the picker must show the choice just made.
+  await typeVerb(page, "/beep");
+  await expect(page.getByTestId("push-subpage")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("pref-notification-sound")).toHaveValue("chime", {
+    timeout: 10_000,
+  });
+
+  // Round trip the other way. deadbeef_'s actual request was "make it stop",
+  // and this is the one-verb version of it.
+  await page.getByTestId("settings-drawer-close").click();
+  await typeVerb(page, "/beep off");
+  await openSettingsSection(page, "push");
+  await expect(page.getByTestId("pref-notification-sound")).toHaveValue("none", {
+    timeout: 10_000,
+  });
+});

--- a/cicchetto/e2e/tests/ux-6-l-foreground-push-beep.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-l-foreground-push-beep.spec.ts
@@ -15,6 +15,19 @@
 //     and this spec asserts the production call-site is reached at
 //     the right moments through real WS + IRC.
 //
+// 🔴 #1480 — every test here now OPTS IN first, with `/beep on` through the
+// real compose box. The default preset became `none` (silence), so a mention
+// no longer stamps the seam for a subject who never chose a sound: without
+// the opt-in the two positive tests would be red, and — worse — the negative
+// one would be VACUOUSLY green, passing because nothing ever beeps rather
+// than because the mention gate held. The default's own behaviour is the
+// subject of `issue1480-notification-sound-preset.spec.ts`.
+//
+// The opt-in doubles as the barrier for its own write: `/beep on` awaits the
+// PUT and only then plays the preset it selected, so the first stamp IS the
+// proof the server pref landed. Each test therefore compares against the
+// stamp the opt-in left, not against null.
+//
 // We do NOT assert that the SW suppressed showNotification — same
 // reason `push-foreground-suppression.spec.ts` (#182) asserts the
 // SERVER-side gate via push-catcher instead: the integration harness
@@ -50,6 +63,19 @@ async function readLastBeepAt(page: import("@playwright/test").Page): Promise<nu
   );
 }
 
+// #1480 — opt in to the 440 Hz tone through the verb a user would type, and
+// return the stamp the confirmation left. `/beep on` persists the preference
+// server-side and plays it only after the PUT resolves, so a non-null read
+// here is evidence the write landed — no sleep, no separate probe.
+async function optInToTheBeep(page: import("@playwright/test").Page): Promise<number> {
+  await page.locator(".compose-box textarea").fill("/beep on");
+  await page.locator(".compose-box textarea").press("Enter");
+  await expect.poll(async () => await readLastBeepAt(page), { timeout: 5_000 }).not.toBeNull();
+  const stamp = await readLastBeepAt(page);
+  if (stamp === null) throw new Error("opt-in confirmation never stamped");
+  return stamp;
+}
+
 test("inbound DM fires in-app beep (__lastBeepAt advances) on a non-focused window", async ({
   page,
 }) => {
@@ -64,9 +90,9 @@ test("inbound DM fires in-app beep (__lastBeepAt advances) on a non-focused wind
   // gate).
   await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
 
-  // Sanity: no beep has fired pre-DM.
-  const baseline = await readLastBeepAt(page);
-  expect(baseline).toBeNull();
+  // Sanity: no beep has fired before anything was chosen — the shipped state.
+  expect(await readLastBeepAt(page)).toBeNull();
+  const baseline = await optInToTheBeep(page);
 
   // Wait for the DM-listener phx.join() ack BEFORE driving a peer DM —
   // see `waitForDmListenerReady` doc for the race shape. Suite saw
@@ -95,11 +121,15 @@ test("inbound DM fires in-app beep (__lastBeepAt advances) on a non-focused wind
       timeout: 5_000,
     });
 
-    // Step 3: __lastBeepAt should have advanced — the DM-listener
-    // call site fires playBeep BEFORE routeMessage (which is what
-    // appends to scrollback + opens the sidebar window). If sidebar
-    // is present, beep MUST have fired.
-    await expect.poll(async () => await readLastBeepAt(page), { timeout: 5_000 }).not.toBeNull();
+    // Step 3: __lastBeepAt should have ADVANCED past the opt-in's own stamp —
+    // the DM-listener call site fires playBeep BEFORE routeMessage (which is
+    // what appends to scrollback + opens the sidebar window). If sidebar is
+    // present, beep MUST have fired. Compared against the baseline rather than
+    // against null since #1480: the opt-in already stamped once, so `not null`
+    // would now be satisfied by the opt-in alone.
+    await expect
+      .poll(async () => await readLastBeepAt(page), { timeout: 5_000 })
+      .toBeGreaterThan(baseline);
   } finally {
     await peer.disconnect("ux6l DM done");
   }
@@ -110,8 +140,8 @@ test("channel mention fires in-app beep on a non-focused mention target", async 
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
 
-  const baseline = await readLastBeepAt(page);
-  expect(baseline).toBeNull();
+  expect(await readLastBeepAt(page)).toBeNull();
+  const baseline = await optInToTheBeep(page);
 
   const peer = await IrcPeer.connect({ nick: PEER_NICK_MENTION });
   try {
@@ -138,7 +168,9 @@ test("channel mention fires in-app beep on a non-focused mention target", async 
       body: mentionBody,
     });
 
-    await expect.poll(async () => await readLastBeepAt(page), { timeout: 5_000 }).not.toBeNull();
+    await expect
+      .poll(async () => await readLastBeepAt(page), { timeout: 5_000 })
+      .toBeGreaterThan(baseline);
   } finally {
     await peer.disconnect("ux6l mention done");
     await partChannel(vjt.token, NETWORK_SLUG, MENTION_CHANNEL).catch(() => {});
@@ -152,8 +184,11 @@ test("PRIVMSG without nick mention does NOT fire beep on a non-focused channel",
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
 
-  const baseline = await readLastBeepAt(page);
-  expect(baseline).toBeNull();
+  expect(await readLastBeepAt(page)).toBeNull();
+  // #1480 — the opt-in is what keeps this negative honest. Left at the
+  // default the subject is silent anyway, so the test would pass without the
+  // mention gate existing at all.
+  const baseline = await optInToTheBeep(page);
 
   const peer = await IrcPeer.connect({ nick: PEER_NICK_MENTION });
   try {
@@ -174,18 +209,18 @@ test("PRIVMSG without nick mention does NOT fire beep on a non-focused channel",
 
     // Negative arm: wait long enough for cic WS round-trip + handler
     // to settle, but use a polled stable read instead of a hardcoded
-    // sleep (audit 2026-05-26). If a beep DOES fire it'll set
-    // __lastBeepAt to a number; we poll for "still null" + a single
-    // final check. assertMessagePersisted above already guarantees
-    // the message reached cic; the only thing we're waiting for is
-    // the (non-)dispatch of beep handler.
+    // sleep (audit 2026-05-26). If a beep DOES fire it'll MOVE
+    // __lastBeepAt past the opt-in's stamp; we poll for "still the
+    // opt-in's value" + a single final check. assertMessagePersisted
+    // above already guarantees the message reached cic; the only thing
+    // we're waiting for is the (non-)dispatch of beep handler.
     await expect
       .poll(async () => readLastBeepAt(page), {
         timeout: 1_500,
         intervals: [100, 200, 400, 800],
       })
-      .toBeNull();
-    expect(await readLastBeepAt(page)).toBeNull();
+      .toBe(baseline);
+    expect(await readLastBeepAt(page)).toBe(baseline);
   } finally {
     await peer.disconnect("ux6l no-mention done");
   }

--- a/cicchetto/public/sounds/PROVENANCE.md
+++ b/cicchetto/public/sounds/PROVENANCE.md
@@ -6,24 +6,34 @@ service worker can precache them and a chosen preset still plays offline.
 Everything about their origin that is known is recorded below; nothing is
 inferred.
 
-These files land *ahead of* the code that reads them: as of this commit
-`cicchetto/src/lib/beep.ts` still plays one hard-coded 440 Hz sine and nothing
-here is referenced yet. Per #1480 the default preset stays synthesised, so the
+All five are wired up as presets in `cicchetto/src/lib/notificationSound.ts`
+and precached by the service worker (`vite.config.ts`'s `globPatterns` carries
+`mp3` for exactly this reason), so a chosen preset still plays offline. Per
+#1480 the DEFAULT preset is silence and the opt-in one is synthesised, so the
 feature is designed to survive this directory being removed.
 
-| File | Bytes | Duration | Origin |
-|---|---|---|---|
-| `icq-uh-oh.mp3` | 12537 | 0.50 s | ICQ message sound, supplied by vjt from <https://sindro.me/t/icq-uh-oh.mp3> |
-| `xp-notify.mp3` | 11969 | 1.18 s | `Windows XP Notify` — the balloon-tip chime |
-| `xp-ding.mp3` | 5447 | 0.44 s | `Windows XP Ding` |
-| `xp-balloon.mp3` | 3335 | 0.21 s | `Windows XP Balloon` |
-| `xp-exclamation.mp3` | 10636 | 1.02 s | `Windows XP Exclamation` |
+| File | Bytes | Duration | Format | Origin |
+|---|---|---|---|---|
+| `icq-uh-oh.mp3` | 12537 | 0.50 s | 44100 Hz mono | ICQ message sound, supplied by vjt from <https://sindro.me/t/icq-uh-oh.mp3> |
+| `xp-notify.mp3` | 11969 | 1.18 s | 22050 Hz stereo | `Windows XP Notify` — the balloon-tip chime |
+| `xp-ding.mp3` | 5447 | 0.44 s | 22050 Hz stereo | `Windows XP Ding` |
+| `xp-balloon.mp3` | 3335 | 0.21 s | 22050 Hz stereo | `Windows XP Balloon` |
+| `xp-exclamation.mp3` | 10636 | 1.02 s | 22050 Hz stereo | `Windows XP Exclamation` |
 
 The four `xp-*` files come from the Internet Archive item
 [`windowsxpstartup_201910`](https://archive.org/details/windowsxpstartup_201910)
 ("ALL Windows XP Sounds"), renamed to lowercase-kebab and otherwise
-byte-identical to the item's own files. All five are 22050 Hz stereo MP3 and
-were verified with `ffprobe` before being committed.
+byte-identical to the item's own files.
+
+The per-file `Format` column corrects this table's first version, which said
+"all five are 22050 Hz stereo": the ICQ sound is **44100 Hz mono**, and it does
+not come from the Archive item, so there was never a reason for it to match.
+Re-measured independently on 2026-09-11 with `afinfo` (this host has no
+`ffprobe`) after re-downloading all three reachable originals — the bytes came
+back identical to what is committed here, so the correction is to the
+description, not to the files. The oracle was calibrated in both directions
+first: `afinfo` exits 1 on a text file and reports a duration for a known-good
+system AIFF.
 
 ## Licence status
 

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -93,7 +93,6 @@ import {
 } from "./lib/uploadOrchestrator";
 import { deviceClassIcon, deviceDisplayName, parseUserAgent } from "./lib/userAgent";
 import {
-  DEFAULT_NOTIFICATION_PREFS,
   getNotificationPrefs,
   getVhostSettings,
   type MutedTargets,
@@ -152,7 +151,6 @@ const SettingsDrawer: Component<Props> = (props) => {
   const [timeFmt, setTimeFmt] = createSignal<TimeFormatKey>(getTimeFormat());
   const [coloredNicklist, setColoredNicklistSig] = createSignal<boolean>(getColoredNicklist());
 
-  const [prefs, setPrefs] = createSignal<NotificationPrefs>(DEFAULT_NOTIFICATION_PREFS);
   const [devices, setDevices] = createSignal<PushDeviceSummary[]>([]);
   // #964 — the server row THIS browser registered, so its list entry can say
   // so. Proven by endpoint match (`subscriptionIdForEndpoint`), never guessed
@@ -625,10 +623,10 @@ const SettingsDrawer: Component<Props> = (props) => {
     if (t === null) return;
     try {
       const loaded = await getNotificationPrefs(t);
-      setPrefs(loaded);
       // #868 — feed the live notify path the same authoritative map the form
       // renders, so the beep obeys a pref the moment it is read, not on the
-      // next user-topic rejoin.
+      // next user-topic rejoin. Since issue 1480 the form renders THIS, and
+      // nothing else: see the note above `savePrefs`.
       mirrorNotificationPrefs(loaded);
       setChannelsOnlyText(loaded.channel_messages_only.join(", "));
       setNicksOnlyText(loaded.private_messages_only.join(", "));
@@ -736,6 +734,22 @@ const SettingsDrawer: Component<Props> = (props) => {
       .map((x) => x.trim())
       .filter((x) => x !== "");
 
+  // This form has NO private copy of the prefs, and that is the fix issue 1480
+  // owes its own CI red. It used to keep one, loaded once at mount, and #950
+  // had already patched the single key that grew a second writer
+  // (`muted_targets` ← the rail picker) by reading THAT key off the shared
+  // mirror. `/beep` made `notification_sound` the second such key and the
+  // patch did not generalise: the picker showed `none` to someone who had just
+  // typed `/beep chime`, and — worse, because it loses data rather than
+  // displaying it late — this endpoint is a FULL replace, so the next
+  // unrelated checkbox would have written that stale `none` straight back over
+  // the choice.
+  //
+  // The snapshot was never anything but a duplicate: its only two writers were
+  // the two lines below, each already handing the SAME value to the mirror.
+  // Deriving costs nothing and cannot drift, and it is what CLAUDE.md's design
+  // discipline asks for — the parallel structure WAS the bug, and a third
+  // per-key patch would only have deferred the next one.
   const savePrefs = async (next: NotificationPrefs) => {
     const t = token();
     if (t === null) return;
@@ -743,7 +757,6 @@ const SettingsDrawer: Component<Props> = (props) => {
     setPrefsError(null);
     try {
       const saved = await putNotificationPrefs(t, next);
-      setPrefs(saved);
       // #868 — mirror the server's NORMALIZED echo (not `next`): the whitelists
       // come back folded, which is the form the predicate compares against.
       mirrorNotificationPrefs(saved);
@@ -756,37 +769,34 @@ const SettingsDrawer: Component<Props> = (props) => {
   };
 
   const togglePref = (key: keyof NotificationPrefs, checked: boolean) => {
-    const current = prefs();
+    const current = notificationPrefs();
     if (typeof current[key] !== "boolean") return;
     void savePrefs({ ...current, [key]: checked });
   };
 
-  // #1480 — the drawer writes the sound through its OWN hydrated form, like
-  // every checkbox here. The `/beep` verb cannot: it holds no form, so it goes
-  // through `notificationPrefs.applyNotificationSound`, which re-GETs first.
-  // Same split as the mute picker (#950), same reason.
+  // issue 1480 — the drawer writes the sound the way it writes every checkbox
+  // here: merge one key over the mirrored map and PUT the whole thing. The
+  // `/beep` verb cannot reach that map — it runs with no drawer mounted at
+  // all — so it goes through `notificationPrefs.applyNotificationSound`, which
+  // GETs first. Same split as the mute picker (#950), same reason.
   const setNotificationSound = (sound: NotificationSound) => {
-    void savePrefs({ ...prefs(), notification_sound: sound });
+    void savePrefs({ ...notificationPrefs(), notification_sound: sound });
   };
 
   const commitChannelsOnly = () => {
-    const next = { ...prefs(), channel_messages_only: splitCsv(channelsOnlyText()) };
+    const next = { ...notificationPrefs(), channel_messages_only: splitCsv(channelsOnlyText()) };
     void savePrefs(next);
   };
 
   const commitNicksOnly = () => {
-    const next = { ...prefs(), private_messages_only: splitCsv(nicksOnlyText()) };
+    const next = { ...notificationPrefs(), private_messages_only: splitCsv(nicksOnlyText()) };
     void savePrefs(next);
   };
 
-  // #950 — the mute map comes from the SHARED mirror, not from this drawer's
-  // private `prefs()` snapshot. The drawer is mounted once and loads its form
-  // at mount (see the moduledoc): that was sound while it was the only writer
-  // of `muted_targets`, but the rail picker is a second one and it feeds the
-  // mirror the server's echo. Reading the snapshot here would show a global
-  // list missing the mute the operator just made — derive, don't duplicate.
-  // Every write still goes through `savePrefs`, whose echo lands in the same
-  // mirror, so this drawer's own picker is unchanged in behaviour.
+  // #950 — the one key that reached the mirror first, back when the rest of
+  // this form still read a private snapshot; issue 1480 moved every other read
+  // here too (see `savePrefs`). Kept as its own accessor for the `?? {}`: the
+  // key is optional on the wire and three call sites below want a map.
   const mutedTargets = (): MutedTargets => notificationPrefs().muted_targets ?? {};
 
   // #866 — the per-conversation mute list, sorted by the stored key so the
@@ -851,14 +861,14 @@ const SettingsDrawer: Component<Props> = (props) => {
   const muteConversation = (key: ChannelKey) => {
     if (key === "") return;
     void savePrefs({
-      ...prefs(),
+      ...notificationPrefs(),
       muted_targets: withConversationMute(mutedTargets(), key, null),
     });
   };
 
   const unmuteConversation = (key: ChannelKey) => {
     void savePrefs({
-      ...prefs(),
+      ...notificationPrefs(),
       muted_targets: withoutConversationMute(mutedTargets(), key),
     });
   };
@@ -2427,7 +2437,7 @@ const SettingsDrawer: Component<Props> = (props) => {
               <label class="prefs-list">
                 notification sound:
                 <select
-                  value={prefs().notification_sound ?? DEFAULT_NOTIFICATION_SOUND}
+                  value={notificationPrefs().notification_sound ?? DEFAULT_NOTIFICATION_SOUND}
                   disabled={savingPrefs()}
                   onChange={(e) =>
                     setNotificationSound(
@@ -2452,7 +2462,9 @@ const SettingsDrawer: Component<Props> = (props) => {
               <button
                 type="button"
                 class="prefs-preview"
-                onClick={() => playBeep(prefs().notification_sound ?? DEFAULT_NOTIFICATION_SOUND)}
+                onClick={() =>
+                  playBeep(notificationPrefs().notification_sound ?? DEFAULT_NOTIFICATION_SOUND)
+                }
                 data-testid="pref-notification-sound-preview"
               >
                 preview
@@ -2471,7 +2483,7 @@ const SettingsDrawer: Component<Props> = (props) => {
               <label>
                 <input
                   type="checkbox"
-                  checked={prefs().channel_messages_all}
+                  checked={notificationPrefs().channel_messages_all}
                   disabled={savingPrefs()}
                   onChange={(e) =>
                     togglePref(
@@ -2488,7 +2500,7 @@ const SettingsDrawer: Component<Props> = (props) => {
                 <input
                   type="text"
                   value={channelsOnlyText()}
-                  disabled={prefs().channel_messages_all || savingPrefs()}
+                  disabled={notificationPrefs().channel_messages_all || savingPrefs()}
                   placeholder="#sbiffo, #grappa"
                   onInput={(e) => setChannelsOnlyText((e.currentTarget as HTMLInputElement).value)}
                   onBlur={commitChannelsOnly}
@@ -2498,7 +2510,7 @@ const SettingsDrawer: Component<Props> = (props) => {
               <label>
                 <input
                   type="checkbox"
-                  checked={prefs().channel_mentions}
+                  checked={notificationPrefs().channel_mentions}
                   disabled={savingPrefs()}
                   onChange={(e) =>
                     togglePref("channel_mentions", (e.currentTarget as HTMLInputElement).checked)
@@ -2512,7 +2524,7 @@ const SettingsDrawer: Component<Props> = (props) => {
               <label>
                 <input
                   type="checkbox"
-                  checked={prefs().private_messages_all}
+                  checked={notificationPrefs().private_messages_all}
                   disabled={savingPrefs()}
                   onChange={(e) =>
                     togglePref(
@@ -2529,7 +2541,7 @@ const SettingsDrawer: Component<Props> = (props) => {
                 <input
                   type="text"
                   value={nicksOnlyText()}
-                  disabled={prefs().private_messages_all || savingPrefs()}
+                  disabled={notificationPrefs().private_messages_all || savingPrefs()}
                   placeholder="alice, bob"
                   onInput={(e) => setNicksOnlyText((e.currentTarget as HTMLInputElement).value)}
                   onBlur={commitNicksOnly}
@@ -2547,7 +2559,7 @@ const SettingsDrawer: Component<Props> = (props) => {
               <label>
                 <input
                   type="checkbox"
-                  checked={prefs().presence_online}
+                  checked={notificationPrefs().presence_online}
                   disabled={savingPrefs()}
                   onChange={(e) =>
                     togglePref("presence_online", (e.currentTarget as HTMLInputElement).checked)
@@ -2559,7 +2571,7 @@ const SettingsDrawer: Component<Props> = (props) => {
               <label>
                 <input
                   type="checkbox"
-                  checked={prefs().presence_offline}
+                  checked={notificationPrefs().presence_offline}
                   disabled={savingPrefs()}
                   onChange={(e) =>
                     togglePref("presence_offline", (e.currentTarget as HTMLInputElement).checked)

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -18,6 +18,7 @@ import { ApiError, displayNick, type Network, visitorNetworkNick } from "./lib/a
 import { getSubject, token } from "./lib/auth";
 import { autoAwayDebounceValue, loadAutoAwayDebounce, saveAutoAwayDebounce } from "./lib/autoAway";
 import { createBackdropDismiss } from "./lib/backdropDismiss";
+import { playBeep } from "./lib/beep";
 import { type ChannelKey, decodeChannelKey } from "./lib/channelKey";
 import { getColoredNicklist } from "./lib/colorNicklist";
 import {
@@ -48,6 +49,12 @@ import {
 } from "./lib/lifecycle";
 import { networks, user } from "./lib/networks";
 import { mirrorNotificationPrefs, notificationPrefs } from "./lib/notificationPrefs";
+import {
+  DEFAULT_NOTIFICATION_SOUND,
+  NOTIFICATION_SOUND_PRESETS,
+  NOTIFICATION_SOUNDS,
+  type NotificationSound,
+} from "./lib/notificationSound";
 import { popOverlay, pushOverlay } from "./lib/overlayScrollLock";
 import {
   loadShowPeerProfiles,
@@ -752,6 +759,14 @@ const SettingsDrawer: Component<Props> = (props) => {
     const current = prefs();
     if (typeof current[key] !== "boolean") return;
     void savePrefs({ ...current, [key]: checked });
+  };
+
+  // #1480 — the drawer writes the sound through its OWN hydrated form, like
+  // every checkbox here. The `/beep` verb cannot: it holds no form, so it goes
+  // through `notificationPrefs.applyNotificationSound`, which re-GETs first.
+  // Same split as the mute picker (#950), same reason.
+  const setNotificationSound = (sound: NotificationSound) => {
+    void savePrefs({ ...prefs(), notification_sound: sound });
   };
 
   const commitChannelsOnly = () => {
@@ -2395,6 +2410,53 @@ const SettingsDrawer: Component<Props> = (props) => {
                   {pushBanner()}
                 </p>
               </Show>
+
+              <hr />
+
+              {/* #1480 — the in-app beep preset. FIRST in the section, above
+                  the trigger checkboxes, because "make it stop making that
+                  noise" is what sends people here and it is the one control
+                  that answers it; the checkboxes answer "when", which is the
+                  question you ask second. Default is `silent`, so for most
+                  subjects this select is the opt-IN. */}
+              <h3>sound</h3>
+              <p class="prefs-hint">
+                Played in the app when a conversation you are not looking at notifies you. Silent by
+                default — the browser notification is a separate switch above.
+              </p>
+              <label class="prefs-list">
+                notification sound:
+                <select
+                  value={prefs().notification_sound ?? DEFAULT_NOTIFICATION_SOUND}
+                  disabled={savingPrefs()}
+                  onChange={(e) =>
+                    setNotificationSound(
+                      (e.currentTarget as HTMLSelectElement).value as NotificationSound,
+                    )
+                  }
+                  data-testid="pref-notification-sound"
+                >
+                  <For each={NOTIFICATION_SOUNDS}>
+                    {(name) => (
+                      <option value={name}>{NOTIFICATION_SOUND_PRESETS[name].label}</option>
+                    )}
+                  </For>
+                </select>
+              </label>
+              {/* Not decoration. Browsers keep the AudioContext suspended until
+                  a user gesture, and the live notify path has no gesture of its
+                  own — it leans on "something was clicked earlier this session".
+                  A deliberate tap here IS that gesture, made on the very surface
+                  where the choice is being made, so the first real notification
+                  after choosing is audible instead of swallowed. */}
+              <button
+                type="button"
+                class="prefs-preview"
+                onClick={() => playBeep(prefs().notification_sound ?? DEFAULT_NOTIFICATION_SOUND)}
+                data-testid="pref-notification-sound-preview"
+              >
+                preview
+              </button>
 
               <hr />
 

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -803,6 +803,67 @@ describe("SettingsDrawer notification sound — #1480", () => {
     // is selected NOW, not the value the drawer loaded with.
     expect(beep.playBeep).toHaveBeenCalledWith("chime");
   });
+
+  // The `/beep` verb is a SECOND writer of this key, exactly as the rail
+  // picker is a second writer of `muted_targets` (#950, and see the sibling
+  // test below). It holds no form, so it writes through
+  // `applyNotificationSound` and feeds the shared mirror the server's echo —
+  // the drawer never hears about it. A picker reading the drawer's own
+  // mount-time snapshot then shows `none` to someone who just typed
+  // `/beep chime`, which is the CI red this pair was written for.
+  it("shows a preset another surface wrote after the drawer had already loaded", async () => {
+    const { mirrorNotificationPrefs } = await import("../lib/notificationPrefs");
+    const userSettings = await import("../lib/userSettings");
+    await openPush();
+
+    // What `applyNotificationSound` does on its PUT's echo — no drawer
+    // re-open, no second GET, exactly as `/beep chime` leaves things.
+    mirrorNotificationPrefs({
+      ...userSettings.DEFAULT_NOTIFICATION_PREFS,
+      notification_sound: "chime",
+    });
+
+    await waitFor(() => {
+      expect((screen.getByTestId("pref-notification-sound") as HTMLSelectElement).value).toBe(
+        "chime",
+      );
+    });
+  });
+
+  // The half of the defect the picker does not show, and the worse half: this
+  // endpoint is a FULL replace, so a form that merges over its stale snapshot
+  // writes the stale sound back. Ticking an unrelated checkbox would then
+  // silently undo a `/beep` — a lost preference, not a display lag.
+  it("carries a preset another surface wrote into an unrelated pref save", async () => {
+    const { mirrorNotificationPrefs } = await import("../lib/notificationPrefs");
+    const userSettings = await import("../lib/userSettings");
+    await openPush();
+
+    mirrorNotificationPrefs({
+      ...userSettings.DEFAULT_NOTIFICATION_PREFS,
+      notification_sound: "chime",
+    });
+    await waitFor(() => {
+      expect((screen.getByTestId("pref-notification-sound") as HTMLSelectElement).value).toBe(
+        "chime",
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("pref-channel-all"));
+    await waitFor(() => {
+      expect(userSettings.putNotificationPrefs).toHaveBeenCalled();
+    });
+
+    const body = (userSettings.putNotificationPrefs as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(body[1]).toEqual({
+      ...userSettings.DEFAULT_NOTIFICATION_PREFS,
+      notification_sound: "chime",
+      channel_messages_all: true,
+    });
+  });
 });
 
 describe("SettingsDrawer muted conversations — #866", () => {

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -325,8 +325,16 @@ vi.mock("../DeleteAccountModal", async () => {
   };
 });
 
+// #1480 — jsdom has no Web Audio, so the real `playBeep` is a silent no-op
+// and the preview button would be untestable. Mocked so the preset it plays
+// becomes observable.
+vi.mock("../lib/beep", () => ({
+  playBeep: vi.fn(),
+}));
+
 import { channelKey } from "../lib/channelKey";
 import { deleteAccountBody } from "../lib/lifecycle";
+import { NOTIFICATION_SOUNDS } from "../lib/notificationSound";
 import { SHARE_SESSION_LABEL } from "../lib/shareModal";
 import SettingsDrawer from "../SettingsDrawer";
 
@@ -725,6 +733,78 @@ describe("SettingsDrawer notifications section", () => {
 // free-text line of channel names is bad UX") in favour of a picker over the
 // conversations you actually have, with each mute rendered as its own
 // removable row.
+// #1480 — the notification-sound picker. Two things are load-bearing here and
+// neither is the select existing: that saving the sound carries the WHOLE map
+// (the endpoint is a full replace, so a partial body would 422 or reset the
+// subject's other prefs), and that the preview reaches the same `playBeep`
+// door the live notify path uses.
+describe("SettingsDrawer notification sound — #1480", () => {
+  const openPush = async () => {
+    const userSettings = await import("../lib/userSettings");
+    wrap(true);
+    openSub("push-settings-entry");
+    await waitFor(() => {
+      expect(userSettings.getNotificationPrefs).toHaveBeenCalled();
+    });
+  };
+
+  it("offers every preset the closed set defines, defaulting to silence", async () => {
+    await openPush();
+
+    const select = screen.getByTestId("pref-notification-sound") as HTMLSelectElement;
+    // Read from the production table, not a literal list: a test that spelled
+    // the presets out would keep passing while the two lists diverged, which
+    // is exactly the drift that makes a picker offer a name the server 422s.
+    expect([...select.options].map((o) => o.value)).toEqual([...NOTIFICATION_SOUNDS]);
+    expect(select.value).toBe("none");
+  });
+
+  it("choosing a preset PUTs the whole prefs map with only the sound changed", async () => {
+    const userSettings = await import("../lib/userSettings");
+    await openPush();
+
+    fireEvent.change(screen.getByTestId("pref-notification-sound"), {
+      target: { value: "xp_notify" },
+    });
+
+    await waitFor(() => {
+      expect(userSettings.putNotificationPrefs).toHaveBeenCalled();
+    });
+
+    const body = (userSettings.putNotificationPrefs as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    // The trap #1480 names outright: this endpoint is a full replace, so a
+    // form that did not carry the new field would silently reset the sound
+    // every time any other notification pref was saved — and vice versa.
+    expect(body[1]).toEqual({
+      ...userSettings.DEFAULT_NOTIFICATION_PREFS,
+      notification_sound: "xp_notify",
+    });
+  });
+
+  it("the preview plays the SELECTED preset without waiting for a message", async () => {
+    const beep = await import("../lib/beep");
+    await openPush();
+
+    fireEvent.change(screen.getByTestId("pref-notification-sound"), {
+      target: { value: "chime" },
+    });
+    await waitFor(() => {
+      expect((screen.getByTestId("pref-notification-sound") as HTMLSelectElement).value).toBe(
+        "chime",
+      );
+    });
+    fireEvent.click(screen.getByTestId("pref-notification-sound-preview"));
+
+    // Not decoration: this click is the user gesture that un-suspends the
+    // AudioContext, on the surface where the choice is made. It must play what
+    // is selected NOW, not the value the drawer loaded with.
+    expect(beep.playBeep).toHaveBeenCalledWith("chime");
+  });
+});
+
 describe("SettingsDrawer muted conversations — #866", () => {
   // #1038 — the stored key is the composite ChannelKey. Built with the
   // production `channelKey` so these tests speak the app's grammar; the SHAPE

--- a/cicchetto/src/__tests__/beep.test.ts
+++ b/cicchetto/src/__tests__/beep.test.ts
@@ -25,6 +25,7 @@ type StartedOsc = {
 type FakeContext = {
   state: AudioContextState;
   currentTime: number;
+  constructed: number;
   resumes: number;
   oscillators: StartedOsc[];
   bufferSources: Array<{ buffer: AudioBuffer | null; started: boolean }>;
@@ -48,6 +49,7 @@ function installFakeAudio(): void {
   fake = {
     state: "running",
     currentTime: 0,
+    constructed: 0,
     resumes: 0,
     oscillators: [],
     bufferSources: [],
@@ -56,6 +58,9 @@ function installFakeAudio(): void {
   decodeFails = false;
 
   class FakeAudioContext {
+    constructor() {
+      fake.constructed += 1;
+    }
     get state() {
       return fake.state;
     }
@@ -182,12 +187,13 @@ describe("playBeep — the silent preset (#1480)", () => {
 
     playBeep("none");
 
-    // Negative control for the assertion above: the same call with a real
-    // preset DOES build one, so the zero is a property of `none` and not of
-    // the harness.
-    expect(fake.resumes).toBe(0);
+    expect(fake.constructed).toBe(0);
+
+    // Negative control: the same module instance DOES build one for a real
+    // preset, so the zero above is a property of `none` and not of a harness
+    // that never wires the constructor up.
     playBeep("tone");
-    expect(fake.oscillators).toHaveLength(1);
+    expect(fake.constructed).toBe(1);
   });
 });
 

--- a/cicchetto/src/__tests__/beep.test.ts
+++ b/cicchetto/src/__tests__/beep.test.ts
@@ -1,0 +1,352 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NOTIFICATION_SOUND_PRESETS } from "../lib/notificationSound";
+
+// #1480 — the preset player.
+//
+// Playwright cannot hear anything and neither can jsdom, so what is testable
+// here is what `playBeep` SCHEDULES: which nodes it builds, at which
+// frequencies, from which buffer, and — the load-bearing one — when it does
+// nothing at all. The fake AudioContext below records exactly that.
+//
+// The recipes themselves (which Hz, how long) are DATA in
+// `notificationSound.ts` and are read from there rather than restated: a test
+// that hardcoded 440 would pin this file's opinion of the table instead of the
+// wiring under test. The one exception is the silent/stamp contract, which is
+// the ruling and is asserted as literals.
+
+type StartedOsc = {
+  type: OscillatorType;
+  freqAt: Array<{ value: number; at: number }>;
+  ramps: Array<{ value: number; at: number }>;
+  startedAt: number;
+  stoppedAt: number;
+};
+
+type FakeContext = {
+  state: AudioContextState;
+  currentTime: number;
+  resumes: number;
+  oscillators: StartedOsc[];
+  bufferSources: Array<{ buffer: AudioBuffer | null; started: boolean }>;
+  decoded: ArrayBuffer[];
+};
+
+let fake: FakeContext;
+let decodeFails: boolean;
+
+const makeGain = () => ({
+  gain: {
+    setValueAtTime: () => {},
+    linearRampToValueAtTime: () => {},
+    exponentialRampToValueAtTime: () => {},
+    value: 0,
+  },
+  connect: (next: unknown) => next,
+});
+
+function installFakeAudio(): void {
+  fake = {
+    state: "running",
+    currentTime: 0,
+    resumes: 0,
+    oscillators: [],
+    bufferSources: [],
+    decoded: [],
+  };
+  decodeFails = false;
+
+  class FakeAudioContext {
+    get state() {
+      return fake.state;
+    }
+    get currentTime() {
+      return fake.currentTime;
+    }
+    resume() {
+      fake.resumes += 1;
+      fake.state = "running";
+      return Promise.resolve();
+    }
+    createOscillator() {
+      const rec: StartedOsc = {
+        type: "sine",
+        freqAt: [],
+        ramps: [],
+        startedAt: Number.NaN,
+        stoppedAt: Number.NaN,
+      };
+      fake.oscillators.push(rec);
+      return {
+        set type(v: OscillatorType) {
+          rec.type = v;
+        },
+        get type() {
+          return rec.type;
+        },
+        frequency: {
+          setValueAtTime: (value: number, at: number) => rec.freqAt.push({ value, at }),
+          linearRampToValueAtTime: (value: number, at: number) => rec.ramps.push({ value, at }),
+        },
+        connect: (next: unknown) => next,
+        start: (at: number) => {
+          rec.startedAt = at;
+        },
+        stop: (at: number) => {
+          rec.stoppedAt = at;
+        },
+      };
+    }
+    createGain() {
+      return makeGain();
+    }
+    createBufferSource() {
+      const rec = { buffer: null as AudioBuffer | null, started: false };
+      fake.bufferSources.push(rec);
+      return {
+        set buffer(b: AudioBuffer | null) {
+          rec.buffer = b;
+        },
+        get buffer() {
+          return rec.buffer;
+        },
+        connect: (next: unknown) => next,
+        start: () => {
+          rec.started = true;
+        },
+      };
+    }
+    decodeAudioData(bytes: ArrayBuffer) {
+      fake.decoded.push(bytes);
+      if (decodeFails) return Promise.reject(new Error("bad mp3"));
+      return Promise.resolve({ duration: 0.5 } as unknown as AudioBuffer);
+    }
+  }
+
+  vi.stubGlobal("AudioContext", FakeAudioContext);
+  (window as unknown as { AudioContext: unknown }).AudioContext = FakeAudioContext;
+}
+
+// `noUncheckedIndexedAccess` is on, and biome bans the `!` shortcut, so array
+// access goes through this: a missing element is a harness bug and should say
+// so loudly rather than surface three lines later as "expected undefined".
+const at = <T>(xs: readonly T[], i: number): T => {
+  const v = xs[i];
+  if (v === undefined) throw new Error(`beep test harness: no element at index ${i}`);
+  return v;
+};
+
+// Every test needs a module instance whose lazily-built AudioContext (and
+// whose sample cache) is its own — both are module-level singletons, so a
+// shared import would let one test's decode satisfy the next one's assertion.
+async function freshBeep() {
+  vi.resetModules();
+  return await import("../lib/beep");
+}
+
+beforeEach(() => {
+  installFakeAudio();
+  window.__lastBeepAt = undefined;
+  // A FRESH Response per call, not one shared instance: a body can only be
+  // read once, so `mockResolvedValue(new Response(...))` makes the second
+  // fetch of the session fail inside `arrayBuffer()`. That is the harness
+  // lying, not the module — measured while writing this file, where it turned
+  // both the cache-eviction and the two-assets tests red for a reason that
+  // does not exist in a browser.
+  vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+    Promise.resolve(new Response(new Uint8Array([1, 2, 3]), { status: 200 })),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  window.__lastBeepAt = undefined;
+});
+
+describe("playBeep — the silent preset (#1480)", () => {
+  it("schedules nothing and does NOT stamp the seam", async () => {
+    const { playBeep } = await freshBeep();
+
+    playBeep("none");
+
+    expect(fake.oscillators).toHaveLength(0);
+    expect(fake.bufferSources).toHaveLength(0);
+    // The discriminating assertion. `none` is the DEFAULT, so a seam that
+    // ticked here would report "beeped" for every subject who never opted in
+    // — which is everyone — and the e2e oracle would be green on silence.
+    expect(window.__lastBeepAt).toBeUndefined();
+  });
+
+  it("does not even build an AudioContext", async () => {
+    const { playBeep } = await freshBeep();
+
+    playBeep("none");
+
+    // Negative control for the assertion above: the same call with a real
+    // preset DOES build one, so the zero is a property of `none` and not of
+    // the harness.
+    expect(fake.resumes).toBe(0);
+    playBeep("tone");
+    expect(fake.oscillators).toHaveLength(1);
+  });
+});
+
+describe("playBeep — synthesised presets (#1480)", () => {
+  it("plays the 440 Hz tone cic shipped before the preset pack", async () => {
+    const { playBeep } = await freshBeep();
+
+    playBeep("tone");
+
+    const preset = NOTIFICATION_SOUND_PRESETS.tone;
+    if (preset.kind !== "synth") throw new Error("tone must stay a synth preset");
+    const voice = at(preset.voices, 0);
+
+    expect(fake.oscillators).toHaveLength(1);
+    const osc = at(fake.oscillators, 0);
+    expect(osc.type).toBe(voice.wave);
+    expect(at(osc.freqAt, 0).value).toBe(voice.fromHz);
+    expect(osc.stoppedAt - osc.startedAt).toBeCloseTo(voice.durationMs / 1000, 6);
+  });
+
+  it("schedules one oscillator per voice, offset by the recipe's atMs", async () => {
+    const { playBeep } = await freshBeep();
+    fake.currentTime = 10;
+
+    playBeep("chime");
+
+    const preset = NOTIFICATION_SOUND_PRESETS.chime;
+    if (preset.kind !== "synth") throw new Error("chime must stay a synth preset");
+
+    expect(fake.oscillators).toHaveLength(preset.voices.length);
+    // The second note is what makes it a chime rather than a tone: if the
+    // offset were dropped both voices would fire together and the preset
+    // would be an interval, not a sequence.
+    expect(at(fake.oscillators, 1).startedAt - at(fake.oscillators, 0).startedAt).toBeCloseTo(
+      at(preset.voices, 1).atMs / 1000,
+      6,
+    );
+  });
+
+  it("ramps a swept voice to its end frequency instead of holding the start", async () => {
+    const { playBeep } = await freshBeep();
+
+    playBeep("blip");
+
+    const preset = NOTIFICATION_SOUND_PRESETS.blip;
+    if (preset.kind !== "synth") throw new Error("blip must stay a synth preset");
+
+    const voice = at(preset.voices, 0);
+    expect(at(at(fake.oscillators, 0).freqAt, 0).value).toBe(voice.fromHz);
+    expect(at(at(fake.oscillators, 0).ramps, 0).value).toBe(voice.toHz);
+    expect(voice.toHz).not.toBe(voice.fromHz);
+  });
+
+  it("stamps the seam on the attempt", async () => {
+    const { playBeep } = await freshBeep();
+
+    playBeep("pop");
+
+    expect(typeof window.__lastBeepAt).toBe("number");
+  });
+
+  it("resumes a suspended context so the next gesture is not needed", async () => {
+    const { playBeep } = await freshBeep();
+    fake.state = "suspended";
+
+    playBeep("tone");
+
+    expect(fake.resumes).toBe(1);
+  });
+});
+
+describe("playBeep — sampled presets (#1480)", () => {
+  it("fetches the preset's asset and plays the decoded buffer", async () => {
+    const { playBeep } = await freshBeep();
+    const preset = NOTIFICATION_SOUND_PRESETS.icq;
+    if (preset.kind !== "sample") throw new Error("icq must stay a sampled preset");
+
+    playBeep("icq");
+    await vi.waitFor(() => expect(fake.bufferSources).toHaveLength(1));
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(preset.url);
+    expect(at(fake.bufferSources, 0).started).toBe(true);
+    expect(at(fake.bufferSources, 0).buffer).not.toBeNull();
+    // No oscillator: a sampled preset must not also synthesise, or the two
+    // species would stack on top of each other.
+    expect(fake.oscillators).toHaveLength(0);
+  });
+
+  it("decodes each asset once and replays the cached buffer", async () => {
+    const { playBeep } = await freshBeep();
+
+    playBeep("xp_notify");
+    await vi.waitFor(() => expect(fake.bufferSources).toHaveLength(1));
+    playBeep("xp_notify");
+    await vi.waitFor(() => expect(fake.bufferSources).toHaveLength(2));
+
+    expect(fake.decoded).toHaveLength(1);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps different presets on different assets", async () => {
+    const { playBeep } = await freshBeep();
+
+    playBeep("xp_ding");
+    playBeep("xp_balloon");
+    await vi.waitFor(() => expect(fake.bufferSources).toHaveLength(2));
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("a failed decode is swallowed AND evicted, so the next attempt retries", async () => {
+    const { playBeep } = await freshBeep();
+    decodeFails = true;
+
+    playBeep("xp_exclamation");
+    await vi.waitFor(() => expect(fake.decoded).toHaveLength(1));
+    expect(fake.bufferSources).toHaveLength(0);
+
+    // The eviction is the point: caching a rejected promise would poison the
+    // preset for the rest of the session, so one bad response on a flaky
+    // network would silence the operator until they reload.
+    decodeFails = false;
+    playBeep("xp_exclamation");
+    await vi.waitFor(() => expect(fake.bufferSources).toHaveLength(1));
+  });
+
+  it("a failed fetch never reaches the decoder and never throws", async () => {
+    const { playBeep } = await freshBeep();
+    vi.mocked(globalThis.fetch).mockResolvedValue(new Response("gone", { status: 404 }));
+
+    expect(() => playBeep("icq")).not.toThrow();
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+
+    expect(fake.decoded).toHaveLength(0);
+    expect(fake.bufferSources).toHaveLength(0);
+  });
+});
+
+describe("playBeep — failure posture (#1480)", () => {
+  it("a browser with no AudioContext is a no-op, not a crash", async () => {
+    vi.stubGlobal("AudioContext", undefined);
+    (window as unknown as { AudioContext: unknown }).AudioContext = undefined;
+    (window as unknown as { webkitAudioContext: unknown }).webkitAudioContext = undefined;
+    const { playBeep } = await freshBeep();
+
+    expect(() => playBeep("tone")).not.toThrow();
+  });
+
+  it("a throwing node constructor is swallowed — the WS handler must survive", async () => {
+    const { playBeep } = await freshBeep();
+    // First build the context, THEN break it: the throw has to happen inside
+    // the try, which is where a real invalid-state error would land.
+    playBeep("tone");
+    const ctx = fake;
+    ctx.oscillators = [];
+    vi.spyOn(window.AudioContext.prototype, "createOscillator").mockImplementation(() => {
+      throw new Error("InvalidStateError");
+    });
+
+    expect(() => playBeep("tone")).not.toThrow();
+  });
+});

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -158,6 +158,23 @@ vi.mock("../lib/settingsNav", () => ({
   settingsOpenTick: vi.fn(() => 0),
 }));
 
+// #1480 — `/beep` writes a server pref and plays the preset it just chose.
+// Both seams are mocked: the write so the arm does not reach `fetch`, and the
+// player because jsdom has no Web Audio at all, so the real one would be a
+// silent no-op and the confirmation half of the arm would be untestable.
+vi.mock("../lib/notificationPrefs", () => ({
+  applyNotificationSound: vi.fn().mockResolvedValue(undefined),
+  applyConversationMute: vi.fn().mockResolvedValue(undefined),
+  clearConversationMute: vi.fn().mockResolvedValue(undefined),
+  notificationPrefs: vi.fn(() => ({})),
+  mirrorNotificationPrefs: vi.fn(),
+  refreshNotificationPrefs: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../lib/beep", () => ({
+  playBeep: vi.fn(),
+}));
+
 // #248 — compose marks a /lusers request solicited so the incoming
 // bundle surfaces the card (the connect-welcome auto-emit does not).
 vi.mock("../lib/lusersBundle", () => ({
@@ -5111,6 +5128,72 @@ describe("compose submit — /credits (#1958)", () => {
   });
 });
 
+// #1480 — `/beep` is the shortcut into the notification-sound preference. It
+// PERSISTS (server round-trip, converges across devices) rather than flipping
+// a local flag, and it plays what it selected: the confirmation is the sound,
+// and that tap is also the gesture that un-suspends the AudioContext.
+describe("compose submit — /beep (#1480)", () => {
+  it("/beep <preset> persists the preset, plays it, and confirms by name", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const prefs = await import("../lib/notificationPrefs");
+    const beep = await import("../lib/beep");
+    const sb = await import("../lib/scrollback");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/beep chime");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(prefs.applyNotificationSound).toHaveBeenCalledWith("chime");
+    expect(beep.playBeep).toHaveBeenCalledWith("chime");
+    expect(sb.sendMessage).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: "beep: chime" });
+  });
+
+  it("/beep off persists silence — and does not send anything to the network", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const prefs = await import("../lib/notificationPrefs");
+    const sb = await import("../lib/scrollback");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/beep off");
+    await compose.submit(k, "freenode", "#a");
+
+    expect(prefs.applyNotificationSound).toHaveBeenCalledWith("none");
+    expect(sb.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("bare /beep opens the settings sub-page and writes nothing", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const nav = await import("../lib/settingsNav");
+    const prefs = await import("../lib/notificationPrefs");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/beep");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(nav.requestOpenSettings).toHaveBeenCalledWith("push");
+    expect(prefs.applyNotificationSound).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("a rejected write surfaces as an error instead of a confirmation", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const prefs = await import("../lib/notificationPrefs");
+    const beep = await import("../lib/beep");
+    vi.mocked(prefs.applyNotificationSound).mockRejectedValueOnce(new Error("save_failed"));
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/beep icq");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    // No silent-swallow: a preference that did not land must not be confirmed,
+    // and the sound must not play either — it would be the one piece of
+    // feedback claiming the write worked.
+    expect(result).not.toEqual({ ok: 'beep: ICQ "uh-oh"' });
+    expect(beep.playBeep).not.toHaveBeenCalled();
+  });
+});
+
 // #356 — watch-family dispatch: keyword highlight (/hilight add, /dehilight
 // del, /highlight alias) + presence (/notify, /watch alias) as classic-IRC
 // irssi-direct verbs; a bare form opens the watch-lists settings section
@@ -5693,6 +5776,7 @@ const DISPATCH_CASE_LABELS = [
   "away",
   "ban",
   "banlist",
+  "beep",
   "connect",
   "ctcp",
   "cycle",
@@ -5845,6 +5929,10 @@ const DISPATCH_DRAFTS: ReadonlyArray<{ kind: SlashCommand["kind"]; draft: string
   { kind: "unalias", draft: "/unalias hi" },
   { kind: "open-settings", draft: "/watch" },
   { kind: "open-credits", draft: "/credits" },
+  // #1480 — a NAMED preset, not `on`/`off`: those two resolve in the parser,
+  // so a row using either would pin the same arm while leaving the alias
+  // resolution itself outside the net (that half lives in slashCommands.test).
+  { kind: "beep", draft: "/beep chime" },
   { kind: "service-modal", draft: "/ns" },
   { kind: "error", draft: "/nosuchverb" },
 ];
@@ -5856,12 +5944,14 @@ const MOCKED_SEAM_MODULES = [
   "../lib/aliasList",
   "../lib/api",
   "../lib/banlistModal",
+  "../lib/beep",
   "../lib/channelDirectory",
   "../lib/creditsModal",
   "../lib/members",
   "../lib/mentionsWindow",
   "../lib/modeModal",
   "../lib/networks",
+  "../lib/notificationPrefs",
   "../lib/queryWindows",
   "../lib/scrollback",
   "../lib/selection",
@@ -5941,12 +6031,12 @@ describe("#1396 — dispatch characterization over every arm", () => {
       misparsed,
     }).toMatchInlineSnapshot(`
       {
-        "arms": 64,
+        "arms": 65,
         "armsWithNoDraft": [],
         "draftsNamingNoArm": [],
         "duplicated": [],
         "misparsed": [],
-        "rows": 64,
+        "rows": 65,
       }
     `);
   });
@@ -6068,6 +6158,17 @@ describe("#1396 — dispatch characterization over every arm", () => {
           ],
           "result": {
             "ok": true,
+          },
+        },
+        "beep": {
+          "effects": [
+            "aliasList.aliases()",
+            "beep.playBeep("chime")",
+            "networks.networkIdBySlug("freenode")",
+            "notificationPrefs.applyNotificationSound("chime")",
+          ],
+          "result": {
+            "ok": "beep: chime",
           },
         },
         "connect": {
@@ -6759,7 +6860,7 @@ describe("#1396 — dispatch characterization over every arm", () => {
           "aliasList.aliases()",
           "networks.networkIdBySlug("freenode")",
         ],
-        "arms": 64,
+        "arms": 65,
         "indistinguishablePairs": [
           [
             "ame",

--- a/cicchetto/src/__tests__/notificationPrefs.test.ts
+++ b/cicchetto/src/__tests__/notificationPrefs.test.ts
@@ -3,6 +3,7 @@ import { setToken } from "../lib/auth";
 import { channelKey } from "../lib/channelKey";
 import {
   applyConversationMute,
+  applyNotificationSound,
   clearConversationMute,
   mirrorNotificationPrefs,
   notificationPrefs,
@@ -305,5 +306,62 @@ describe("conversation mute writer — #950", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope", { status: 500 }));
 
     await expect(applyConversationMute(NOISY, 1_800_000_600)).rejects.toBeDefined();
+  });
+
+  // #1480 — the sound writer rides the SAME GET-merge-PUT verb, so it inherits
+  // the additivity above rather than restating it. What is asserted here is
+  // only what is new: the key it moves, and that it moves nothing else.
+  describe("notification sound writer — #1480", () => {
+    it("PUTs the chosen preset without disturbing the rest of the map", async () => {
+      const spy = mockGetThenPut();
+
+      await applyNotificationSound("xp_notify");
+
+      const body = putBody(spy);
+      expect(body.notification_sound).toBe("xp_notify");
+      // The additive property, on this verb: an opted-in subject typing
+      // `/beep icq` must not lose the mute or the whitelist they configured
+      // in the drawer.
+      expect(body.muted_targets).toMatchObject({ [ALREADY]: { until: null } });
+      expect(body.channel_messages_only).toEqual(["#italia"]);
+      expect(body.channel_mentions).toBe(false);
+    });
+
+    it("adopts the echo so the live beep path plays the new preset at once", async () => {
+      mockGetThenPut();
+
+      await applyNotificationSound("chime");
+
+      expect(notificationPrefs().notification_sound).toBe("chime");
+    });
+
+    it("propagates a failed write instead of reporting a preset that never landed", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope", { status: 500 }));
+
+      await expect(applyNotificationSound("chime")).rejects.toBeDefined();
+    });
+  });
+});
+
+// #1480 — the identity reset is what stops account B inheriting account A's
+// sound. It has the same shape as the rest of the store (one signal, reset to
+// the server defaults on identity change), but it is worth its own assertion:
+// the default is SILENCE, so a reset that missed this key would leave the new
+// account audibly notifying on a preference it never chose.
+describe("notification sound — identity scoping (#1480)", () => {
+  it("a logout returns the sound to silence, not to the previous account's pick", async () => {
+    vi.resetModules();
+    const fresh = await import("../lib/notificationPrefs");
+    const auth = await import("../lib/auth");
+
+    fresh.mirrorNotificationPrefs({
+      ...DEFAULT_NOTIFICATION_PREFS,
+      notification_sound: "xp_exclamation",
+    });
+    expect(fresh.notificationPrefs().notification_sound).toBe("xp_exclamation");
+
+    auth.setToken(null);
+
+    expect(fresh.notificationPrefs().notification_sound).toBe("none");
   });
 });

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -1464,6 +1464,49 @@ describe("parseSlash — /notify + /watch presence (#356: irssi-direct, bare →
   });
 });
 
+// #1480 — `/beep`, vjt's shape: bare opens the settings, `on`/`off` are
+// shorthands for two presets, anything else is a preset name.
+describe("parseSlash — /beep (#1480)", () => {
+  it("bare /beep opens the settings sub-page that holds the picker", () => {
+    expect(parseSlash("/beep")).toEqual({ kind: "open-settings", section: "push" });
+  });
+
+  it("/beep on selects the 440 Hz tone, NOT the default", () => {
+    // The discriminating pair. `on` and the DEFAULT are different values since
+    // this issue: the shipped state is silence and `on` is the opt-in. A
+    // handler that resolved `on` to "the default preset" would make `/beep on`
+    // mean `/beep off`, and both tests below would still pass individually.
+    expect(parseSlash("/beep on")).toEqual({ kind: "beep", sound: "tone" });
+  });
+
+  it("/beep off selects silence", () => {
+    expect(parseSlash("/beep off")).toEqual({ kind: "beep", sound: "none" });
+  });
+
+  it("/beep <preset> selects that preset by name", () => {
+    expect(parseSlash("/beep icq")).toEqual({ kind: "beep", sound: "icq" });
+    expect(parseSlash("/beep xp_notify")).toEqual({ kind: "beep", sound: "xp_notify" });
+  });
+
+  it("the preset name is case-insensitive, like every other verb argument here", () => {
+    expect(parseSlash("/beep XP_Ding")).toEqual({ kind: "beep", sound: "xp_ding" });
+  });
+
+  it("an unknown name errors and names the set rather than just refusing", () => {
+    const result = parseSlash("/beep airhorn");
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") throw new Error("unreachable");
+    // The operator asked for a sound by name; "unknown preset" would send them
+    // to the settings drawer to find out what the names are.
+    expect(result.message).toContain("airhorn");
+    expect(result.message).toContain("xp_ding");
+  });
+
+  it("//beep is a literal message, not the verb (the #427 escape holds)", () => {
+    expect(parseSlash("//beep off")).toEqual({ kind: "privmsg", body: "/beep off" });
+  });
+});
+
 describe("#385 — expandAlias grammar", () => {
   it("positional $1 substitution (whois-with-idle motivating example)", () => {
     // /wii foo → whois foo foo. This also pins the NO-implicit-append half of

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -3610,6 +3610,12 @@ describe("subscribe - not-joined pre-subscribe loop (CP15 B5 fix + #78)", () => 
 //
 // Negative cases mirror the existing mention-bump gates so a
 // regression in either path surfaces here first.
+//
+// #1480 — `playBeep` now takes the subject's preset. The call counts below are
+// unchanged on purpose: WHETHER to alert is still this path's decision, and
+// `none` (the default) is a no-op inside `playBeep`, not a missing call —
+// keeping the badge bump alongside it. The ARGUMENT is asserted separately, at
+// the end of this block.
 describe("subscribe — UX-6-L foreground beep wiring", () => {
   it("PRIVMSG mentioning own nick on non-selected channel calls playBeep", async () => {
     localStorage.setItem("grappa-token", "tok");
@@ -3912,6 +3918,64 @@ describe("subscribe — UX-6-L foreground beep wiring", () => {
     });
 
     expect(beep.playBeep).not.toHaveBeenCalled();
+  });
+
+  // #1480 — WHICH sound. The preset is the subject's server pref, passed as
+  // data so `beep.ts` reads no store and the settings preview reaches the same
+  // door. These two are the whole argument contract.
+  it("passes the subject's chosen preset to playBeep", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    setNotificationPrefsForTest({ ...DEFAULT_NOTIFICATION_PREFS, notification_sound: "icq" });
+    await seedStubs();
+    const beep = await import("../lib/beep");
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalled();
+    });
+
+    store.setSelectedChannel({
+      networkSlug: "freenode",
+      channelName: "#cicchetto",
+      kind: "channel",
+    });
+
+    fireMessageEvent("#grappa", { id: 307, kind: "privmsg", body: "alice ping" });
+
+    expect(beep.playBeep).toHaveBeenCalledWith("icq");
+  });
+
+  it("falls back to the default preset when the BEAM predates the key", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    // The field is optional on the wire (#618: cic ships independently of the
+    // BEAM), so the live path must have an answer for a prefs map that simply
+    // does not carry it — and that answer is silence, never `undefined`
+    // reaching the preset table as a key.
+    const { notification_sound: _dropped, ...withoutSound } = DEFAULT_NOTIFICATION_PREFS;
+    setNotificationPrefsForTest(withoutSound as typeof DEFAULT_NOTIFICATION_PREFS);
+    await seedStubs();
+    const beep = await import("../lib/beep");
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalled();
+    });
+
+    store.setSelectedChannel({
+      networkSlug: "freenode",
+      channelName: "#cicchetto",
+      kind: "channel",
+    });
+
+    fireMessageEvent("#grappa", { id: 308, kind: "privmsg", body: "alice ping" });
+
+    expect(beep.playBeep).toHaveBeenCalledWith("none");
   });
 });
 

--- a/cicchetto/src/__tests__/userSettings.test.ts
+++ b/cicchetto/src/__tests__/userSettings.test.ts
@@ -58,6 +58,12 @@ describe("DEFAULT_NOTIFICATION_PREFS", () => {
       // an un-hydrated client decides beeps with, so a divergence here means
       // the client is silently stricter (or looser) than the push it mirrors.
       muted_targets: {},
+      // #1480 — SILENCE, and the same byte-identity requirement applies: an
+      // un-hydrated client must not beep at a subject the server considers
+      // opted out. Written as a literal rather than as
+      // DEFAULT_NOTIFICATION_SOUND, so this asserts the RULING (default off)
+      // and not merely that two constants agree with each other.
+      notification_sound: "none",
     });
   });
 });

--- a/cicchetto/src/lib/beep.ts
+++ b/cicchetto/src/lib/beep.ts
@@ -1,28 +1,64 @@
 // In-app beep for foreground alerts.
 //
-// UX-6-L (2026-05-20) — when the cic page is foreground and a
-// notification-worthy WS event arrives (channel mention or inbound
-// DM), play a short sine-wave tone instead of relying on the OS
-// notification (which the SW suppresses for visible windows per
-// `lib/pushDedup.ts`).
+// UX-6-L (2026-05-20) — when a notification-worthy WS event arrives (channel
+// mention or inbound DM) for a conversation the operator is NOT looking at,
+// play a short sound instead of relying on the OS notification (which the SW
+// suppresses for visible windows per `lib/pushDedup.ts`).
 //
-// Web Audio API only — no asset bytes, no autoplay-policy
-// negotiation beyond the first user gesture that any cic session
-// already produces (login click, channel switch, etc.). The
-// AudioContext is lazy-initialised on the first call so SSR /
-// older browsers without `AudioContext` don't fail at import time.
+// 🔴 The gate is per-CONVERSATION focus, not page foreground, and this comment
+// used to say the opposite. Measured at the call site (#1480,
+// `lib/subscribe.ts` — `!effectivelyFocused(slug, displayName)`): the beep
+// fires for a background TAB too, as long as the page is alive. That is not a
+// detail — it is exactly the case the deadbeef_ report hit, cicchetto sitting
+// behind a macOS Focus session, and a reader who trusted the old sentence
+// would have looked for the bug in the wrong half of the system.
 //
-// Test seam: when `playBeep` fires it stamps
-// `window.__lastBeepAt = Date.now()` so e2e + CDP smoke can assert
-// on the last-beep timestamp without poking at the AudioContext
-// itself (Playwright cannot observe sound). Production callers
-// don't read the property.
+// ## Which sound (#1480)
+//
+// The preset is DATA — `lib/notificationSound.ts` owns the table — and it
+// arrives as an ARGUMENT, from the caller that already holds the subject's
+// prefs. This module reads no store: same input, same sound, and the settings
+// drawer's preview button reaches the identical door as the live notify path
+// (CLAUDE.md — one feature, one code path, every door).
+//
+// Two species, one exhaustive switch: an oscillator recipe we synthesise, or
+// an mp3 we fetch once and decode into this same `AudioContext`. Decoded
+// buffers are cached in-module, so a preset costs one round trip per session
+// and the service worker serves it from precache offline.
+//
+// Everything is wrapped in a `try` that swallows: audio failure is non-fatal,
+// the unread badge and the sidebar bump still surface the event. The
+// AudioContext is lazy-initialised on the first call so SSR / older browsers
+// without `AudioContext` don't fail at import time.
+//
+// Test seam: when `playBeep` schedules something it stamps
+// `window.__lastBeepAt = Date.now()` so e2e + CDP smoke can assert on the
+// last-beep timestamp without poking at the AudioContext itself (Playwright
+// cannot observe sound). 🔴 `none` returns BEFORE the stamp, deliberately:
+// silence is not an attempt to play, and a seam that ticked for the default
+// preset would report "beeped" for every user who never opted in — which is
+// everybody, which would make the seam useless exactly where the e2e needs
+// it. Production callers don't read the property.
 
-const BEEP_FREQ_HZ = 440;
-const BEEP_DURATION_MS = 80;
-const BEEP_GAIN = 0.1;
+import {
+  NOTIFICATION_SOUND_PRESETS,
+  type NotificationSound,
+  type SoundPreset,
+  type SoundVoice,
+} from "./notificationSound";
+
+// Shared amplitude envelope, in seconds. A bare gain step clicks at both ends;
+// a 5 ms attack and a decay to (near) zero is the cheapest fix that costs no
+// extra node. `exponentialRampToValueAtTime` cannot reach 0, hence the epsilon.
+const ATTACK_S = 0.005;
+const SILENCE_GAIN = 0.0001;
 
 let ctx: AudioContext | null = null;
+
+// url → the decode, memoised. The PROMISE is cached rather than the buffer so
+// two beeps in the same tick share one fetch; a rejection evicts its entry so
+// a later attempt can retry rather than being poisoned for the session.
+const sampleBuffers = new Map<string, Promise<AudioBuffer>>();
 
 declare global {
   interface Window {
@@ -30,42 +66,119 @@ declare global {
   }
 }
 
-export function playBeep(): void {
-  if (typeof window === "undefined") return;
+function audioContext(): AudioContext | null {
   const Ctor =
     window.AudioContext ??
     (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
-  if (!Ctor) return;
+  if (!Ctor) return null;
+  if (ctx === null) ctx = new Ctor();
+  return ctx;
+}
+
+function playVoice(context: AudioContext, voice: SoundVoice, startAt: number): void {
+  const osc = context.createOscillator();
+  const gain = context.createGain();
+  const at = startAt + voice.atMs / 1000;
+  const end = at + voice.durationMs / 1000;
+
+  osc.type = voice.wave;
+  osc.frequency.setValueAtTime(voice.fromHz, at);
+  // Flat when `fromHz === toHz`, which is the common case and costs the same.
+  osc.frequency.linearRampToValueAtTime(voice.toHz, end);
+
+  gain.gain.setValueAtTime(SILENCE_GAIN, at);
+  gain.gain.linearRampToValueAtTime(voice.gain, at + ATTACK_S);
+  gain.gain.exponentialRampToValueAtTime(SILENCE_GAIN, end);
+
+  osc.connect(gain).connect(context.destination);
+  osc.start(at);
+  osc.stop(end);
+}
+
+function decodeSample(context: AudioContext, url: string): Promise<AudioBuffer> {
+  const cached = sampleBuffers.get(url);
+  if (cached !== undefined) return cached;
+
+  const pending = fetch(url)
+    .then((res) => {
+      if (!res.ok) throw new Error(`sound fetch failed: ${res.status}`);
+      return res.arrayBuffer();
+    })
+    .then((bytes) => context.decodeAudioData(bytes))
+    .catch((err) => {
+      sampleBuffers.delete(url);
+      throw err;
+    });
+
+  sampleBuffers.set(url, pending);
+  return pending;
+}
+
+function playSample(context: AudioContext, url: string, peakGain: number): void {
+  // Fire-and-forget: the fetch/decode is async and nothing downstream waits on
+  // the sound. A failure is swallowed for the same reason the synth path's is
+  // — the badge already told the operator something arrived.
+  void decodeSample(context, url)
+    .then((buffer) => {
+      const src = context.createBufferSource();
+      const gain = context.createGain();
+      src.buffer = buffer;
+      gain.gain.value = peakGain;
+      src.connect(gain).connect(context.destination);
+      src.start();
+    })
+    .catch(() => {});
+}
+
+function playPreset(context: AudioContext, preset: SoundPreset): void {
+  switch (preset.kind) {
+    case "silent":
+      return;
+    case "synth": {
+      const now = context.currentTime;
+      for (const voice of preset.voices) playVoice(context, voice, now);
+      return;
+    }
+    case "sample":
+      playSample(context, preset.url, preset.gain);
+      return;
+  }
+}
+
+/**
+ * Play `sound`. Silent presets, unsupported browsers and every audio failure
+ * are no-ops — never a throw, since this runs inside the WS message handler.
+ */
+export function playBeep(sound: NotificationSound): void {
+  if (typeof window === "undefined") return;
+
+  const preset = NOTIFICATION_SOUND_PRESETS[sound];
+  // Before the context is even built: the opted-out majority should not be
+  // constructing an AudioContext on every mention, and the seam below must
+  // stay honest about what was scheduled.
+  if (preset.kind === "silent") return;
 
   try {
-    if (ctx === null) ctx = new Ctor();
-    // Some browsers suspend the context until the next user gesture.
-    // Resume is a no-op if already running; ignore the promise — the
-    // beep simply doesn't play if the resume hasn't completed by the
-    // time the oscillator starts, and the next beep tries again.
-    if (ctx.state === "suspended") void ctx.resume();
+    const context = audioContext();
+    if (context === null) return;
 
-    // Stamp BEFORE the oscillator so the e2e test seam advances even
-    // if `osc.start()` throws (e.g. ctx in an invalid state). The
-    // contract surface this property exposes is "playBeep was
-    // called", not "audio actually played" — the latter is
-    // unobservable from Playwright. Keep stamp tied to the
-    // attempt-to-play, not the success-of-play.
+    // Some browsers suspend the context until the next user gesture. Resume is
+    // a no-op if already running; ignore the promise — the sound simply
+    // doesn't play if the resume hasn't completed in time, and the next one
+    // tries again. The settings preview button exists to make that gesture
+    // deliberately, on the surface where the choice is made.
+    if (context.state === "suspended") void context.resume();
+
+    // Stamp BEFORE scheduling so the seam advances even if a node constructor
+    // throws (e.g. ctx in an invalid state). The contract is "playBeep
+    // scheduled a non-silent preset", not "audio was audible" — the latter is
+    // unobservable from Playwright.
     window.__lastBeepAt = Date.now();
 
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.type = "sine";
-    osc.frequency.value = BEEP_FREQ_HZ;
-    gain.gain.value = BEEP_GAIN;
-    osc.connect(gain).connect(ctx.destination);
-
-    const now = ctx.currentTime;
-    osc.start(now);
-    osc.stop(now + BEEP_DURATION_MS / 1000);
+    playPreset(context, preset);
   } catch {
-    // Audio failure is non-fatal — the unread badge + sidebar bump
-    // still surface the event. Suppress so a beep glitch never
-    // crashes the WS handler.
+    // Audio failure is non-fatal — the unread badge + sidebar bump still
+    // surface the event. Suppress so a beep glitch never crashes the WS
+    // handler.
   }
 }

--- a/cicchetto/src/lib/commands/local.ts
+++ b/cicchetto/src/lib/commands/local.ts
@@ -1,5 +1,8 @@
 import { addAlias, delAlias } from "../aliasList";
+import { playBeep } from "../beep";
 import { openCreditsModal } from "../creditsModal";
+import { applyNotificationSound } from "../notificationPrefs";
+import { NOTIFICATION_SOUND_PRESETS } from "../notificationSound";
 import { requestOpenSettings } from "../settingsNav";
 import type { CommandHandler } from "./context";
 
@@ -49,6 +52,28 @@ export const aliasDefineCommand: CommandHandler<"alias-define"> = async (cmd) =>
 export const unaliasCommand: CommandHandler<"unalias"> = async (cmd) => {
   await delAlias(cmd.name);
   return { ok: `alias: removed /${cmd.name}` };
+};
+
+/**
+ * #1480 — `/beep <preset>` selects the in-app notification sound. The parser
+ * has already narrowed the argument to a real preset name (`on`/`off` resolved
+ * there), so this only has to persist it.
+ *
+ * The write is a server round-trip, not a local flag: the setting converges
+ * across devices like every other preference, and the command is a shortcut
+ * INTO it rather than a parallel store. A rejected PUT throws and the
+ * dispatcher's catch renders it — no silent no-op.
+ *
+ * The confirmation PLAYS the sound it just selected. This is the one place the
+ * feedback can be the thing itself, and it doubles as the user gesture that
+ * un-suspends the AudioContext, exactly like the drawer's preview button —
+ * which matters most here, because someone who reaches for `/beep` is
+ * explicitly avoiding the drawer.
+ */
+export const beepCommand: CommandHandler<"beep"> = async (cmd) => {
+  await applyNotificationSound(cmd.sound);
+  playBeep(cmd.sound);
+  return { ok: `beep: ${NOTIFICATION_SOUND_PRESETS[cmd.sound].label}` };
 };
 
 /**

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -10,6 +10,7 @@ import { fanOutCommand } from "./commands/fanout";
 import { watchlistCommand } from "./commands/highlight";
 import {
   aliasDefineCommand,
+  beepCommand,
   errorCommand,
   openCreditsCommand,
   openSettingsCommand,
@@ -1152,6 +1153,10 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         }
         case "open-credits": {
           result = await openCreditsCommand(cmd, ctx);
+          break;
+        }
+        case "beep": {
+          result = await beepCommand(cmd, ctx);
           break;
         }
         case "quote": {

--- a/cicchetto/src/lib/notificationPrefs.ts
+++ b/cicchetto/src/lib/notificationPrefs.ts
@@ -30,6 +30,7 @@ import { token } from "./auth";
 import type { ChannelKey } from "./channelKey";
 import { withConversationMute, withoutConversationMute } from "./conversationMute";
 import { identityScopedStore } from "./identityScopedStore";
+import type { NotificationSound } from "./notificationSound";
 import {
   DEFAULT_NOTIFICATION_PREFS,
   getNotificationPrefs,
@@ -96,10 +97,11 @@ export const notificationPrefs = exports_.notificationPrefs;
 export const mirrorNotificationPrefs = exports_.mirrorNotificationPrefs;
 export const refreshNotificationPrefs = exports_.refreshNotificationPrefs;
 
-// #950 — the mute WRITE verb for callers outside the settings drawer (the rail
-// picker). The drawer holds its own hydrated copy of the prefs form and PUTs
-// that; a rail tap holds nothing, so this verb GETs the authoritative map
-// first, merges the one key, and PUTs the result.
+// #950 — the prefs WRITE verb for callers outside the settings drawer (the
+// rail mute picker; the `/beep` verb since #1480). The drawer holds its own
+// hydrated copy of the prefs form and PUTs that; a rail tap or a typed command
+// holds nothing, so this verb GETs the authoritative map first, merges the one
+// key, and PUTs the result.
 //
 // The GET is not belt-and-braces. `notificationPrefs()` is the DEFAULT map
 // until a user-topic (re)join hydrates it, and the endpoint is a FULL replace:
@@ -108,19 +110,25 @@ export const refreshNotificationPrefs = exports_.refreshNotificationPrefs;
 // undoing their settings. One extra round-trip on a rare, deliberate action
 // buys a write that is additive by construction.
 //
-// Rejects rather than swallowing: the caller decides what to say about a mute
+// Rejects rather than swallowing: the caller decides what to say about a write
 // that did not land (CLAUDE.md — no silent-swallow at boundaries).
-async function writeMutedTargets(
-  mutate: (muted: MutedTargets | undefined) => MutedTargets,
+async function writeNotificationPrefs(
+  mutate: (current: NotificationPrefs) => NotificationPrefs,
 ): Promise<void> {
   const t = token();
   if (t === null) throw new Error("no session");
   const current = await getNotificationPrefs(t);
-  const saved = await putNotificationPrefs(t, {
+  const saved = await putNotificationPrefs(t, mutate(current));
+  mirrorNotificationPrefs(saved);
+}
+
+function writeMutedTargets(
+  mutate: (muted: MutedTargets | undefined) => MutedTargets,
+): Promise<void> {
+  return writeNotificationPrefs((current) => ({
     ...current,
     muted_targets: mutate(current.muted_targets),
-  });
-  mirrorNotificationPrefs(saved);
+  }));
 }
 
 /**
@@ -138,4 +146,16 @@ export function applyConversationMute(key: ChannelKey, until: number | null): Pr
 /** Unmute `key`, whatever its expiry was. */
 export function clearConversationMute(key: ChannelKey): Promise<void> {
   return writeMutedTargets((muted) => withoutConversationMute(muted, key));
+}
+
+/**
+ * #1480 — select the in-app beep preset, for the `/beep` verb. The settings
+ * drawer does NOT use this: it PUTs its own hydrated form, like every other
+ * control on that page.
+ *
+ * Rejects on a failed round-trip; the caller turns that into the line the
+ * operator reads.
+ */
+export function applyNotificationSound(sound: NotificationSound): Promise<void> {
+  return writeNotificationPrefs((current) => ({ ...current, notification_sound: sound }));
 }

--- a/cicchetto/src/lib/notificationPrefs.ts
+++ b/cicchetto/src/lib/notificationPrefs.ts
@@ -98,10 +98,10 @@ export const mirrorNotificationPrefs = exports_.mirrorNotificationPrefs;
 export const refreshNotificationPrefs = exports_.refreshNotificationPrefs;
 
 // #950 — the prefs WRITE verb for callers outside the settings drawer (the
-// rail mute picker; the `/beep` verb since #1480). The drawer holds its own
-// hydrated copy of the prefs form and PUTs that; a rail tap or a typed command
-// holds nothing, so this verb GETs the authoritative map first, merges the one
-// key, and PUTs the result.
+// rail mute picker; the `/beep` verb since #1480). An OPEN drawer has hydrated
+// this mirror from the server and merges its one key over it; a rail tap or a
+// typed command can run with no drawer ever opened, so this verb GETs the
+// authoritative map first, merges the one key, and PUTs the result.
 //
 // The GET is not belt-and-braces. `notificationPrefs()` is the DEFAULT map
 // until a user-topic (re)join hydrates it, and the endpoint is a FULL replace:
@@ -149,9 +149,9 @@ export function clearConversationMute(key: ChannelKey): Promise<void> {
 }
 
 /**
- * #1480 — select the in-app beep preset, for the `/beep` verb. The settings
- * drawer does NOT use this: it PUTs its own hydrated form, like every other
- * control on that page.
+ * issue 1480 — select the in-app beep preset, for the `/beep` verb. The
+ * settings drawer does NOT use this: it merges over the mirror it can see and
+ * PUTs that, like every other control on that page.
  *
  * Rejects on a failed round-trip; the caller turns that into the line the
  * operator reads.

--- a/cicchetto/src/lib/notificationSound.ts
+++ b/cicchetto/src/lib/notificationSound.ts
@@ -1,0 +1,192 @@
+// #1480 — the notification-sound preset pack: the vocabulary and the recipes.
+//
+// ## Why this is not inside `beep.ts`
+//
+// `beep.ts` is MOCKED wholesale by `__tests__/subscribe.test.ts`
+// (`vi.mock("../lib/beep", () => ({ playBeep: vi.fn() }))`), and a mock factory
+// only exports what it lists. Anything else importing a VALUE from `beep.ts`
+// would resolve to a missing export inside that suite — the exact failure its
+// own comment warns about ("bleeds a missing-export into UX-6-L beep tests
+// downstream"). `userSettings.ts` needs `DEFAULT_NOTIFICATION_SOUND` for the
+// prefs default, the settings drawer needs the labels and the slash-command
+// parser needs the name set, so the vocabulary lives here, on the far side of
+// that mock, and `beep.ts` imports it like everyone else.
+//
+// Sibling shape: `timeFormat.ts` (#217) — one small module owning a closed-set
+// key, its default and its guard.
+//
+// ## Two species, one table
+//
+// A preset is either an oscillator recipe we SYNTHESISE (no bytes, no fetch)
+// or an mp3 we DECODE. The discriminated union is what makes adding one a
+// table row: the switch in `beep.ts` is exhaustive, so a new `kind` is a
+// compile error at every site that must learn about it, rather than a silent
+// fall-through to silence.
+//
+// The samples are committed under `public/sounds/` on vjt's explicit ruling
+// (2026-09-11) with the licence position stated in that directory's
+// `PROVENANCE.md`. They are precached by the service worker
+// (`vite.config.ts`'s `globPatterns` carries `mp3` for this reason), so a
+// chosen preset still plays with the network down — the case that matters
+// most for a PWA notification sound. If they ever have to come out, the synth
+// presets are the fallback and the feature degrades rather than breaks.
+//
+// ## The default is SILENCE
+//
+// `none` ships selected for everybody, existing subjects included (vjt,
+// 2026-09-11: «suono deve essere opt-in», «mi sta bene che sia disattivato per
+// tutti»). It is also the only implementable answer to the report that opened
+// the issue — a page cannot read macOS Focus/Do Not Disturb, so "respect DND"
+// is not a gate anybody can build here; a preset the user picks is.
+//
+// The server holds the same closed set (`Grappa.UserSettings`'s
+// `@notification_sounds`) and rejects anything outside it at the write
+// boundary. Adding a preset therefore touches BOTH lists — this one for the
+// recipe, that one for the vocabulary.
+
+/** One oscillator burst. A preset is a list of these, scheduled together. */
+export type SoundVoice = {
+  readonly wave: OscillatorType;
+  /** Start frequency in Hz. */
+  readonly fromHz: number;
+  /**
+   * End frequency in Hz — always present, equal to `fromHz` for a flat note.
+   * Stated rather than optional so the player has one code path (a ramp) and
+   * no "did the author mean a glide?" branch.
+   */
+  readonly toHz: number;
+  /** Offset from the start of the preset, in ms. */
+  readonly atMs: number;
+  readonly durationMs: number;
+  /** Peak linear gain, before the shared envelope. */
+  readonly gain: number;
+};
+
+export type SoundPreset =
+  | { readonly kind: "silent"; readonly label: string }
+  | { readonly kind: "synth"; readonly label: string; readonly voices: readonly SoundVoice[] }
+  | {
+      readonly kind: "sample";
+      readonly label: string;
+      readonly url: string;
+      readonly gain: number;
+    };
+
+/**
+ * Every preset name, in the order the settings drawer offers them: silence
+ * first, then the synthesised ones (cheapest, always available), then the
+ * samples.
+ *
+ * Wire values, so snake_case and never a hyphen — they cross the JSON boundary
+ * into `notification_prefs.notification_sound` and are matched against the
+ * server's own list byte for byte.
+ */
+export const NOTIFICATION_SOUNDS = [
+  "none",
+  "tone",
+  "chime",
+  "blip",
+  "pop",
+  "icq",
+  "xp_notify",
+  "xp_ding",
+  "xp_balloon",
+  "xp_exclamation",
+] as const;
+
+export type NotificationSound = (typeof NOTIFICATION_SOUNDS)[number];
+
+export const DEFAULT_NOTIFICATION_SOUND: NotificationSound = "none";
+
+/**
+ * The name `/beep on` selects — "the sound we shipped before this issue", not
+ * a synonym for "the default". The two are deliberately different values now:
+ * the default is silence, and `on` is what a user types to opt in.
+ */
+export const OPT_IN_NOTIFICATION_SOUND: NotificationSound = "tone";
+
+/**
+ * Narrow an untrusted string (a stored pref, a `/beep` argument) to a preset
+ * name. Everything unrecognised is the caller's problem to report — this does
+ * not silently substitute the default, because a mistyped `/beep` deserves an
+ * error and a stale stored value deserves the default, and only the caller
+ * knows which it is holding.
+ */
+export function isNotificationSound(value: unknown): value is NotificationSound {
+  return typeof value === "string" && (NOTIFICATION_SOUNDS as readonly string[]).includes(value);
+}
+
+// One gain for every sample. The mp3s are third-party recordings at their own
+// mastering levels and this host has no way to measure loudness, so the number
+// is a judgement (roughly the headroom the synth presets sit at), NOT a
+// measurement — it is one constant precisely so a future ear can move it once.
+const SAMPLE_GAIN = 0.6;
+
+export const NOTIFICATION_SOUND_PRESETS: Readonly<Record<NotificationSound, SoundPreset>> = {
+  none: { kind: "silent", label: "silent (default)" },
+
+  // The pre-#1480 sound, unchanged to the Hz: a bare 440 Hz sine for 80 ms at
+  // gain 0.1. Kept exactly because it is what `/beep on` promises and what an
+  // existing user who opts back in expects to hear.
+  tone: {
+    kind: "synth",
+    label: "tone (440 Hz)",
+    voices: [{ wave: "sine", fromHz: 440, toHz: 440, atMs: 0, durationMs: 80, gain: 0.1 }],
+  },
+
+  // A falling two-note interval — the shape everyone reads as "message", and
+  // the direct answer to the complaint that opened the issue (alk: the 440 Hz
+  // tone is indistinguishable from the Windows Sticky Keys chime). Triangle
+  // rather than sine so it carries over a noisy room without being harsh.
+  chime: {
+    kind: "synth",
+    label: "chime",
+    voices: [
+      { wave: "triangle", fromHz: 988, toHz: 988, atMs: 0, durationMs: 110, gain: 0.09 },
+      { wave: "triangle", fromHz: 659, toHz: 659, atMs: 100, durationMs: 220, gain: 0.09 },
+    ],
+  },
+
+  // A short rising sweep. Square is the loudest wave per unit gain, hence the
+  // markedly lower number — same perceived level, not a quieter preset.
+  blip: {
+    kind: "synth",
+    label: "blip",
+    voices: [{ wave: "square", fromHz: 660, toHz: 1320, atMs: 0, durationMs: 60, gain: 0.05 }],
+  },
+
+  // A fast downward sweep: the bubble-pop shape, and the least intrusive of
+  // the four for someone who wants to know without being addressed.
+  pop: {
+    kind: "synth",
+    label: "pop",
+    voices: [{ wave: "sine", fromHz: 1200, toHz: 300, atMs: 0, durationMs: 70, gain: 0.12 }],
+  },
+
+  icq: { kind: "sample", label: 'ICQ "uh-oh"', url: "/sounds/icq-uh-oh.mp3", gain: SAMPLE_GAIN },
+
+  xp_notify: {
+    kind: "sample",
+    label: "Windows XP notify",
+    url: "/sounds/xp-notify.mp3",
+    gain: SAMPLE_GAIN,
+  },
+  xp_ding: {
+    kind: "sample",
+    label: "Windows XP ding",
+    url: "/sounds/xp-ding.mp3",
+    gain: SAMPLE_GAIN,
+  },
+  xp_balloon: {
+    kind: "sample",
+    label: "Windows XP balloon",
+    url: "/sounds/xp-balloon.mp3",
+    gain: SAMPLE_GAIN,
+  },
+  xp_exclamation: {
+    kind: "sample",
+    label: "Windows XP exclamation",
+    url: "/sounds/xp-exclamation.mp3",
+    gain: SAMPLE_GAIN,
+  },
+};

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -1,4 +1,11 @@
 import { DEFAULT_CHANTYPES, isChannelName } from "./chantypes";
+import {
+  DEFAULT_NOTIFICATION_SOUND,
+  isNotificationSound,
+  NOTIFICATION_SOUNDS,
+  type NotificationSound,
+  OPT_IN_NOTIFICATION_SOUND,
+} from "./notificationSound";
 
 // Pure slash-command parser for cicchetto's compose box.
 //
@@ -242,7 +249,12 @@ export type SlashCommand =
   // Opening the drawer IS the feedback. `section` widens as sub-pages gain
   // bare-verb deep-links; it must stay assignable to settingsNav's
   // SettingsSubPage.
-  | { kind: "open-settings"; section: "watchlists" | "aliases" | "ignores" }
+  | { kind: "open-settings"; section: "watchlists" | "aliases" | "ignores" | "push" }
+  // #1480 — `/beep <preset>` selects the in-app notification sound. Carries the
+  // NARROWED preset name, so the handler cannot be handed a string the server
+  // would 422: `on`/`off` are resolved to their preset here, in the parser,
+  // where every other alias-to-value mapping in this file lives.
+  | { kind: "beep"; sound: NotificationSound }
   // #1958 — a bare `/credits` opens the end titles: the same modal the
   // settings drawer's last entry opens, one verb deep instead of three taps.
   // It carries nothing — the modal is a module-singleton signal and the verb
@@ -322,6 +334,40 @@ function parseIgnore(_verb: string, rest: string): SlashCommand {
   const [mask] = tokens(rest);
   if (mask === undefined) return { kind: "open-settings", section: "ignores" };
   return { kind: "ignore", action: "add", mask };
+}
+
+// #1480 — `/beep`, the shortcut into the notification-sound preference. vjt's
+// shape, verbatim (2026-09-11): «/beep nudo ti apre i settinfs», «on è il beep
+// che abbiamo ora il default, off è none, e preset è il preset».
+//
+//   /beep            → the settings sub-page that holds the picker
+//   /beep on         → the 440 Hz tone cic shipped before this issue
+//   /beep off        → `none`
+//   /beep <preset>   → that preset by name
+//
+// `on` is NOT a synonym for "the default": the default is silence, and `on` is
+// what a subject types to opt in. Keeping them separate constants is what
+// stops a later change of default from silently redefining `/beep on`.
+//
+// A generic `/set <key> <value>` was proposed and killed by vjt on his own
+// call the same afternoon («/set è un puttanaio lasciamo perdere») — do not
+// grow this into one.
+function parseBeep(verb: string, rest: string): SlashCommand {
+  const [name] = tokens(rest);
+  if (name === undefined) return { kind: "open-settings", section: "push" };
+
+  const lowered = name.toLowerCase();
+  if (lowered === "on") return { kind: "beep", sound: OPT_IN_NOTIFICATION_SOUND };
+  if (lowered === "off") return { kind: "beep", sound: DEFAULT_NOTIFICATION_SOUND };
+  if (isNotificationSound(lowered)) return { kind: "beep", sound: lowered };
+
+  // Name the whole set rather than "unknown preset": the operator asked for a
+  // sound by name and the answer they need is which names exist.
+  return {
+    kind: "error",
+    verb,
+    message: `unknown sound: ${name} — try on, off, or one of: ${NOTIFICATION_SOUNDS.join(", ")}`,
+  };
 }
 
 function parseUnignore(verb: string, rest: string): SlashCommand {
@@ -953,6 +999,11 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
   unignore: (verb, rest) => parseUnignore(verb, rest),
   notify: (verb, rest) => parseNotify(verb, rest),
   watch: (verb, rest) => parseNotify(verb, rest),
+
+  // #1480 — the notification-sound shortcut. Registered as an ordinary
+  // builtin, so it inherits the `//beep` literal escape, #427 alias shadowing
+  // and the dispatch characterization net for free.
+  beep: (verb, rest) => parseBeep(verb, rest),
 
   // #356 — keyword highlight. /hilight is canonical (irssi spelling on the
   // host /usr/share/irssi/help/), /dehilight removes, /highlight kept as an

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -174,7 +174,18 @@ let _socket: Socket | null = null;
 // as an old bundle rejects `loading`. `MIN_SERVER_PROTOCOL_VERSION` still
 // stays at 9, deliberately: raising it would refuse the whole socket over one
 // broken pane, and the two ship together anyway.
-export const CLIENT_PROTOCOL_VERSION = 17;
+//
+// 18 (issue 1480) — `notification_prefs` grows `notification_sound`, the
+// in-app beep preset. Additive, and the FOURTH bump `wire_pin --check` cannot
+// see: this one rides `UserSettingsJSON`, whose spec names the prefs type
+// remotely, so growing the type moves no digest byte.
+// `MIN_SERVER_PROTOCOL_VERSION` stays at 9: this bundle falls back to `none`
+// when the server does not send the key, which is the pre-#1480 behaviour in
+// the pre-#1480 place — silence, since the default is silence — so it still
+// serves an older server. The direction that would hurt is the other one, and
+// the server closes it: it treats an ABSENT key on the PUT as unchanged, so an
+// old bundle saving any other pref cannot mute a subject who opted in.
+export const CLIENT_PROTOCOL_VERSION = 18;
 
 // #193 — force the correct WS scheme from the page origin, absolutely.
 //

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -24,6 +24,7 @@ import {
 } from "./networks";
 import { nickEquals } from "./nickEquals";
 import { notificationPrefs } from "./notificationPrefs";
+import { DEFAULT_NOTIFICATION_SOUND } from "./notificationSound";
 import { isOperatorActionEcho } from "./operatorActionEcho";
 import { isOwnPresenceEvent } from "./ownPresenceEvent";
 import { resolveCtcpReply, resolvePing } from "./pingCorrelation";
@@ -452,7 +453,12 @@ moduleRoot(() => {
       !effectivelyFocused(slug, displayName) &&
       shouldNotify(message, slug, ownNick, notificationPrefs(), highlightPatterns())
     ) {
-      playBeep();
+      // #1480 — WHETHER to alert is this predicate's call; WHICH sound is the
+      // subject's preset, and it is passed as data rather than read inside
+      // `beep.ts` so the same door serves the settings preview. `none` (the
+      // default for everyone) makes `playBeep` a no-op, so the badge still
+      // bumps for an opted-out subject: silence is not "no notification".
+      playBeep(notificationPrefs().notification_sound ?? DEFAULT_NOTIFICATION_SOUND);
       incrementBadge();
     }
   };

--- a/cicchetto/src/lib/userSettings.ts
+++ b/cicchetto/src/lib/userSettings.ts
@@ -15,6 +15,7 @@
 // inline.
 
 import { ApiError, readError } from "./api";
+import { DEFAULT_NOTIFICATION_SOUND, type NotificationSound } from "./notificationSound";
 import type { PresencePref } from "./presenceFilter";
 import type { TimeFormatKey } from "./timeFormat";
 
@@ -51,6 +52,12 @@ export type NotificationPrefs = {
   // rather than crash the predicate on every arriving message. Present in
   // DEFAULT_NOTIFICATION_PREFS, and every reader defaults it to `{}`.
   muted_targets?: MutedTargets;
+  // #1480 — the in-app beep preset. Optional for the same reason as
+  // `muted_targets` and it runs BOTH ways here: this bundle may be talking to
+  // a BEAM that predates the key, and the server treats an absent key on the
+  // PUT as "unchanged" rather than "reset to default", so neither side reads
+  // the other's silence as a choice.
+  notification_sound?: NotificationSound;
 };
 
 export type NotificationPrefsResponse = {
@@ -66,6 +73,7 @@ export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
   presence_online: false,
   presence_offline: false,
   muted_targets: {},
+  notification_sound: DEFAULT_NOTIFICATION_SOUND,
 };
 
 export async function getNotificationPrefs(token: string): Promise<NotificationPrefs> {

--- a/cicchetto/vite.config.ts
+++ b/cicchetto/vite.config.ts
@@ -230,7 +230,16 @@ export default defineConfig({
         // architectural, not denylist-driven. The navigation fallback
         // (denylist for /auth, /me, /networks, /socket) is wired
         // explicitly in `service-worker.ts` via NavigationRoute.
-        globPatterns: ["**/*.{js,css,html,svg,png,webmanifest,ico}"],
+        //
+        // #1480 — `mp3` joined the list, and unlike the logos below these ARE
+        // shell: a notification sound that has to be fetched is silent exactly
+        // when the operator most needs it (offline, backgrounded, on the phone),
+        // and the whole `public/sounds/` set is 43 KB — the same order as one
+        // icon. Precaching the WHOLE set rather than the chosen preset is
+        // deliberate: the choice is a server pref that can change on another
+        // device, so "precache what they picked" would go stale silently, and
+        // the alternative to 43 KB is bookkeeping nobody can verify offline.
+        globPatterns: ["**/*.{js,css,html,svg,png,mp3,webmanifest,ico}"],
         // #1739 — the vendored station logos are NOT shell, and leaving them
         // to the pattern above would have precached them HALF: 7 `.png` plus
         // one `.svg` are matched by it and 14 `.jpg` are not, so the offline

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53857,3 +53857,153 @@ explicitly not measured** — they are not cited here as causes, and the cure
 does not depend on which, if any, is true. No repro was built in a real
 browser; the e2e lane was not held, and this defect is fully decidable at the
 unit layer on both ports.
+<!-- entry #1480 -->
+
+---
+
+## 2026-09-11 — #1480: the notification sound becomes a preset, and its default becomes silence
+
+alk reported that cic's notification sound is indistinguishable from the
+Windows Sticky Keys chime. deadbeef_ reported, separately and the same week,
+that cicchetto still beeps while macOS is in Do Not Disturb. One module
+answers both — `cicchetto/src/lib/beep.ts`, until now a single hard-coded
+440 Hz sine with no way to change it and no way to turn it off.
+
+### Why "respect Do Not Disturb" is not the cure
+
+A web page cannot read macOS Focus/DND. There is no browser API, so cic has
+no signal to gate on and no amount of server work creates one. The BANNER
+half already behaves — the OS suppresses its own notification, and deadbeef_
+confirmed none arrived. The SOUND half is a Web Audio `OscillatorNode`
+started by the page, which the OS never sees and therefore never gates. The
+implementable answer is a preset the user picks, including one that is
+silence.
+
+### The default is silence, and that is a deliberate break
+
+vjt ruled it on the day: «e mettiamo default off», «suono deve essere
+opt-in», «mi sta bene che sia disattivato per tutti», his framing being that
+an audible beep a user never asked for is a privacy invasion. The issue body
+said the opposite ("the current 440 Hz tone, so nobody's sound changes on
+upgrade") and is superseded. So `notification_sound` defaults to `"none"`
+for everyone, existing subjects included, and the sound arrives only after
+an explicit opt-in.
+
+That makes `on` and "the default" two different values, and they are two
+different constants (`OPT_IN_NOTIFICATION_SOUND` / `DEFAULT_NOTIFICATION_SOUND`)
+precisely so a later change of default cannot silently redefine `/beep on`.
+
+### The samples are committed, on a ruling, with the licence problem on the table
+
+Three options went to vjt: (a) commit the XP sounds into the public repo,
+(b) host them off-repo like the ICQ one, (c) synthesise homages and ship no
+bytes. Two answers landed within 30 seconds on two channels; asked which
+held, he answered «(a)», «non me ne frega niente (a)», and stated the risk
+himself — «mi manderanno il cease and desist» / «e li levo». That is his
+call on his repo, made with the problem named. The position is recorded in
+`cicchetto/public/sounds/PROVENANCE.md` rather than left to be re-derived
+from the files being present. He then extended it: «generane un po'» / «e
+metti anche quei due di icq e ms» — so the pack ships BOTH species
+populated, not one.
+
+### The shape
+
+`notificationSound.ts` owns the vocabulary and the recipes; `beep.ts` plays
+them. A preset is `silent`, `synth` (an oscillator recipe: wave, from/to Hz,
+offset, duration, gain) or `sample` (an mp3 decoded into the same
+`AudioContext`, buffer memoised per URL). The discriminated union is what
+makes adding a preset a table row — the player's switch is exhaustive, so a
+new `kind` is a compile error at every site that must learn about it rather
+than a silent fall-through to silence.
+
+Three details are load-bearing and none is obvious:
+
+- **The preset is an ARGUMENT, not a store read.** `playBeep(sound)` takes
+  it from the caller that already holds the prefs, so the settings preview
+  and the live notify path are the same door and the recipes are testable
+  without audio.
+- **`none` returns before the `window.__lastBeepAt` stamp** and before the
+  `AudioContext` is even constructed. `none` is the default, so a seam that
+  ticked for it would report "beeped" for everybody who never opted in —
+  which is everybody — and the e2e oracle would read green on silence.
+- **A rejected decode EVICTS its cache entry.** Memoising the promise is
+  what stops two beeps in a tick racing one fetch; keeping a rejected one
+  would poison that preset for the session, so a single bad response on a
+  flaky network would silence the operator until they reloaded.
+
+### Absence and garbage are different claims
+
+Server-side the key follows the `display_prefs.time_format` twin — the READ
+falls back to the default on an unrecognised value, the WRITE rejects one —
+with ONE deviation: an ABSENT key on the write means UNCHANGED, not "reset
+to default". That is `muted_targets`' own rule (#866) and its reason applies
+verbatim: `PUT /user_settings/notification_prefs` is a full replace and cic
+deploys independently of the BEAM, so a bundle that has never heard of the
+picker is saying nothing about the sound. Reading its silence as a choice
+would mute an opted-in subject the first time they ticked any other
+checkbox. An unrecognised VALUE still 422s — tolerating absence is not
+tolerating garbage.
+
+With a second `:unchanged` key, `resolve_muted/2` became the wrong shape and
+is gone: the client that omits either key omits both, so `resolve_unchanged/4`
+reads the stored prefs ONCE and fills whichever are missing.
+
+### `/beep`, and the `/set` interface that will not exist
+
+deadbeef_ asked for `/set beep on/off` because the drawer is «un sacco di
+click». vjt refused the generic form twice — «non voglio iniziare a fare la
+/set interface», then «/set è un puttanaio lasciamo perdere», which also
+kills the follow-up issue he had briefly allowed — and approved `/beep`
+instead: bare opens the settings page, `on` is the 440 Hz tone, `off` is
+`none`, anything else is a preset name. The aliases resolve in the PARSER,
+where every other argument mapping in that file lives, so the handler cannot
+be handed a name the server would reject.
+
+The verb is a shortcut into the preference, never a parallel store, so it
+reuses the rail picker's GET-merge-PUT writer — generalised from
+`writeMutedTargets` to `writeNotificationPrefs` so both inherit one
+additivity argument instead of two copies. Its confirmation PLAYS the preset
+it selected: the one case where the feedback can be the thing itself, and it
+doubles as the gesture that un-suspends the `AudioContext` — which matters
+most for `/beep`, since someone typing it is explicitly avoiding the drawer.
+
+### A comment that had been wrong since UX-6-L
+
+`beep.ts`'s header said the beep fires "when the cic page is foreground".
+The call site gates on `!effectivelyFocused(slug, displayName)` — per
+CONVERSATION, not per page — so it fires for a background TAB too, which is
+exactly the case deadbeef_ hit with cicchetto sitting behind a Focus
+session. Corrected here rather than left as the kind of line the next reader
+trusts instead of the code.
+
+### Measured
+
+- Every mp3 was re-downloaded independently and is byte-identical to what
+  `172df6037` committed (`cmp`, with a two-different-files negative control
+  at rc=1). Sizes match the issue's manifest exactly: 12537 / 11969 / 5447.
+- `afinfo` was calibrated in both directions before being believed — rc=1 on
+  a text file, a duration on a known-good system AIFF. It contradicts
+  `PROVENANCE.md`'s "all five are 22050 Hz stereo": the ICQ sound is 44100 Hz
+  MONO, and it never came from the Archive item, so it had no reason to
+  match. The table now carries a per-file format column.
+- Five mutants, five targeted kills: moving the silent-preset return past
+  the seam stamp; dropping the decode-cache eviction; resolving `/beep on`
+  to the default instead of the tone; passing a literal preset from
+  `subscribe.ts` instead of the pref; and playing the sound BEFORE the write
+  lands. The first exposed a test that asserted `resumes === 0` while
+  claiming to check that no `AudioContext` is built — zero either way. It
+  now counts constructions.
+- The dispatch characterization net moved by exactly the predicted three
+  hunks (64→65 arms, one `beep` row, no new indistinguishable pair) and
+  nothing else.
+
+### Not measured, and not claimed
+
+- **Whether any preset sounds good, or whether alk likes one.** This host
+  has no audio. The issue's acceptance bar ("at least one preset alk
+  actually likes") is not something a gate can answer, and the sample gain
+  (0.6, one shared constant) is a judgement, not a measurement — it is one
+  constant so a future ear can move it once.
+- **The samples playing offline.** The `globPatterns` extension is the
+  mechanism, and it is argued from how workbox precaching works, not from a
+  build inspected with the network down.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54016,3 +54016,44 @@ trusts instead of the code.
 - **The samples playing offline.** The `globPatterns` extension is the
   mechanism, and it is argued from how workbox precaching works, not from a
   build inspected with the network down.
+
+### The CI red this shipped with, and the duplicate state under it
+
+The e2e above went red on the first CI run of the PR, on exactly the arm
+that reads the picker without a reload: `/beep chime`, then bare `/beep` to
+open the drawer, and the `<select>` sat at `none` through 14 polls in 10
+seconds. The sibling arm — same write, but a `page.reload()` before the
+read — was green. That pair is the whole diagnosis: the write LANDED (the
+reload proves the server has it), and the drawer could not see it.
+
+`SettingsDrawer` kept a private `prefs` signal, hydrated once at mount, and
+rendered the form from that. `/beep` writes through
+`applyNotificationSound`, which feeds the SHARED mirror the server's echo —
+a store the drawer was not reading for this key. So the picker rendered the
+value the drawer had loaded at login.
+
+This is the second instance of one defect, not a new one. #950 hit it when
+the rail picker became a second writer of `muted_targets`, and cured it by
+reading THAT ONE KEY off the mirror; the comment it left behind describes
+the mechanism accurately and predicted nothing about the next key. `/beep`
+was the next key. A third per-key patch would have bought the same deferral
+again, so the private snapshot is GONE: its only two writers were
+`refreshPrefs` and `savePrefs`, each of which already handed the identical
+value to the mirror one line later, so it was a pure duplicate of state
+that already existed — design discipline (1), and the parallel structure
+was the bug.
+
+The half the e2e did NOT catch is the worse half, and it is now pinned by
+its own unit test. `/api/user_settings/notification_prefs` is a FULL
+replace and every drawer control PUTs `{...prefs(), oneKey: value}`. With a
+stale snapshot as the base, ticking any unrelated checkbox after a `/beep`
+would have written `notification_sound: "none"` straight back over the
+choice — a lost preference rather than a late-rendering one. Deriving fixes
+both at once, which is why the cure is a deletion and not a third accessor.
+
+One behaviour changed on purpose: the form now re-renders when a user-topic
+rejoin refreshes the prefs mid-open. The controls it feeds are all
+write-on-change with no dirty state, and the two whitelist TEXT fields keep
+their own signals (seeded only by the drawer's own load), so nothing being
+typed can be clobbered — the drawer shows what the server says, which is
+the posture cic holds everywhere else.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53978,6 +53978,15 @@ trusts instead of the code.
 
 ### Measured
 
+- **This slice adds no audio bytes.** The five mp3s landed on main on
+  2026-08-18 in `172df6037` ("assets(#1480): notification sound presets,
+  ahead of the code that reads them"), an ancestor of the base — measured,
+  because the briefing for this work carried the opposite constraint
+  ("synthesised only, nothing third-party in the repo until vjt rules") and
+  the ruling it was waiting for had already been given three and a half
+  weeks earlier. `origin/main..HEAD` contains 0 `.mp3` paths (positive
+  control: 5 exist on the base). What this slice adds is the code that reads
+  them.
 - Every mp3 was re-downloaded independently and is byte-identical to what
   `172df6037` committed (`cmp`, with a two-different-files negative control
   at rc=1). Sizes match the issue's manifest exactly: 12537 / 11969 / 5447.

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -397,7 +397,39 @@ defmodule Grappa.Protocol do
   # broken pane beats a refused socket. The bundle and the server ship
   # together on this deploy, so the window in which a v16 bundle meets a
   # v17 server is a cache miss away from closing.
-  @protocol_version 17
+  # v18 (issue 1480) — `notification_prefs` grows `notification_sound`, the
+  # name of the in-app beep preset. Purely additive, and additive still
+  # bumps (#1393d).
+  #
+  # 🔴 `mix grappa.wire_pin --check` is blind to it, for the FOURTH time and
+  # for the reason v15 generalised: the digest spans the codegen artefacts
+  # plus the `@spec`s the hand-written `GrappaWeb.*JSON` views export, and
+  # `UserSettingsJSON.notification_prefs/1`'s spec names the REMOTE type
+  # `UserSettings.notification_prefs()`, which is digested as the reference
+  # TEXT. Growing the type behind that name moves no byte the gate can see —
+  # measured before the bump, not assumed: `notification` appears 0 times in
+  # either generated artefact (positive control: `server_time`, 2 hits).
+  # Bumped by hand, and the gate will then read `:pin_stale` rather than the
+  # violation, so `--update` is the correct next step.
+  #
+  # This is the SECOND time `UserSettingsJSON` has been the silent carrier
+  # (v16's `show_event_badge` was the first), which is worth naming: a key
+  # added inside `notification_prefs()` or `display_prefs()` will ALWAYS be
+  # invisible here, because both are remote types behind a view spec.
+  #
+  # 🔴 The behaviour change rides ALONGSIDE the wire one and is not what the
+  # number describes: the default is `"none"`, i.e. SILENCE, for every
+  # existing subject (vjt's ruling — «suono deve essere opt-in»). No client
+  # can detect that from the version; it is a product change, and the entry
+  # in DESIGN_NOTES is where it lives.
+  #
+  # @min_protocol_version stays at 1. The field is additive and BOTH sides
+  # are absent-tolerant on purpose — cic falls back to `none` when the
+  # server does not send it, and the server treats an absent key on the PUT
+  # as UNCHANGED rather than as a reset — so a new bundle against an older
+  # server is silent instead of broken, and an old bundle cannot mute a
+  # subject who opted in.
+  @protocol_version 18
   @min_protocol_version 1
 
   @doc "The protocol version the server currently speaks."
@@ -408,7 +440,7 @@ defmodule Grappa.Protocol do
   # alongside `@protocol_version`; the spec doubles as the bump tripwire,
   # and now that the bump is routine the tripwire is what keeps it from
   # being done half-way.
-  @spec version() :: 17
+  @spec version() :: 18
   def version, do: @protocol_version
 
   @doc """

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -170,11 +170,18 @@ defmodule Grappa.UserSettings do
   @typedoc """
   Per-subject notification preferences — push-notifications cluster B3.
 
-  Five booleans + two string-list whitelists + one mute map (#866).
+  Five booleans + two string-list whitelists + one mute map (#866) + one
+  closed-set sound key (#1480).
   Three of the booleans gate MESSAGE push; `presence_online` /
   `presence_offline` gate `/notify` presence push (#378) and are a
   SEPARATE trigger class — see `@prefs_trigger_keys` for why they are
   excluded from the at-least-one-trigger guard.
+
+  `notification_sound` names the IN-APP beep preset cic plays on the live
+  notify path (`cicchetto/src/lib/beep.ts`); it does NOT gate the OS push,
+  which is decided here by `Push.Triggers` and has no audio of ours. It is
+  a closed set (`@notification_sounds`) enforced at the write boundary, and
+  the DEFAULT IS SILENCE — see `default_notification_prefs/0`.
   Whitelist semantics: IF `channel_messages_all` is true the
   `channel_messages_only` list is ignored at trigger-eval time (UI greys
   it out, server still stores the value so toggling `_all` off restores
@@ -199,7 +206,8 @@ defmodule Grappa.UserSettings do
           private_messages_only: [String.t()],
           presence_online: boolean(),
           presence_offline: boolean(),
-          muted_targets: muted_targets()
+          muted_targets: muted_targets(),
+          notification_sound: String.t()
         }
 
   @typedoc """
@@ -242,6 +250,23 @@ defmodule Grappa.UserSettings do
         }
 
   @notification_prefs_key "notification_prefs"
+
+  # #1480 — the in-app beep preset, a closed set inside `notification_prefs`.
+  # Wire strings rather than atoms for the same reason `@display_time_formats`
+  # is (see the `display_prefs` typedoc): they cross a JSON boundary and
+  # `String.to_atom/1` on user input is banned. Two species share one list —
+  # oscillator recipes cic synthesises (`tone`, `chime`, `blip`, `pop`) and
+  # mp3 samples it decodes (`icq`, the four `xp_*`) — because the SERVER never
+  # needs to tell them apart: it stores a name and validates membership. The
+  # recipe/asset table is cic's (`cicchetto/src/lib/notificationSound.ts`), and
+  # THAT is the pair to keep in step when a preset is added.
+  #
+  # `none` is the DEFAULT for everybody (vjt, 2026-09-11: «suono deve essere
+  # opt-in», «mi sta bene che sia disattivato per tutti»), so an untouched
+  # subject is silent and the sound only ever arrives after an explicit pick.
+  @notification_sounds ~w(none tone chime blip pop icq xp_notify xp_ding xp_balloon xp_exclamation)
+  @default_notification_sound "none"
+
   @upload_ttl_seconds_key "upload_ttl_seconds"
   @vhost_selection_key "vhost_selection"
   @active_theme_id_key "active_theme_id"
@@ -532,6 +557,17 @@ defmodule Grappa.UserSettings do
   the opt-in and costs nothing: #247's Watched panel already tells users
   the feature exists.
 
+  `notification_sound` defaults to `"none"` — SILENCE — and that is a
+  deliberate behaviour change for existing subjects, not the usual
+  "nobody's setting moves on upgrade" (#1480). vjt ruled it on
+  2026-09-11: «suono deve essere opt-in», «mi sta bene che sia disattivato
+  per tutti», the framing being that an audible beep a user never asked
+  for is a privacy invasion. It is also the only implementable answer to
+  the report that triggered the issue — a page cannot read macOS Focus /
+  Do Not Disturb (no browser API exists), the OS suppresses the BANNER by
+  itself, and our beep is a Web Audio node the OS never sees. So the cure
+  is a preset the user can pick, not a DND gate we cannot build.
+
   The spec's return type is the wider `notification_prefs()` (not the
   Dialyzer-inferred singleton shape) so callers can pattern-match
   the result interchangeably with `get_notification_prefs/1` results.
@@ -547,7 +583,8 @@ defmodule Grappa.UserSettings do
       private_messages_only: [],
       presence_online: false,
       presence_offline: false,
-      muted_targets: %{}
+      muted_targets: %{},
+      notification_sound: @default_notification_sound
     }
   end
 
@@ -626,6 +663,11 @@ defmodule Grappa.UserSettings do
       operator's mutes the first time they tick any other checkbox. Keys
       are folded (`Identifier.canonical_target/1`) and `until` must be
       `null` or a positive unix timestamp in seconds.
+    * `notification_sound` (#1480) is the SECOND key with that absence
+      rule, for the identical reason: a bundle that has never heard of the
+      preset picker is not asserting the subject wants silence. An
+      unrecognised VALUE, on the other hand, is rejected — absence and
+      garbage are different claims, and only the first one is tolerable.
 
   Returns `{:ok, %Settings{}}` on persistence; `{:error, changeset}`
   with descriptive errors on either validation failure path.
@@ -1874,6 +1916,21 @@ defmodule Grappa.UserSettings do
     bools
     |> Map.merge(lists)
     |> Map.put(:muted_targets, read_muted_targets(stored))
+    |> Map.put(:notification_sound, read_notification_sound(stored))
+  end
+
+  # #1480 — closed-set read, the twin of `read_display_time_format/1`: an
+  # absent or unrecognised value reads as the default. That covers the row
+  # written before this key existed AND the row written by a bundle newer
+  # than this BEAM which picked a preset this BEAM cannot name — both behave
+  # like a subject who never chose, which is silence, never a crash and
+  # never a guess.
+  @spec read_notification_sound(map()) :: String.t()
+  defp read_notification_sound(stored) do
+    case Map.get(stored, :notification_sound, Map.get(stored, "notification_sound")) do
+      v when v in @notification_sounds -> v
+      _ -> @default_notification_sound
+    end
   end
 
   # #866 — defensive read of the mute map, the twin of `sanitize_aliases_read/1`.
@@ -1953,8 +2010,8 @@ defmodule Grappa.UserSettings do
     with {:ok, bools} <- cast_bools(prefs, subject),
          {:ok, lists} <- cast_lists(prefs, subject),
          {:ok, muted} <- cast_muted_targets(prefs, subject),
-         normalized =
-           bools |> Map.merge(lists) |> Map.put(:muted_targets, resolve_muted(muted, subject)),
+         {:ok, sound} <- cast_notification_sound(prefs, subject),
+         normalized = bools |> Map.merge(lists) |> resolve_unchanged(muted, sound, subject),
          :ok <- ensure_at_least_one_trigger(normalized, subject) do
       {:ok, normalized}
     end
@@ -2048,14 +2105,59 @@ defmodule Grappa.UserSettings do
     end
   end
 
-  # Resolving :unchanged costs one extra SELECT, and only on the absent path.
-  # It reads through `get_notification_prefs/1` ON PURPOSE rather than off the
-  # raw column: that reader is also where snoozes expire, so an old client's
-  # save prunes elapsed entries as a side effect instead of writing them back.
-  defp resolve_muted(:unchanged, subject),
-    do: Map.fetch!(get_notification_prefs(subject), :muted_targets)
+  # #1480 — closed-set write, and the axis this shares with the twin above is
+  # ABSENCE, not the value: `nil`/absent is `:unchanged` (the rollout-window
+  # argument in `cast_muted_targets/2`, verbatim — an old bundle omitting the
+  # key is not asking for silence), while an unrecognised value is REJECTED.
+  # That is the `fetch_display_time_format/1` half: the closed set is enforced
+  # at the boundary, so a stored row can only ever hold a name this BEAM knows.
+  @spec cast_notification_sound(map(), Subject.t()) ::
+          {:ok, String.t() | :unchanged} | {:error, Ecto.Changeset.t()}
+  defp cast_notification_sound(prefs, subject) do
+    case Map.get(prefs, :notification_sound, Map.get(prefs, "notification_sound")) do
+      nil ->
+        {:ok, :unchanged}
 
-  defp resolve_muted(muted, _) when is_map(muted), do: muted
+      v when v in @notification_sounds ->
+        {:ok, v}
+
+      _ ->
+        {:error,
+         prefs_changeset_error(
+           "notification_sound must be one of #{inspect(@notification_sounds)}",
+           subject
+         )}
+    end
+  end
+
+  # Fills whichever of the two `:unchanged`-capable keys the client omitted.
+  #
+  # ONE read serves both, deliberately: the client that omits either key is an
+  # old bundle, and an old bundle omits BOTH, so a per-key resolver would pay
+  # two SELECTs for one PUT and neither would be the interesting one. It reads
+  # through `get_notification_prefs/1` rather than off the raw column because
+  # that reader is also where snoozes expire — an old client's save prunes
+  # elapsed entries as a side effect instead of writing them back.
+  @spec resolve_unchanged(map(), muted_targets() | :unchanged, String.t() | :unchanged, Subject.t()) ::
+          map()
+  defp resolve_unchanged(base, muted, sound, subject) do
+    stored = unchanged_fallback(muted, sound, subject)
+
+    base
+    |> Map.put(:muted_targets, keep_or_take(muted, stored, :muted_targets))
+    |> Map.put(:notification_sound, keep_or_take(sound, stored, :notification_sound))
+  end
+
+  # `%{}` on the nothing-to-resolve arm rather than `nil`: it keeps the return
+  # a `map()` for every caller, and it is never indexed — `keep_or_take/3`
+  # touches it only on the `:unchanged` arm, which is exactly the arm that
+  # forced the read.
+  defp unchanged_fallback(muted, sound, subject) do
+    if :unchanged in [muted, sound], do: get_notification_prefs(subject), else: %{}
+  end
+
+  defp keep_or_take(:unchanged, stored, key), do: Map.fetch!(stored, key)
+  defp keep_or_take(value, _stored, _key), do: value
 
   defp normalize_muted_targets(map, subject) when map_size(map) > @muted_targets_max_count do
     {:error,

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -2157,7 +2157,7 @@ defmodule Grappa.UserSettings do
   end
 
   defp keep_or_take(:unchanged, stored, key), do: Map.fetch!(stored, key)
-  defp keep_or_take(value, _stored, _key), do: value
+  defp keep_or_take(value, _, _), do: value
 
   defp normalize_muted_targets(map, subject) when map_size(map) > @muted_targets_max_count do
     {:error,

--- a/priv/wire/shape.pin
+++ b/priv/wire/shape.pin
@@ -12,5 +12,5 @@
 # This line states the COVERAGE on purpose: widening or narrowing what
 # the digest spans is not a wire-shape change, the gate cannot tell one
 # from the other, and reading the pin is the only place a review sees it.
-protocol_version = 17
+protocol_version = 18
 shape_digest = sha256:b651b30c24227355ad5c5c797e60bbc29f46d016bd3ddd15200c5ced37b2c81c

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -808,7 +808,7 @@ defmodule Grappa.UserSettingsTest do
     do: rewrite_stored_prefs(user, &Map.delete(&1, "notification_sound"))
 
   defp rewrite_stored_prefs(user, fun) do
-    settings = UserSettings.get_or_init({:user, user.id})
+    {:ok, settings} = UserSettings.get_or_init({:user, user.id})
     prefs = Map.get(settings.data, "notification_prefs", %{})
     next = Map.put(settings.data, "notification_prefs", fun.(prefs))
 

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -343,7 +343,13 @@ defmodule Grappa.UserSettingsTest do
                # byte-for-byte by cic's DEFAULT_NOTIFICATION_PREFS, so an
                # un-hydrated client behaves like a subject who configured
                # nothing rather than one who muted everything.
-               muted_targets: %{}
+               muted_targets: %{},
+               # #1480 — SILENCE, and deliberately so for existing subjects
+               # too (vjt: «suono deve essere opt-in»). Asserted as a literal
+               # rather than through the module attribute: the value IS the
+               # ruling, and a test that reads the constant it is guarding
+               # would go green on a default someone flipped.
+               notification_sound: "none"
              }
     end
   end
@@ -460,7 +466,8 @@ defmodule Grappa.UserSettingsTest do
         private_messages_only: ["alice"],
         presence_online: false,
         presence_offline: false,
-        muted_targets: %{"azzurra #noisy" => %{"until" => nil}}
+        muted_targets: %{"azzurra #noisy" => %{"until" => nil}},
+        notification_sound: "icq"
       }
 
       assert {:ok, %Settings{}} = UserSettings.put_notification_prefs({:user, user.id}, prefs)
@@ -701,6 +708,112 @@ defmodule Grappa.UserSettingsTest do
 
   defp read_muted(user),
     do: UserSettings.get_notification_prefs({:user, user.id}).muted_targets
+
+  # ---------------------------------------------------------------------------
+  # notification_sound — the in-app beep preset (#1480)
+  # ---------------------------------------------------------------------------
+
+  defp put_sound(user, prefs),
+    do:
+      UserSettings.put_notification_prefs(
+        {:user, user.id},
+        Map.merge(base_prefs(%{}), prefs)
+      )
+
+  defp read_sound(user),
+    do: UserSettings.get_notification_prefs({:user, user.id}).notification_sound
+
+  describe "notification_prefs notification_sound (#1480 — the closed-set twin)" do
+    test "round-trips a member of the closed set" do
+      user = user_fixture()
+
+      assert {:ok, _} = put_sound(user, %{notification_sound: "xp_notify"})
+      assert read_sound(user) == "xp_notify"
+    end
+
+    test "the WRITE rejects a value outside the closed set, naming the set" do
+      user = user_fixture()
+
+      assert {:error, %Ecto.Changeset{} = cs} =
+               put_sound(user, %{notification_sound: "airhorn"})
+
+      assert {"notification_sound must be one of " <> _, _} =
+               Keyword.fetch!(cs.errors, :notification_prefs)
+    end
+
+    test "a rejected write leaves the STORED value untouched" do
+      user = user_fixture()
+      assert {:ok, _} = put_sound(user, %{notification_sound: "chime"})
+
+      assert {:error, %Ecto.Changeset{}} = put_sound(user, %{notification_sound: "airhorn"})
+
+      # The 422 is only half the contract: a validator that errors AFTER
+      # writing would be indistinguishable at the changeset and would still
+      # have clobbered the subject's pick.
+      assert read_sound(user) == "chime"
+    end
+
+    test "the READ falls back to silence on a value the BEAM cannot name" do
+      user = user_fixture()
+
+      # Not reachable through the writer — that is the point. This is the row
+      # a NEWER cic bundle wrote (a preset added after this BEAM shipped), or
+      # one hand-edited in the DB. The reader must degrade to the default
+      # rather than hand the client a name it will not match either.
+      poison_stored_sound(user, "preset_from_the_future")
+
+      assert read_sound(user) == "none"
+    end
+
+    test "the READ falls back to silence when the key is absent entirely" do
+      user = user_fixture()
+      # The pre-#1480 row: prefs configured, no sound key at all.
+      assert {:ok, _} = put_muted(user, %{})
+      drop_stored_sound(user)
+
+      assert read_sound(user) == "none"
+    end
+
+    test "an OLD bundle's save preserves the pick instead of resetting it" do
+      user = user_fixture()
+      assert {:ok, _} = put_sound(user, %{notification_sound: "icq"})
+
+      # `base_prefs/1` is byte-for-byte the pre-#1480 PUT body: every key the
+      # old cic knows, and no `notification_sound`. The endpoint is a full
+      # replace, so absence has to mean "I am saying nothing about the sound"
+      # — reading it as "set it to the default" would silence an opted-in
+      # subject the first time they tick any other checkbox.
+      assert {:ok, _} = put_muted(user, %{})
+
+      assert read_sound(user) == "icq"
+    end
+
+    test "an explicit \"none\" is a real choice, not an absence" do
+      user = user_fixture()
+      assert {:ok, _} = put_sound(user, %{notification_sound: "chime"})
+
+      assert {:ok, _} = put_sound(user, %{notification_sound: "none"})
+
+      assert read_sound(user) == "none"
+    end
+  end
+
+  # Write a value straight into the stored blob, bypassing the validator. Used
+  # only to stage rows the writer cannot produce (a future preset name, or the
+  # pre-#1480 shape) — the reader's tolerance is the thing under test.
+  defp poison_stored_sound(user, value),
+    do: rewrite_stored_prefs(user, &Map.put(&1, "notification_sound", value))
+
+  defp drop_stored_sound(user),
+    do: rewrite_stored_prefs(user, &Map.delete(&1, "notification_sound"))
+
+  defp rewrite_stored_prefs(user, fun) do
+    settings = UserSettings.get_or_init({:user, user.id})
+    prefs = Map.get(settings.data, "notification_prefs", %{})
+    next = Map.put(settings.data, "notification_prefs", fun.(prefs))
+
+    Repo.update!(Settings.changeset(settings, %{data: next}))
+  end
 
   describe "notification_prefs muted_targets (#866, network-keyed since #1038)" do
     test "folds the TARGET and keeps the slug, so the stored key is the one a row matches" do

--- a/test/grappa_web/controllers/user_settings_controller_test.exs
+++ b/test/grappa_web/controllers/user_settings_controller_test.exs
@@ -36,7 +36,11 @@ defmodule GrappaWeb.UserSettingsControllerTest do
       "presence_offline" => false,
       # #866 — nothing muted by default; the wire carries the key so a client
       # can tell "no mutes" from "a server that predates the field".
-      "muted_targets" => %{}
+      "muted_targets" => %{},
+      # #1480 — the in-app beep preset, shipped SILENT. Same reasoning as the
+      # line above for why the key is on the wire at all, and the value is the
+      # ruling: an untouched subject makes no sound.
+      "notification_sound" => "none"
     }
   end
 
@@ -100,7 +104,13 @@ defmodule GrappaWeb.UserSettingsControllerTest do
                "private_messages_only" => ["alice"],
                "presence_online" => false,
                "presence_offline" => false,
-               "muted_targets" => %{}
+               "muted_targets" => %{},
+               # #1480 — the PUT above is a pre-#1480 body: it names every key
+               # the old client knew and NOT the sound. The endpoint is a full
+               # replace, so this asserts the one place absence must not mean
+               # "reset" — the reader still answers with the default rather
+               # than dropping the key.
+               "notification_sound" => "none"
              }
     end
   end
@@ -236,6 +246,28 @@ defmodule GrappaWeb.UserSettingsControllerTest do
       conn = put(conn, "/me/settings/notification-prefs", body)
 
       assert %{"error" => "validation_failed"} = json_response(conn, 422)
+    end
+
+    # #1480 — the closed set is enforced at THIS boundary, not only in the
+    # context: cic narrows the value to the union before it ever gets typed,
+    # so the only writer that can reach here with garbage is one that is not
+    # cic, which is exactly the writer a boundary exists for.
+    test "422 when notification_sound is outside the closed set", %{conn: conn} do
+      body = valid_prefs_wire(%{"notification_sound" => "airhorn"})
+      conn = put(conn, "/me/settings/notification-prefs", body)
+
+      assert %{"error" => "validation_failed"} = json_response(conn, 422)
+    end
+
+    test "200 for a member of the set, and the echo carries it back", %{conn: conn} do
+      body = valid_prefs_wire(%{"notification_sound" => "xp_ding"})
+      conn = put(conn, "/me/settings/notification-prefs", body)
+
+      # The echo is what the drawer and the `/beep` verb both adopt, so a
+      # server that persisted the value but answered with the old one would
+      # leave every client one round-trip behind its own write.
+      assert %{"notification_prefs" => %{"notification_sound" => "xp_ding"}} =
+               json_response(conn, 200)
     end
   end
 


### PR DESCRIPTION
Implements issue 1480: the in-app notification sound becomes a chosen preset, and the shipped choice becomes silence.

Two reports land on one module. alk: the sound is indistinguishable from the Windows Sticky Keys chime. deadbeef_ (macOS): cicchetto still beeps through Do Not Disturb. `cicchetto/src/lib/beep.ts` was a single hard-coded 440 Hz sine with no way to change it and no way to turn it off.

**"Respect Do Not Disturb" is not the cure, and cannot be.** A web page cannot read macOS Focus/DND — there is no browser API, so cic has no signal to gate on. The *banner* half already behaves (the OS suppresses its own notification; deadbeef_ confirmed none arrived). The *sound* half is a Web Audio node started by the page, which the OS never sees and therefore never gates. The implementable answer is a preset the user picks, one of which is silence.

## What ships

| | |
|---|---|
| **default** | `none` — silence, for everyone, existing subjects included |
| **synthesised** | `tone` (the 440 Hz sine, unchanged to the Hz), `chime`, `blip`, `pop` |
| **sampled** | `icq`, `xp_notify`, `xp_ding`, `xp_balloon`, `xp_exclamation` |
| **UI** | a picker at the top of the notifications page, plus a preview button |
| **verb** | `/beep` · `/beep on` · `/beep off` · `/beep <preset>` |
| **wire** | `protocol_version` 17 → 18; `min_protocol_version` unmoved at 1 |

The default flip is vjt's ruling («e mettiamo default off», «suono deve essere opt-in», «mi sta bene che sia disattivato per tutti»), his framing being that an audible beep a user never asked for is a privacy invasion. It is a deliberate behaviour change for existing subjects, not the usual "nobody's setting moves on upgrade".

`on` is **not** a synonym for "the default" — the default is silence and `on` is what a user types to opt in. They are two separate constants so a later change of default cannot silently redefine `/beep on`. A generic `/set <key> <value>` was proposed and killed by vjt on his own call («/set è un puttanaio lasciamo perdere»).

**No audio bytes are added here.** The five mp3s landed on main on 2026-08-18 in `172df6037`, an ancestor of this base; `origin/main..HEAD` carries 0 `.mp3` paths against 5 on the base. This branch adds the code that reads them, and extends the service worker's `globPatterns` with `mp3` so a chosen preset still plays offline — the case that matters most for a PWA notification sound.

## 🔴 The wire-shape pin is blind to this change, and that is a finding

CLAUDE.md sells `mix grappa.wire_pin --check` as the tripwire that forces `protocol_version` to move on every wire-shape change. It did not fire here, and the refreshed pin proves it rather than merely suggesting it:

```
before   protocol_version = 17   shape_digest = sha256:b651b30c…37b2c81c
after    protocol_version = 18   shape_digest = sha256:b651b30c…37b2c81c
```

`--update` moved the number and left the digest **byte-identical**. Predicted before the bump by a static measurement with controls: `notification` appears **0** times in each generated artefact (`wireTypes.ts`, `wireSchema.ts`); positive control `server_time` appears **2** times in `wireTypes.ts`, so the grep was answering.

The mechanism is the one the task's own moduledoc names as a limit: the digest's third component covers the `@spec`s the hand-written `GrappaWeb.*JSON` views export, and a spec referencing a **remote** type is digested as the reference *text*. `UserSettingsJSON.notification_prefs/1` names `UserSettings.notification_prefs()`, so growing that type behind the name moves nothing the gate reads.

This is the **fourth** occurrence (`BootJSON` #1679, `MessagesJSON` #2037, `UserSettingsJSON` v16, this) and the **second** through this same view — which generalises: *any* key added inside `notification_prefs()` or `display_prefs()` will always be invisible there, because both are remote types behind a view spec. The bump was therefore made by hand. No issue filed; the enqueue is not mine.

## Absence and garbage are different claims

Server-side the key follows the `display_prefs.time_format` twin — the READ falls back to the default on an unrecognised value, the WRITE rejects one — with one deviation: an **absent** key on the write means UNCHANGED, not "reset to default".

That is `muted_targets`' own rule (#866) and its reason applies verbatim: `PUT /user_settings/notification_prefs` is a full replace and cic deploys independently of the BEAM, so a bundle that has never heard of the picker is saying nothing about the sound. Reading its silence as a choice would mute an opted-in subject the first time they ticked any other checkbox. An unrecognised *value* still 422s.

## Dead code removed in the same commit

- `resolve_muted/2` — with a second `:unchanged` key it would have paid two SELECTs for one PUT, and the client that omits either key omits both. `resolve_unchanged/4` reads once and fills whichever are missing.
- `beep.ts`'s three module constants (`BEEP_FREQ_HZ` / `BEEP_DURATION_MS` / `BEEP_GAIN`) — the tone is now a row in the preset table, and a duplicate would be a second place to change it.
- `writeMutedTargets`'s standalone GET-merge-PUT body — generalised to `writeNotificationPrefs` so `/beep` inherits one additivity argument instead of a second copy of it.

## A comment that had been wrong since UX-6-L

`beep.ts`'s header said the beep fires "when the cic page is foreground". The call site gates on `!effectivelyFocused(slug, displayName)` — per **conversation**, not per page — so it fires for a background tab too, which is exactly the case deadbeef_ hit with cicchetto behind a Focus session. A reader who trusted that sentence would have looked in the wrong half of the system.

## The e2e this change breaks, and why that is the point

`ux-6-l-foreground-push-beep.spec.ts` asserted `__lastBeepAt` advances on a mention and on a DM. With the default at `none` those arms are red — correctly. Worse was its third arm, "PRIVMSG without a mention does NOT beep": it would have gone **vacuously green**, passing because nothing ever beeps rather than because the mention gate held.

All three now opt in first with `/beep on`, typed into the real compose box, and compare against the stamp that opt-in leaves rather than against `null`. The verb is its own barrier — it plays the preset only after the PUT resolves — so no sleep and no side probe are needed to know the server has the value.

The new `issue1480-notification-sound-preset.spec.ts` covers the axis this work adds. Its default arm waits for the mention to be persisted server-side **and** rendered in cic's scrollback before asserting silence, so a green says "the alert path ran and chose not to sound" and can never say "the message never arrived".

## Measured

- **Six mutants, six targeted kills.** Moving the silent-preset return past the seam stamp; dropping the decode-cache eviction; resolving `/beep on` to the default instead of the tone; passing a literal preset from `subscribe.ts` instead of the pref; playing the sound before the write lands; and stripping the reader's closed-set fallback. Each killed exactly the assertion that owns its property.
- The first mutant exposed a test that **claimed** to check "does not even build an AudioContext" while asserting `resumes === 0` — zero either way. It now counts constructions, with the negative control being the same module instance building one for a real preset.
- The three mp3s reachable from here were re-downloaded independently and are byte-identical to what `172df6037` committed (`cmp`; two-different-files negative control at rc=1). Sizes match the issue's manifest exactly: 12537 / 11969 / 5447.
- `PROVENANCE.md` said "all five are 22050 Hz stereo". Re-measured with `afinfo`, calibrated in both directions first (rc=1 on a text file, a duration on a known-good system AIFF): the ICQ sound is **44100 Hz mono** and does not come from the Archive item, so it never had a reason to match. The table now carries a per-file format column.
- The dispatch characterization net moved by exactly the predicted three hunks — 64→65 arms, one `beep` row, **no** new indistinguishable pair — and nothing else.

## Not measured, and not claimed

- **Whether any preset sounds good, or whether alk likes one.** This host has no audio. The issue's acceptance bar ("at least one preset alk actually likes") is not something a gate can answer. The sample gain (0.6, one shared constant) is a judgement, not a measurement — it is one constant precisely so a future ear can move it once.
- **The samples playing offline.** The `globPatterns` extension is the mechanism, argued from how workbox precaching works, not from a build inspected with the network down.
- **Cross-device convergence.** The e2e proves the round trip through a reload; a second device is the same round trip and is not reachable from the harness.

## Gates

- `scripts/bun.sh run check` — 5/5 stages green.
- `scripts/bun.sh run test` — 352/352 files green.
- `scripts/check.sh` — rc 0. `7299 tests, 0 failures`; bats `764/764`, zero `not ok`.
- `mix grappa.wire_pin --check` — `wire shape and protocol 18 agree.`
- `mix grappa.gen_wire_types --check` — both artefacts in sync.
- `scripts/design-notes-gate.sh` — 1 new entry, separator and marker present.
- `integration` runs from this PR's own CI; it was deliberately not run locally.

**Every number above was taken AFTER the rebase, not before.** `origin/main`
moved by three commits while this was in flight, and two of them land inside
this branch's dependency graph — `cicchetto/src/lib/pushTriggers.ts` and
`lib/grappa/mentions.ex` — so the pre-rebase green stopped being attributable
and was re-taken rather than quoted. The wire pin in particular had to be
re-checked on top of them: a pin refreshed under a different base is a pin for
nobody.

The rebase went through `scripts/union-rebase.sh` with the branch contribution
pinned before and diffed after. The prediction was written first — 159 added,
0 deleted on `docs/DESIGN_NOTES.md`, every other path byte-identical — and it
held on both sides, with the entry boundary read on the real file afterwards
(previous entry's last line, marker, blank, `---`, blank, heading) because an
identical numstat proves nothing if the pre-state was already broken.
