### PR TITLE
cic(2086): dim the reply's quoted head so the answer carries the weight

### DIFF
--- a/cicchetto/src/MircText.tsx
+++ b/cicchetto/src/MircText.tsx
@@ -6,6 +6,7 @@ import { classifyMediaLink, sameHostHref } from "./lib/mediaLink";
 import { openMediaViewer } from "./lib/mediaViewer";
 import { mircPlainRuns, parseMircFormat, type Run } from "./lib/mircFormat";
 import { maybeEscapePwaClick } from "./lib/platform";
+import { replyQuoteHeadLength } from "./lib/quotableBody";
 import { serverSettings } from "./lib/serverSettings";
 import { getStripFormatting } from "./lib/stripFormatting";
 
@@ -110,6 +111,53 @@ const renderChannel = (
   );
 };
 
+// issue 2086 — a run, plus whether it falls inside the quoted head of a reply.
+// The flag is the ONLY thing this layer adds to `Run`: `mircFormat` decodes the
+// wire and knows nothing about what cic's Reply verb emits, and keeping the
+// classification here is what stops the wire parser from growing a second job.
+type QuotedRun = Run & { quoted: boolean };
+
+// issue 2086 — split the runs at the end of the quoted head, so the head can be
+// dimmed and the answer cannot. vjt (#it-opers, 2026-09-11): "facciamo sì che
+// il colore della parte quotata sia più muted, cosi si vede di più il messaggio
+// inviato".
+//
+// The boundary comes from `replyQuoteHeadLength` — the SAME `PREVIOUS_QUOTE`
+// predicate a re-reply strips with — measured against the run texts joined
+// back, which IS the plain projection (`mircPlainText` is literally that
+// concatenation). So the dimmed region and the stripped region are one region
+// by construction: no second detector, and nothing to keep in step.
+//
+// `trimStart` because the requote path matches a `.trim()`ed body while the
+// renderer must keep every character it was given. Two lines to keep the two
+// answers identical on a body with leading whitespace; without them the render
+// would silently decline to dim a head the requote would still cut.
+//
+// The cut can land INSIDE a run (the common case: one plain run for the whole
+// body), so that run is split in two — which is also why this returns runs and
+// not an index. Emphasis and linkify then run per half; neither can span the
+// `<< ` boundary, because a space sits there.
+const splitReplyQuote = (runs: Run[]): QuotedRun[] => {
+  const plain = runs.map((run) => run.text).join("");
+  const lead = plain.length - plain.trimStart().length;
+  const head = replyQuoteHeadLength(plain.slice(lead));
+  if (head === 0) return runs.map((run) => ({ ...run, quoted: false }));
+  const cut = lead + head;
+  const out: QuotedRun[] = [];
+  let seen = 0;
+  for (const run of runs) {
+    const end = seen + run.text.length;
+    if (end <= cut) out.push({ ...run, quoted: true });
+    else if (seen >= cut) out.push({ ...run, quoted: false });
+    else {
+      out.push({ ...run, text: run.text.slice(0, cut - seen), quoted: true });
+      out.push({ ...run, text: run.text.slice(cut - seen), quoted: false });
+    }
+    seen = end;
+  }
+  return out;
+};
+
 // CP13 S10: render an IRC body string with mIRC formatting expanded into
 // per-run <span> elements. Plain text (no control chars) collapses into a
 // single Run and renders as one <span>; the no-formatting fast path is
@@ -117,7 +165,7 @@ const renderChannel = (
 // active toggle attribute + inline style for fg/bg colors (the palette is
 // 16 fixed values — we don't generate per-color CSS classes).
 const renderRun = (
-  run: Run,
+  run: QuotedRun,
   linkPolicy: LinkPolicy,
   emphasis: boolean,
   onChannelClick: ((channel: string) => void) | undefined,
@@ -154,6 +202,20 @@ const renderRun = (
         "scrollback-mirc-strikethrough": run.strikethrough,
         "scrollback-mirc-monospace": run.monospace,
         "scrollback-mirc-reverse": run.reverse && run.fg === undefined && run.bg === undefined,
+        // issue 2086 — the quoted head, dimmed to `--muted` (the token every
+        // theme already defines for secondary text, so the gallery themes and
+        // the theme editor follow for free; a literal grey would not).
+        //
+        // Withheld from a run that carries an EXPLICIT colour, on the same
+        // fg/bg test the reverse line above uses. The dimming must LOSE to a
+        // `\x03` the sender chose: a colour opened inside the quote keeps
+        // applying past `<< `, so the head is already part-coloured, and a dim
+        // that fought it would repaint characters the sender coloured on
+        // purpose. The inline `style` would win the cascade anyway on a plain
+        // fg run — stating it here also covers `reverse`, where fg lands on
+        // `background-color` and leaves `color` free for the class to take,
+        // and keeps the DOM from claiming "muted" where nothing is muted.
+        "scrollback-reply-quote": run.quoted && run.fg === undefined && run.bg === undefined,
       }}
       style={style}
     >
@@ -304,8 +366,14 @@ export const MircBody: Component<{
   // re-runs on `props.body`: toggling re-renders every open pane with no
   // reconnect and no refetch, because the raw body is untouched and only its
   // projection changed. That is the issue's own contract, not a nicety.
-  const runs = (): Run[] =>
-    getStripFormatting() ? mircPlainRuns(props.body) : parseMircFormat(props.body);
+  //
+  // issue 2086 rides the same chokepoint, and for the reason stated right
+  // above: a reply reads the same way on every surface that renders a body,
+  // and a per-surface opt-in list is the thing that rots. The classification
+  // is by SHAPE, so a hand-typed quote dims too — acceptable by the issue's
+  // own ruling, because it looks like a quote precisely because it is one.
+  const runs = (): QuotedRun[] =>
+    splitReplyQuote(getStripFormatting() ? mircPlainRuns(props.body) : parseMircFormat(props.body));
   // Default "navigate" is the genuine config default — correct
   // production behavior for every non-tappable-surface consumer.
   //

--- a/cicchetto/src/__tests__/MircText.test.tsx
+++ b/cicchetto/src/__tests__/MircText.test.tsx
@@ -330,3 +330,75 @@ describe("MircText strip-formatting preference (#2029)", () => {
     expect(link.href).toBe("https://example.com/x");
   });
 });
+
+// issue 2086 — the quoted head of a reply renders MUTED so the answer after
+// `<< ` carries the visual weight. The region is the one `PREVIOUS_QUOTE`
+// identifies (`lib/quotableBody`), the same predicate a re-reply strips with:
+// these tests assert the SEEN outcome, so a rendering that drifted from the
+// detector shows up as a wrong span boundary rather than as a passing mirror.
+describe("MircText reply-quote dimming (issue 2086)", () => {
+  const MUTED = ".scrollback-reply-quote";
+  const mutedText = (container: HTMLElement): string =>
+    [...container.querySelectorAll(MUTED)].map((el) => el.textContent).join("");
+
+  beforeEach(() => setStripFormatting(false));
+  afterEach(() => setStripFormatting(false));
+
+  it("dims the head up to and including the tail, and nothing of the answer", () => {
+    const { container } = render(() => <MircBody body="<vjt> ciao mondo << sì certo" />);
+    expect(mutedText(container)).toBe("<vjt> ciao mondo << ");
+  });
+
+  // Constraint 1: muted, never hidden. A sender can type the shape by hand and
+  // must still be able to read what they wrote.
+  it("hides nothing — every character of the body is still in the DOM", () => {
+    const { container } = render(() => <MircBody body="<vjt> ciao mondo << sì certo" />);
+    expect(container.textContent).toBe("<vjt> ciao mondo << sì certo");
+  });
+
+  it("dims an ACTION-shaped head too (`* nick …<< `)", () => {
+    const { container } = render(() => <MircBody body="* vjt saluta << ricambio" />);
+    expect(mutedText(container)).toBe("* vjt saluta << ");
+  });
+
+  // The detector is not a bare `<<` search, and the render must not become one:
+  // these are somebody's sentence, not a quote.
+  it("leaves a body that merely CONTAINS `<<` completely undimmed", () => {
+    for (const body of ["shift << 2 is a doubling", "cat <<EOF then the heredoc"]) {
+      const { container } = render(() => <MircBody body={body} />);
+      expect(container.querySelector(MUTED)).toBeNull();
+      expect(container.textContent).toBe(body);
+    }
+  });
+
+  // Constraint 2 — the one that breaks in silence. A colour opened INSIDE the
+  // quoted head keeps applying past `<< `, so the head is half-coloured and the
+  // answer is coloured. The dimming must LOSE to the explicit colour: the
+  // coloured characters keep the sender's colour on both sides of the boundary,
+  // and only the uncoloured head prefix is muted.
+  it("loses to an explicit mIRC colour that crosses the `<< ` boundary", () => {
+    const { container } = render(() => <MircBody body={"<vjt> ciao \x0304mondo << sì certo"} />);
+
+    // Only the run before the colour code is dimmed.
+    expect(mutedText(container)).toBe("<vjt> ciao ");
+    // The coloured run spans the boundary and is NOT dimmed anywhere.
+    for (const el of container.querySelectorAll(MUTED)) {
+      expect((el as HTMLElement).style.color).toBe("");
+    }
+    const coloured = [...container.querySelectorAll("span")].filter(
+      (el) => (el as HTMLElement).style.color !== "",
+    );
+    expect(coloured.length).toBeGreaterThan(0);
+    expect(coloured.map((el) => el.textContent).join("")).toBe("mondo << sì certo");
+    expect(container.textContent).toBe("<vjt> ciao mondo << sì certo");
+  });
+
+  // The head is a property of the TEXT, not of the decoration: #2029's strip
+  // takes the colours away and the quote is still a quote.
+  it("still dims the head with the strip-formatting preference ON", () => {
+    setStripFormatting(true);
+    const { container } = render(() => <MircBody body={"<vjt> ciao \x0304mondo << sì certo"} />);
+    expect(mutedText(container)).toBe("<vjt> ciao mondo << ");
+    expect(container.textContent).toBe("<vjt> ciao mondo << sì certo");
+  });
+});

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -7509,3 +7509,57 @@ describe("#1914 /topic answer row", () => {
     expect(rows).toEqual(["scrollback-line", "topic-show-line", "scrollback-line"]);
   });
 });
+
+// issue 2086 — vjt (#it-opers, 2026-09-11): "sul reply facciamo sì che il
+// colore della parte quotata sia più muted, cosi si vede di più il messaggio
+// inviato". The dimming itself is proven at the renderer (MircText.test.tsx);
+// what belongs HERE is that a real scrollback row shows it — the pane is the
+// surface the operator actually looks at, and a class that never reaches a
+// message body would pass every unit test and change nothing on screen.
+describe("issue 2086 reply-quote dimming in the pane", () => {
+  const CHAN = "#t2086";
+  const KEY_2086 = `freenode ${CHAN}` as ChannelKey;
+
+  const msg = (id: number, body: string, kind: ScrollbackMessage["kind"]): ScrollbackMessage => ({
+    id,
+    network: "freenode",
+    channel: CHAN,
+    server_time: 1_700_000_000_000 + id,
+    kind,
+    sender: "alice",
+    body,
+    meta: {},
+  });
+
+  const mount = () =>
+    render(() => <ScrollbackPane networkSlug="freenode" channelName={CHAN} kind="channel" />);
+
+  beforeEach(() => {
+    setUserNick("vjt");
+    mockMembersByChannel.mockReturnValue({});
+  });
+
+  it("dims the quoted head of a message row and leaves the answer at full weight", () => {
+    setScrollback({ [KEY_2086]: [msg(1, "<bob> ciao mondo << sì certo", "privmsg")] });
+    mount();
+
+    const row = screen.getByTestId("scrollback-line");
+    const dimmed = Array.from(row.querySelectorAll(".scrollback-reply-quote"))
+      .map((el) => el.textContent)
+      .join("");
+    expect(dimmed).toBe("<bob> ciao mondo << ");
+    // Muted, not hidden: the whole line is still readable in the row.
+    expect(row).toHaveTextContent("<bob> ciao mondo << sì certo");
+  });
+
+  // The negative control that keeps this from becoming a `<<` search on the
+  // surface where ordinary prose actually arrives.
+  it("leaves an ordinary message that merely contains `<<` alone", () => {
+    setScrollback({ [KEY_2086]: [msg(2, "shift << 2 gives four", "privmsg")] });
+    mount();
+
+    const row = screen.getByTestId("scrollback-line");
+    expect(row.querySelector(".scrollback-reply-quote")).toBeNull();
+    expect(row).toHaveTextContent("shift << 2 gives four");
+  });
+});

--- a/cicchetto/src/__tests__/replyQuote.test.ts
+++ b/cicchetto/src/__tests__/replyQuote.test.ts
@@ -4,6 +4,7 @@ import type { ScrollbackMessage } from "../lib/api";
 import { channelKey } from "../lib/channelKey";
 import { getDraft, setDraft } from "../lib/compose";
 import { appendToCompose } from "../lib/composeAppend";
+import { quotableBody, replyQuoteHeadLength } from "../lib/quotableBody";
 import {
   REPLY_QUOTE_BODY_LIMIT,
   REPLY_QUOTE_ELLIPSIS,
@@ -597,5 +598,55 @@ describe("replyQuote — a bridged message quotes its AUTHOR, not the relay (iss
     expect(replyQuote(msg({ sender: "alice", body: "<bob> original<< answer" }))).toBe(
       "<alice> answer << ",
     );
+  });
+});
+
+// issue 2086 — the render dims the quoted head, and it must dim EXACTLY the
+// region a re-reply strips. `replyQuoteHeadLength` is the one door that answers
+// "how far does the quote reach"; `startsWithReplyQuote` is now derived from
+// it, so the boolean and the offset cannot come apart.
+//
+// The structural assertion is the last `it` below: what stays visible past the
+// dimmed head is byte-for-byte what `quotableBody` keeps. If the two ever
+// disagree, one of them is lying to the reader.
+describe("replyQuoteHeadLength — how far the quote reaches (issue 2086)", () => {
+  it("counts the head up to and including the tail's trailing space", () => {
+    const body = "<bob> ciao mondo << risposta";
+    expect(body.slice(0, replyQuoteHeadLength(body))).toBe("<bob> ciao mondo << ");
+  });
+
+  it("counts an action-shaped head the same way", () => {
+    const body = "* bob saluta << ricambio";
+    expect(body.slice(0, replyQuoteHeadLength(body))).toBe("* bob saluta << ");
+  });
+
+  it("lands on the LAST tail, so a chain sheds every hop", () => {
+    const body = "<a> uno << <b> due << tre";
+    expect(body.slice(0, replyQuoteHeadLength(body))).toBe("<a> uno << <b> due << ");
+  });
+
+  it("reaches the whole body when the sender wrote nothing past the tail", () => {
+    const body = "<bob> ciao mondo <<";
+    expect(replyQuoteHeadLength(body)).toBe(body.length);
+  });
+
+  it("answers 0 for the shapes that only LOOK like a quote", () => {
+    expect(replyQuoteHeadLength("shift << 2 gives four")).toBe(0);
+    expect(replyQuoteHeadLength("cat <<EOF > f")).toBe(0);
+    expect(replyQuoteHeadLength("<3 you << me")).toBe(0);
+    expect(replyQuoteHeadLength("bozza <bob> ciao<< risposta")).toBe(0);
+    expect(replyQuoteHeadLength("nessuna citazione qui")).toBe(0);
+  });
+
+  it("agrees with what quotableBody keeps — same region, by construction", () => {
+    for (const body of [
+      "<bob> ciao mondo << risposta",
+      "* bob saluta << ricambio",
+      "<a> uno << <b> due << tre",
+      "shift << 2 gives four",
+      "nessuna citazione qui",
+    ]) {
+      expect(body.slice(replyQuoteHeadLength(body)).trim()).toBe(quotableBody(msg({ body })));
+    }
   });
 });

--- a/cicchetto/src/lib/quotableBody.ts
+++ b/cicchetto/src/lib/quotableBody.ts
@@ -98,6 +98,19 @@ function attributed(msg: ScrollbackMessage): { author: string | null; body: stri
   return { author: relay[1] ?? null, body: body.slice(relay[0].length).trim() };
 }
 
+// How far a quote-shaped head reaches into `text`, in UTF-16 units, or 0 when
+// the text is not quote-shaped. The count INCLUDES the tail's trailing space,
+// so `text.slice(headLength)` is exactly what `withoutPreviousQuote` keeps.
+//
+// issue 2086 — the RENDER dims that head, and it must dim the same region a
+// re-reply strips: a second detector would let the two drift, and then the
+// colour on screen would be describing a boundary the requote does not use.
+// The offset is the general answer here — a boolean cannot say WHERE — so the
+// two doors below are one `exec` and its `> 0`, never two regexes.
+export function replyQuoteHeadLength(text: string): number {
+  return PREVIOUS_QUOTE.exec(text)?.[0].length ?? 0;
+}
+
 // #1688 — the same question asked of a COMPOSE DRAFT rather than of a wire
 // body: does this string already open with a quote WE emitted?
 //
@@ -107,7 +120,7 @@ function attributed(msg: ScrollbackMessage): { author: string | null; body: stri
 // mis-classification is what decides whether the operator's own sentence gets
 // reordered. One nick charset, one anchor, one answer.
 export function startsWithReplyQuote(text: string): boolean {
-  return PREVIOUS_QUOTE.test(text);
+  return replyQuoteHeadLength(text) > 0;
 }
 
 // Only CONTENT kinds quote (`isContentKind` — privmsg/notice/action, the same

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -4003,6 +4003,21 @@ button.topic-bar-windows-opener {
   filter: invert(1);
 }
 
+/* issue 2086 — the quoted head of a reply (`<nick> …body… << `), dimmed so the
+   answer typed after it carries the weight. `--muted` is the token every theme
+   already defines for secondary text, and it is the SAME pair timestamps run
+   against `--bg`, so the contrast floor is one that was already accepted — a
+   literal grey here would break the gallery themes and the theme editor, and
+   anything dimmer than `--muted` would owe a measurement.
+
+   Colour ONLY: muted, never hidden. A sender can type the shape by hand (the
+   detector says "quote-shaped", not "we emitted it") and must still be able to
+   read every character back. The renderer withholds this class from a run that
+   carries an explicit mIRC colour — see MircText's renderRun. */
+.scrollback-reply-quote {
+  color: var(--muted);
+}
+
 .scrollback-presence {
   color: var(--muted);
   font-style: italic;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54057,3 +54057,83 @@ write-on-change with no dirty state, and the two whitelist TEXT fields keep
 their own signals (seeded only by the drawer's own load), so nothing being
 typed can be clobbered — the drawer shows what the server says, which is
 the posture cic holds everywhere else.
+<!-- entry #2086 -->
+
+---
+
+## 2026-09-11 — issue 2086: the quoted head dims by losing, and it dims the region a re-reply strips
+
+vjt, #it-opers 18:47: *"sul reply.. facciamo sì che il colore della parte
+quotata sia più 'muted' cosi si vede di più il messaggio inviato"*. A reply
+is plain wire text — `<nick> …body… << ` then the answer — so in cic's own
+scrollback the two halves render as one undifferentiated run, and the quote
+is the longer half (up to 100 body characters since #1277 raised the #1235
+cap). Render-side only: nothing on the wire, nothing in what gets quoted, no
+new persisted field.
+
+### One detector, and the offset is the general door
+
+`PREVIOUS_QUOTE` (`quotableBody.ts`) already answers "is this quote-shaped",
+and it is the predicate a re-reply strips with. The render needs the same
+answer plus WHERE, which a boolean cannot say, so `startsWithReplyQuote/1`
+is now derived from a new `replyQuoteHeadLength/1` — one `exec`, and its
+`> 0`. The count includes the tail's trailing space, so `slice(headLength)`
+is exactly what `withoutPreviousQuote` keeps.
+
+That sharing is structural, not thrift. If the styled region and the
+stripped region were computed twice they would drift, and then the colour on
+screen would be describing a boundary the requote does not use — one of the
+two would be lying to the reader about what "the quote" is.
+
+The boundary is measured against the run texts joined back, which IS the
+plain projection: `mircPlainText` is literally that concatenation, and
+`mircPlainRuns` (#2029's strip) keeps the same text. So the same offset
+holds with the strip preference on or off. One correction the requote path
+forces: it matches a `.trim()`ed body while the renderer must keep every
+character it was handed, so the render measures from `trimStart`. Without
+those two lines a body with leading whitespace would be dimmed by nobody and
+cut by the requote.
+
+### The dimming LOSES, and it is withheld rather than out-cascaded
+
+Constraint the issue names and the one that breaks in silence: a `\x03`
+opened INSIDE the quoted head keeps applying past `<< `. The head is
+therefore already part-coloured, and a dim that fought the colour would
+repaint characters the sender chose on purpose.
+
+So the class is withheld from any run carrying an explicit fg or bg — the
+same `run.fg === undefined && run.bg === undefined` test the reverse line one
+row above already uses. Relying on inline-style-beats-class would have been
+true for a plain coloured run and FALSE for `reverse`, where the parser puts
+fg on `background-color` and leaves `color` free for a class to take. It also
+keeps the DOM from claiming `muted` on a span where nothing is muted, which
+is what the test asserts against.
+
+### `--muted`, and the chokepoint
+
+`--muted` is the token every theme already defines for secondary text, so
+the gallery themes and the theme editor follow for free; a literal grey would
+break both. It is also the same pair timestamps run against `--bg`, so the
+contrast floor is one already accepted — anything dimmer would owe a
+measurement, not a taste call.
+
+Applied at `MircBody`'s single `runs()` accessor, with no per-surface prop,
+for the reason #2029 wrote three lines above it: a reply reads the same way
+on every surface that renders a body, and a per-surface opt-in list is the
+thing that rots. The classification is by SHAPE, so a head somebody typed by
+hand dims too — acceptable by the issue's own ruling, because it looks like a
+quote precisely because it is one. Colour only: muted, never hidden.
+
+### What this does NOT claim
+
+- No contrast measurement was taken. The claim is inheritance — `--muted` on
+  `--bg` is the timestamp pair — not a fresh ratio.
+- Nothing was looked at in a browser. The evidence is jsdom: the dimmed span
+  boundary, the colour crossing it, and the full text still present.
+- #455's emphasis markers cannot pair across the `<< ` boundary any more,
+  because the run is split there. Neither can linkify join a URL across it —
+  but a space sits at that boundary, so no URL could span it anyway, and a
+  marker pair spanning quote-head-to-answer is not a shape anyone writes.
+- Out of scope, as the issue says: turning the reply into a structured field
+  with its own wire representation. This is a colour on a region that was
+  already identified.


### PR DESCRIPTION
Render-side only. Nothing changes on the wire, nothing changes in what gets
quoted, no new persisted field. Implements issue 2086.

## What changed

A reply is plain wire text — `<nick> …body… << ` then the answer — so cic
renders the two halves as one undifferentiated run, and the quote is the
longer half (up to 100 body characters since #1277 raised the #1235 cap).
The quoted head now renders at `--muted` so the answer carries the weight.

- `quotableBody.ts` — new `replyQuoteHeadLength/1`, one `exec` over the
  existing `PREVIOUS_QUOTE`. `startsWithReplyQuote/1` is now its `> 0`.
- `MircText.tsx` — `splitReplyQuote` cuts the runs at that offset and marks
  the head; `renderRun` adds `.scrollback-reply-quote`.
- `themes/default.css` — `.scrollback-reply-quote { color: var(--muted); }`.

## The three decisions

**One detector.** The styled region and the region a re-reply strips are the
same region by construction. A second detector would let them drift, and then
the colour on screen would describe a boundary the requote does not use. The
offset is measured against the run texts joined back — which IS the plain
projection, `mircPlainText` being literally that concatenation — so it holds
with #2029's strip on or off. `trimStart` aligns it with the requote path's
`.trim()`.

**The dim LOSES to an explicit `\x03`.** The class is withheld from any run
carrying fg or bg, on the same `run.fg === undefined && run.bg === undefined`
test the reverse line above already uses. Leaning on inline-style-beats-class
would have been true for a plain coloured run and FALSE for `reverse`, where
the parser puts fg on `background-color` and leaves `color` free for a class
to take.

**`--muted`, at the chokepoint.** Every theme defines it, so the gallery
themes and the theme editor follow; a literal grey would break both. Its
contrast against `--bg` is the pair timestamps already run. Applied at
`MircBody`'s single `runs()` accessor with no per-surface prop, for the reason
#2029 states three lines above it: a per-surface opt-in list is the thing that
rots.

## Tests

Assert the seen outcome, not the implementation.

- `MircText.test.tsx` (6) — the head dims up to and including the tail and no
  further; nothing is hidden; the action-shaped head dims too; `shift << 2`
  and `cat <<EOF` stay wholly undimmed; **the colour crossing the boundary**
  keeps the sender's colour on both sides while only the uncoloured prefix is
  muted; the head still dims with the strip preference on.
- `replyQuote.test.ts` (6) — the offset's exact cut, the last-tail landing,
  the shapes that must answer 0, and `slice(headLength).trim() ===
  quotableBody(...)` over five bodies: the structural proof that the two
  regions agree.
- `ScrollbackPane.test.tsx` (2) — a real message row shows it, plus the
  negative control on the surface where ordinary prose arrives.

**Mutant check.** Forcing the cut to 0 in `splitReplyQuote` turns the pane's
dimming assertion RED (`rc=1`, 1 failed) and leaves the negative control
green. Reverted; `grep -c MUTANT` = 0 on the committed tree.

## Gates

- `scripts/bun.sh run check` — **5/5 ok**. First run was RED on stage 1 (lock
  drift, 22 packages off-lock: the worktree's cloned `node_modules` carried a
  stale tree) plus biome formatting. Reconciled with
  `bun.sh install --frozen-lockfile` (`bun.lock` unchanged) and `check:fix`;
  everything below stage 1 was re-measured after, since a red stage 1 makes
  nothing under it attributable.
- `scripts/bun.sh run test` — **352 files, 7118 tests, 0 failed**, on the
  reconciled tree.
- `scripts/design-notes-gate.sh` — `rc=0`, run AFTER the commit:
  `1 new entry heading(s), separator and marker present`. Marker uniqueness
  checked against `origin/main`'s tip as it stands now (positive control:
  `entry #1271` found; `entry #2086` absent).

## What this does NOT claim

- No contrast ratio was measured. The claim is inheritance — `--muted` on
  `--bg` is the timestamp pair — not a fresh measurement.
- Nothing was looked at in a real browser. The evidence is jsdom.
- Server gates were not run: the diff touches no Elixir. No lane was taken.
- #455's emphasis markers can no longer pair across the `<< ` boundary,
  because the run is split there. A URL cannot span it either — but a space
  sits at that boundary, so none could.
