### PR TITLE
irc: parse a DCC SEND offer — groundwork for issue 2089, no ruling taken

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54137,3 +54137,97 @@ quote precisely because it is one. Colour only: muted, never hidden.
 - Out of scope, as the issue says: turning the reply into a structured field
   with its own wire representation. This is a colour on a region that was
   already identified.
+<!-- entry #2089 -->
+
+---
+
+## 2026-09-12 — #2089: the DCC wire parser, and the two measurements that must outlive the ruling
+
+vjt reopened DCC on #sbiffo. #167 is closed not-planned, `README.md:289`
+lists DCC under **Out of scope** and `NON-GOALS.md:22` repeats it as **No
+DCC** — so the reversal is an ACT, it needs vjt's word, **it has not been
+made, and neither of those two files is touched here.** What landed is the
+one piece no product decision can move (the wire shape) and the two
+measurements a later reader would otherwise get wrong in both directions.
+
+### #1280's stated reason forbids the INBOUND leg — and receiving is OUTBOUND
+
+Entry #1280 says *"DCC is out of scope, permanently"*, and the reason it
+gives is: *"accepting **inbound** P2P connections from arbitrary IRC nicks
+has no place in that architecture"*. In `DCC SEND` the OFFERER listens and
+the RECEIVER dials out. So the two halves are not symmetric under that
+sentence: **grappa receiving a file is an outbound connect and is outside
+the recorded rationale; grappa sending one requires a listener and is
+squarely inside it.** Receive-only is therefore not a reversal of #1280 —
+it is work the recorded reason never reached. That asymmetry is the whole
+argument for shipping the receive half first, and it is not visible from
+the issue, which does not cite #1280 at all.
+
+Two riders. #1280 also says the question *"was never seriously
+considered"*, so the `permanently` is broader than the analysis behind it.
+And **passive/reverse DCC inverts the roles**: on `DCC SEND <name> <addr> 0
+<size> <token>` it is the RECEIVER that must listen, so "receive-only" does
+not imply "no listener" unless passive offers are refused outright.
+
+### The existing upload store cannot be the destination, and this is measured
+
+The issue's shape says the bytes *"land in the existing upload store as if
+the user had uploaded it"*. Three measurements say otherwise:
+
+- `UploadsController`'s `@mime_categories` is a **closed** MIME allowlist
+  (image / video / document / audio; unknown → 415). A `DCC SEND` carries
+  **no MIME at all** — a name and a size. Either everything outside the
+  allowlist is refused, which makes DCC useless for the archives that are
+  most of real DCC traffic, or the allowlist gets a hole, which weakens the
+  upload surface that already exists for everybody.
+- `GET /uploads/:slug` is **public and unauthenticated** by design —
+  `Uploads.get_by_slug/2` collapses four states into `:not_found` precisely
+  so the route offers no oracle. Committing a stranger's pushed bytes there
+  makes grappa an anonymous public file host.
+- #1280's own last paragraph already rules on this: the route stays
+  *"reserved for content the operator's own users chose to publish — never
+  a proxy for arbitrary third-party URLs."*
+
+`Grappa.Avatars` is the precedent and it went the other way for the same
+reason: a stranger-declared resource we fetch gets its OWN context, own
+storage root, own cap (200 MiB global / 2 MiB per fetch, deliberately
+independent of the uploads budget), own TTL and reaper. A shared data model
+with a type flag across two trust domains is the boundary violation
+CLAUDE.md names, not reuse. **The HTTP read path in the issue survives; the
+STORE does not.**
+
+### What shipped: `Grappa.IRC.DCC`, wire shape only, no call site
+
+`parse/1` takes the argument remainder `Grappa.IRC.CTCP.verb_args/1`
+already returns, so there stays exactly one CTCP framing parser. The
+address decodes to an `:inet.ip_address()` tuple because that is what
+`Grappa.Net.Ssrf.safe_public_ip?/1` takes — a peer-supplied address is
+textbook SSRF input, and the eventual dial site must reuse the #75 guard
+rather than grow a second one.
+
+Three refusals, each a safety property and not a shortcut. **The sizeless
+historical form** is refused because without a declared size a receiver
+cannot check a byte cap BEFORE dialling — the cap stops being a
+precondition — and because the right-to-left split that recovers an
+unquoted spaced filename stops being decidable. **Port 0 with no token** is
+refused because such an offer can be neither dialled nor answered.
+**Address literals** go through `:inet.parse_strict_address/1` only,
+matching Ssrf: a short or octal form must never be quietly decoded into
+loopback. The filename comes back **verbatim**, traversal shapes included,
+because nothing downstream may use it as a path — `Uploads.storage_path/2`
+derives every on-disk name from a base32 slug and raises otherwise, and a
+second weaker guard beside the real one is worse than none.
+
+`CHAT`, `RESUME` and `ACCEPT` return `{:unsupported_verb, verb}` rather
+than `:malformed`: whether grappa answers a resume is one of the open
+product questions, and a parser is the wrong place to settle it.
+
+**There is no call site, deliberately.** Consent, caps, address family and
+malware surface are all unresolved, and every one of them changes the shape
+of the code that would call this. If the ruling goes the other way, this
+entry and one module plus its test are what gets reverted — which is why it
+is one module and not a subsystem.
+
+**Not claimed:** no real DCC frame from a real client was ever observed for
+this work; the interop reading (notably that a classic sender BLOCKS until
+it sees the 4-byte cumulative ack) is protocol knowledge, not measurement.

--- a/lib/grappa/irc.ex
+++ b/lib/grappa/irc.ex
@@ -9,7 +9,9 @@ defmodule Grappa.IRC do
   (`Grappa.IRC.Identifier`), the shared IRC-registration identity tuple
   validators (`Grappa.IRC.Identity`, #211 phase 2), the measured
   JOIN-failure numeric set (`Grappa.IRC.JoinFailure`, #1345), CTCP
-  framing classification (`Grappa.IRC.CTCP`), and the mIRC formatting
+  framing classification (`Grappa.IRC.CTCP`), the pure `DCC SEND` offer
+  parser (`Grappa.IRC.DCC`, issue 2089 — wire shape only, no socket and
+  no policy), and the mIRC formatting
   projection (`Grappa.IRC.MircFormat`, issue 1908 — the de-formatted view
   of a body, kept in lockstep with cic's `mircFormat.ts`).
   Phase 6's IRCv3 listener facade
@@ -30,6 +32,8 @@ defmodule Grappa.IRC do
       AuthFSM,
       Client,
       CTCP,
+      # issue 2089 — pure `DCC SEND` offer parsing; no socket, no policy.
+      DCC,
       Identifier,
       Identity,
       JoinFailure,

--- a/lib/grappa/irc/dcc.ex
+++ b/lib/grappa/irc/dcc.ex
@@ -1,0 +1,246 @@
+defmodule Grappa.IRC.DCC do
+  @moduledoc """
+  The wire half of a `DCC SEND` offer — parsing only (issue 2089).
+
+  A `DCC SEND` arrives inside an ordinary CTCP frame:
+  `\\x01DCC SEND <filename> <address> <port> <size>[ <token>]\\x01`. This
+  module turns the argument remainder into a typed offer, and does nothing
+  else: no socket, no consent, no storage, no policy. It is a pure function
+  over bytes.
+
+  ## It composes with what already exists, rather than repeating it
+
+  `Grappa.IRC.CTCP.verb_args/1` stays the single CTCP framing parser — the
+  caller hands `parse/1` the `args` half of `{"DCC", args}`, so this file
+  never touches `\\x01`:
+
+      case CTCP.verb_args(body) do
+        {"DCC", args} -> DCC.parse(args)
+        _ -> :not_dcc
+      end
+
+  `ip` decodes all the way to an `:inet.ip_address()` tuple, which is exactly
+  what `Grappa.Net.Ssrf.safe_public_ip?/1` already takes. The eventual dial
+  site therefore reuses this repo's hardened guard verbatim instead of
+  deriving a second one — a peer-supplied address is the textbook SSRF input,
+  and `169.254.169.254` reaches a cloud metadata service just as happily over
+  a DCC socket as over HTTP.
+
+  ## What it deliberately refuses, and why each refusal is a safety property
+
+    * **The sizeless historical form** (`DCC SEND <file> <addr> <port>`).
+      Without a declared size a receiver cannot check its byte cap BEFORE
+      dialling, so the cap degrades from a precondition to a hope; and the
+      right-to-left split that recovers an unquoted filename with spaces
+      stops being decidable. Both reasons are structural, not cosmetic.
+
+    * **Port 0 with no trailing token.** Port 0 is the passive/reverse
+      signal: the OFFERER cannot listen and asks the receiver to. Without
+      the token that offer can be neither dialled nor answered, so calling
+      it well-formed would hand the caller an unusable struct.
+
+    * **Non-strict address literals.** `:inet.parse_strict_address/1` only,
+      matching `Grappa.Net.Ssrf`'s posture exactly: a short or octal form
+      (`127.1`, `017700000001`) must never be quietly decoded into a
+      loopback address behind the guard's back.
+
+  ## What it deliberately does NOT do: sanitise the filename
+
+  `filename` comes back verbatim, traversal shapes included. Nothing
+  downstream may use a peer's filename as a path — `Grappa.Uploads`
+  derives every on-disk name from a 26-char base32 slug and
+  `Uploads.storage_path/2` RAISES on anything else. Sanitising here would
+  invent a second, weaker guard beside the real one and would corrupt the
+  display name into the bargain.
+
+  ## Scope, honestly stated
+
+  Only `SEND` is parsed. `CHAT`, `RESUME` and `ACCEPT` come back as
+  `{:error, {:unsupported_verb, verb}}` — naming the verb rather than
+  claiming the frame was malformed — because whether grappa answers a
+  resume, or speaks DCC CHAT at all, is an OPEN product decision on issue
+  2089 and does not belong in a parser. There is no call site for this
+  module yet, deliberately: the consent, cap, address-family and
+  malware-surface questions are unresolved, and every one of them changes
+  the shape of the code that would call this.
+  """
+
+  import Bitwise, only: [band: 2, bsr: 2]
+
+  @enforce_keys [:filename, :ip, :port, :size, :token]
+  defstruct [:filename, :ip, :port, :size, :token]
+
+  @typedoc """
+  A parsed `DCC SEND` offer.
+
+  `token` is `nil` for a classic active offer (the offerer listens on
+  `port`, we dial it) and an integer for a passive/reverse offer (`port` is
+  `0`, the offerer asks US to listen and to echo the token back).
+  """
+  @type t :: %__MODULE__{
+          filename: String.t(),
+          ip: :inet.ip_address(),
+          port: 0..65_535,
+          size: non_neg_integer(),
+          token: non_neg_integer() | nil
+        }
+
+  @typedoc """
+  `:malformed` — the frame is not a usable `SEND` offer.
+  `{:unsupported_verb, verb}` — a DCC verb this module does not parse, named
+  so the caller can log or refuse it truthfully.
+  """
+  @type error :: :malformed | {:unsupported_verb, String.t()}
+
+  # The historical address field is an unsigned 32-bit integer in network
+  # byte order, rendered in decimal.
+  @max_int32 4_294_967_295
+  @max_port 65_535
+
+  @digits ~r/\A[0-9]+\z/
+
+  @doc """
+  Parse the CTCP argument remainder of a `DCC` frame into an offer.
+
+  Takes the `args` half of `Grappa.IRC.CTCP.verb_args/1` — e.g.
+  `"SEND report.pdf 3221225985 5000 12345"`. Returns `{:ok, t()}` for a
+  well-formed `SEND`, `{:error, {:unsupported_verb, verb}}` for another DCC
+  verb, and `{:error, :malformed}` for anything else. Never raises.
+  """
+  @spec parse(String.t()) :: {:ok, t()} | {:error, error()}
+  def parse(args) when is_binary(args) do
+    case args |> String.trim_leading(" ") |> String.split(" ", parts: 2) do
+      [""] -> {:error, :malformed}
+      [verb] -> dispatch(String.upcase(verb, :ascii), "")
+      [verb, rest] -> dispatch(String.upcase(verb, :ascii), rest)
+    end
+  end
+
+  @spec dispatch(String.t(), String.t()) :: {:ok, t()} | {:error, error()}
+  defp dispatch("SEND", rest) do
+    case split_name_and_tail(squeeze_edges(rest)) do
+      {name, tail} -> build(name, tail)
+      :error -> {:error, :malformed}
+    end
+  end
+
+  defp dispatch(verb, _), do: {:error, {:unsupported_verb, verb}}
+
+  # Byte-level edge trim. `String.trim/1` is Unicode-aware and IRC is bytes
+  # (CLAUDE.md), so the two-arity binary form is used throughout: it strips a
+  # literal space and cannot trip over a Latin-1 filename.
+  @spec squeeze_edges(String.t()) :: String.t()
+  defp squeeze_edges(s), do: s |> String.trim_leading(" ") |> String.trim_trailing(" ")
+
+  # The filename is whatever precedes the fixed-arity trailing fields. A
+  # quoted name says where it ends; an unquoted one is recovered
+  # right-to-left, which is the only way to read the shape the CTCP has no
+  # way to quote.
+  @spec split_name_and_tail(String.t()) :: {String.t(), [String.t()]} | :error
+  defp split_name_and_tail(<<?", rest::binary>>) do
+    case String.split(rest, "\"", parts: 2) do
+      [name, tail] -> {name, String.split(tail, " ", trim: true)}
+      [_] -> :error
+    end
+  end
+
+  defp split_name_and_tail(args) do
+    toks = String.split(args, " ")
+    count = length(toks)
+    arity = if count > 4 and passive_tail?(Enum.drop(toks, count - 4)), do: 4, else: 3
+
+    if count > arity do
+      {toks |> Enum.take(count - arity) |> Enum.join(" "), Enum.drop(toks, count - arity)}
+    else
+      :error
+    end
+  end
+
+  # A passive tail is `<addr> 0 <size> <token>`: a literal `0` in the PORT
+  # slot AND a decodable address in front of it AND at least one token left
+  # over for the filename. All three are load-bearing, and each one was a
+  # real misread before it was there:
+  #
+  #   * without the `count > 4` guard, `SEND f 0 1 1` — an active offer from
+  #     0.0.0.0 — reads its own filename as the address slot;
+  #   * without the address check, `SEND my file 0 10 7` reads the word
+  #     `file` as an address and answers `:malformed` on a valid offer.
+  #
+  # Residual ambiguity, accepted knowingly: a filename that is itself a bare
+  # decimal, offered from 0.0.0.0, is undecidable on the wire. 0.0.0.0 is not
+  # dialable and `Grappa.Net.Ssrf` refuses it anyway, so the reading that
+  # loses costs nothing real.
+  @spec passive_tail?([String.t()]) :: boolean()
+  defp passive_tail?([addr, "0", _, _]), do: match?({:ok, _}, decode_addr(addr))
+  defp passive_tail?(_), do: false
+
+  @spec build(String.t(), [String.t()]) :: {:ok, t()} | {:error, :malformed}
+  defp build(name, [addr, port, size]) do
+    with true <- named?(name),
+         {:ok, ip} <- decode_addr(addr),
+         {:ok, p} <- decode_port(port),
+         {:ok, s} <- decode_non_neg(size) do
+      {:ok, %__MODULE__{filename: name, ip: ip, port: p, size: s, token: nil}}
+    else
+      _ -> {:error, :malformed}
+    end
+  end
+
+  defp build(name, [addr, "0", size, token]) do
+    with true <- named?(name),
+         {:ok, ip} <- decode_addr(addr),
+         {:ok, s} <- decode_non_neg(size),
+         {:ok, t} <- decode_non_neg(token) do
+      {:ok, %__MODULE__{filename: name, ip: ip, port: 0, size: s, token: t}}
+    else
+      _ -> {:error, :malformed}
+    end
+  end
+
+  defp build(_, _), do: {:error, :malformed}
+
+  # Blank iff it is nothing but spaces. Byte-level for the same reason
+  # `squeeze_edges/1` is.
+  @spec named?(String.t()) :: boolean()
+  defp named?(name), do: String.trim_leading(name, " ") != ""
+
+  @spec decode_addr(String.t()) :: {:ok, :inet.ip_address()} | :error
+  defp decode_addr(raw) do
+    if Regex.match?(@digits, raw), do: decode_int32(raw), else: decode_literal(raw)
+  end
+
+  @spec decode_int32(String.t()) :: {:ok, :inet.ip_address()} | :error
+  defp decode_int32(raw) do
+    case Integer.parse(raw) do
+      {n, ""} when n >= 0 and n <= @max_int32 ->
+        {:ok, {band(bsr(n, 24), 0xFF), band(bsr(n, 16), 0xFF), band(bsr(n, 8), 0xFF), band(n, 0xFF)}}
+
+      _ ->
+        :error
+    end
+  end
+
+  @spec decode_literal(String.t()) :: {:ok, :inet.ip_address()} | :error
+  defp decode_literal(raw) do
+    case :inet.parse_strict_address(:binary.bin_to_list(raw)) do
+      {:ok, ip} -> {:ok, ip}
+      {:error, _} -> :error
+    end
+  end
+
+  @spec decode_port(String.t()) :: {:ok, 1..65_535} | :error
+  defp decode_port(raw) do
+    case Integer.parse(raw) do
+      {n, ""} when n >= 1 and n <= @max_port -> {:ok, n}
+      _ -> :error
+    end
+  end
+
+  @spec decode_non_neg(String.t()) :: {:ok, non_neg_integer()} | :error
+  defp decode_non_neg(raw) do
+    case Integer.parse(raw) do
+      {n, ""} when n >= 0 -> {:ok, n}
+      _ -> :error
+    end
+  end
+end

--- a/test/grappa/irc/dcc_test.exs
+++ b/test/grappa/irc/dcc_test.exs
@@ -1,0 +1,241 @@
+defmodule Grappa.IRC.DCCTest do
+  use ExUnit.Case, async: true
+
+  use ExUnitProperties
+
+  alias Grappa.IRC.{CTCP, DCC}
+  alias Grappa.Net.Ssrf
+
+  # issue 2089 — the wire half of a DCC SEND offer, and ONLY the wire half.
+  # `parse/1` takes the CTCP argument remainder (what `CTCP.verb_args/1`
+  # already returns for a `\x01DCC …\x01` body) so there is one CTCP framing
+  # parser in this codebase, not two.
+
+  describe "parse/1 — the classic active offer" do
+    test "a SEND offer with the 32-bit integer address parses into a v4 tuple" do
+      assert {:ok, offer} = DCC.parse("SEND report.pdf 3221225985 5000 12345")
+
+      assert %DCC{
+               filename: "report.pdf",
+               ip: {192, 0, 2, 1},
+               port: 5000,
+               size: 12_345,
+               token: nil
+             } = offer
+    end
+
+    test "the address integer is network byte order — highest octet first" do
+      # 0xC0000201 == 192.0.2.1. A little-endian decode would answer
+      # {1, 2, 0, 192}, which is a different (and reserved) host.
+      assert {:ok, %DCC{ip: {192, 0, 2, 1}}} = DCC.parse("SEND f 3221225985 1 1")
+    end
+
+    test "the boundary integers 0 and 2^32-1 decode to the edge addresses" do
+      assert {:ok, %DCC{ip: {0, 0, 0, 0}}} = DCC.parse("SEND f 0 1 1")
+      assert {:ok, %DCC{ip: {255, 255, 255, 255}}} = DCC.parse("SEND f 4294967295 1 1")
+    end
+
+    test "a dotted-quad address is accepted and yields the same tuple as its integer" do
+      # Not the historical field form, but clients emit it. Accepting it costs
+      # one clause (the v6 literal path already needs :inet) and refusing it
+      # would drop an offer we can otherwise honour.
+      assert {:ok, %DCC{ip: {192, 0, 2, 1}}} = DCC.parse("SEND f 192.0.2.1 5000 1")
+    end
+
+    test "an IPv6 literal address parses into a v6 tuple" do
+      assert {:ok, %DCC{ip: {0x2001, 0xDB8, 0, 0, 0, 0, 0, 1}}} =
+               DCC.parse("SEND f 2001:db8::1 5000 1")
+    end
+
+    test "a zero-byte file is a legal offer" do
+      assert {:ok, %DCC{size: 0}} = DCC.parse("SEND empty.txt 3221225985 5000 0")
+    end
+  end
+
+  describe "parse/1 — filenames" do
+    test "a quoted filename preserves its interior spaces" do
+      assert {:ok, %DCC{filename: "my holiday photo.jpg", port: 5000}} =
+               DCC.parse(~s(SEND "my holiday photo.jpg" 3221225985 5000 99))
+    end
+
+    test "an unquoted filename with spaces is recovered right-to-left" do
+      # The trailing fields are fixed-arity, so everything before them is the
+      # name — the only way to read the shape the CTCP cannot quote.
+      assert {:ok, %DCC{filename: "my holiday photo.jpg", size: 99}} =
+               DCC.parse("SEND my holiday photo.jpg 3221225985 5000 99")
+    end
+
+    test "a blank quoted filename is malformed" do
+      assert {:error, :malformed} = DCC.parse(~s(SEND "" 3221225985 5000 1))
+      assert {:error, :malformed} = DCC.parse(~s(SEND "   " 3221225985 5000 1))
+    end
+
+    test "a quoted filename with no closing quote is malformed" do
+      assert {:error, :malformed} = DCC.parse(~s(SEND "unterminated 3221225985 5000 1))
+    end
+
+    test "a missing filename is malformed" do
+      assert {:error, :malformed} = DCC.parse("SEND 3221225985 5000 1")
+    end
+
+    test "a traversal-shaped filename is returned VERBATIM, never sanitised here" do
+      # Deliberate: this module reports what the wire said. Nothing downstream
+      # may use a peer filename as a path — `Grappa.Uploads.storage_path/2`
+      # derives the on-disk name from the 26-char base32 slug and RAISES on
+      # anything else. Sanitising here would invent a second, weaker guard and
+      # would silently corrupt the display name.
+      assert {:ok, %DCC{filename: "../../etc/passwd"}} =
+               DCC.parse("SEND ../../etc/passwd 3221225985 5000 1")
+    end
+  end
+
+  describe "parse/1 — passive (reverse) offers" do
+    test "port 0 with a trailing token parses as a passive offer" do
+      assert {:ok, %DCC{filename: "f", port: 0, size: 10, token: 7}} =
+               DCC.parse("SEND f 3221225985 0 10 7")
+    end
+
+    test "a passive offer keeps an unquoted spaced filename intact" do
+      assert {:ok, %DCC{filename: "two words.bin", port: 0, token: 42}} =
+               DCC.parse("SEND two words.bin 3221225985 0 10 42")
+    end
+
+    test "port 0 WITHOUT a token is malformed — it can be neither dialled nor answered" do
+      assert {:error, :malformed} = DCC.parse("SEND f 3221225985 0 10")
+    end
+
+    test "a non-numeric token is malformed" do
+      assert {:error, :malformed} = DCC.parse("SEND f 3221225985 0 10 abc")
+    end
+
+    test "a spaced filename in front of an address of 0 keeps the ACTIVE reading" do
+      # The four-field tail here is `file 0 10 7`, which LOOKS passive until
+      # you ask whether `file` decodes as an address. It does not, so the
+      # true reading survives: name "my file", address 0.0.0.0, port 10.
+      assert {:ok, %DCC{filename: "my file", ip: {0, 0, 0, 0}, port: 10, size: 7, token: nil}} =
+               DCC.parse("SEND my file 0 10 7")
+    end
+  end
+
+  describe "parse/1 — refusals" do
+    test "an address integer above 2^32-1 is malformed" do
+      assert {:error, :malformed} = DCC.parse("SEND f 4294967296 5000 1")
+    end
+
+    test "a non-strict address literal is malformed, never decoded into loopback" do
+      # Same posture as `Grappa.Net.Ssrf`: an octal/short form must NOT be
+      # decoded into a loopback address behind the caller's back. The two
+      # cases reach the refusal by DIFFERENT routes, which is why both are
+      # here: `017700000001` is all digits, so it takes the 32-bit integer
+      # path and dies on the range check (it is 17_700_000_001); `127.1`
+      # takes the literal path and dies in `:inet.parse_strict_address/1`.
+      assert {:error, :malformed} = DCC.parse("SEND f 017700000001 5000 1")
+      assert {:error, :malformed} = DCC.parse("SEND f 127.1 5000 1")
+    end
+
+    test "a port above 65535 is malformed" do
+      assert {:error, :malformed} = DCC.parse("SEND f 3221225985 65536 1")
+    end
+
+    test "a negative or non-numeric size is malformed" do
+      assert {:error, :malformed} = DCC.parse("SEND f 3221225985 5000 -1")
+      assert {:error, :malformed} = DCC.parse("SEND f 3221225985 5000 lots")
+    end
+
+    test "the historical sizeless form is refused" do
+      # `DCC SEND <file> <addr> <port>` with no size exists in pre-1996
+      # clients. It is refused on purpose: with no declared size a receiver
+      # cannot check its cap BEFORE dialling, and the unquoted-filename
+      # right-to-left split stops being decidable.
+      assert {:error, :malformed} = DCC.parse("SEND f 3221225985 5000")
+    end
+
+    test "empty args are malformed" do
+      assert {:error, :malformed} = DCC.parse("")
+      assert {:error, :malformed} = DCC.parse("   ")
+    end
+  end
+
+  describe "parse/1 — verb discrimination" do
+    test "the SEND verb matches case-insensitively (ASCII)" do
+      assert {:ok, %DCC{filename: "f"}} = DCC.parse("send f 3221225985 5000 1")
+      assert {:ok, %DCC{filename: "f"}} = DCC.parse("Send f 3221225985 5000 1")
+    end
+
+    test "DCC CHAT reports its verb — never a false offer" do
+      assert {:error, {:unsupported_verb, "CHAT"}} = DCC.parse("CHAT chat 3221225985 5000")
+    end
+
+    test "RESUME and ACCEPT report their verb rather than lying about the shape" do
+      # Whether grappa answers a resume is an OPEN product decision (issue
+      # 2089's "protocol edges"). Reporting the verb keeps that decision
+      # outside this module — `:malformed` would have been a lie.
+      assert {:error, {:unsupported_verb, "RESUME"}} = DCC.parse("RESUME f 5000 1024")
+      assert {:error, {:unsupported_verb, "ACCEPT"}} = DCC.parse("ACCEPT f 5000 1024")
+    end
+
+    test "an unknown verb is reported verbatim, uppercased" do
+      assert {:error, {:unsupported_verb, "XMIT"}} = DCC.parse("xmit f 1 2 3")
+    end
+
+    test "a bare verb with no arguments is still a verb, not malformed" do
+      assert {:error, {:unsupported_verb, "CHAT"}} = DCC.parse("CHAT")
+    end
+  end
+
+  describe "composition with the existing CTCP and SSRF primitives" do
+    test "the whole framed body routes through CTCP.verb_args/1 into parse/1" do
+      body = "\x01DCC SEND report.pdf 3221225985 5000 12345\x01"
+
+      assert {"DCC", args} = CTCP.verb_args(body)
+      assert {:ok, %DCC{filename: "report.pdf", port: 5000}} = DCC.parse(args)
+    end
+
+    test "the parsed address feeds Ssrf.safe_public_ip?/1 with no conversion" do
+      # The whole point of decoding to an `:inet.ip_address()` here: the
+      # eventual dial site hands the tuple straight to the guard this repo
+      # already hardened, instead of re-deriving one.
+      assert {:ok, %DCC{ip: public}} = DCC.parse("SEND f 3221225985 5000 1")
+      assert Ssrf.safe_public_ip?(public)
+
+      assert {:ok, %DCC{ip: loopback}} = DCC.parse("SEND f 2130706433 5000 1")
+      refute Ssrf.safe_public_ip?(loopback)
+
+      assert {:ok, %DCC{ip: v6_loopback}} = DCC.parse("SEND f ::1 5000 1")
+      refute Ssrf.safe_public_ip?(v6_loopback)
+
+      assert {:ok, %DCC{ip: mapped}} = DCC.parse("SEND f ::ffff:127.0.0.1 5000 1")
+      refute Ssrf.safe_public_ip?(mapped)
+    end
+  end
+
+  describe "properties" do
+    property "any four octets round-trip through the 32-bit integer field" do
+      check all(
+              a <- integer(0..255),
+              b <- integer(0..255),
+              c <- integer(0..255),
+              d <- integer(0..255)
+            ) do
+        n = a * 16_777_216 + b * 65_536 + c * 256 + d
+
+        assert {:ok, %DCC{ip: {^a, ^b, ^c, ^d}}} = DCC.parse("SEND f #{n} 5000 1")
+      end
+    end
+
+    property "a filename of N space-separated words survives the right-to-left split" do
+      check all(words <- list_of(string(?a..?z, min_length: 1), min_length: 1, max_length: 6)) do
+        name = Enum.join(words, " ")
+
+        assert {:ok, %DCC{filename: ^name}} = DCC.parse("SEND #{name} 3221225985 5000 1")
+      end
+    end
+
+    property "never raises on arbitrary argument bytes" do
+      check all(args <- string(:printable, max_length: 40)) do
+        assert match?({:ok, %DCC{}}, DCC.parse(args)) or
+                 match?({:error, _}, DCC.parse(args))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Groundwork for issue 2089 (grappa as a DCC client). **Two commits, one new
module, no call site, no product decision taken.**

## 🔴 What this PR deliberately does NOT do

`README.md:289` lists DCC under **Out of scope** and `NON-GOALS.md:22`
repeats it as **No DCC**. Amending those two lines is the ACT that performs
the reversal, and it needs vjt's word — the issue says he reopened the
question on IRC, which is not something this branch can verify. **Neither
file is touched here**, and the DESIGN_NOTES entry says so in as many words
so the log cannot be misread as having decided something nobody decided.

It also does not implement DCC. The issue's own "What actually needs
deciding" lists five open product questions (consent, caps, address
families, malware surface, protocol edges). Building on top of those before
they are answered is building the wrong thing carefully. A design note with
options, measured costs and a recommendation per node has been handed to the
orchestrator separately.

## What shipped

`Grappa.IRC.DCC.parse/1` — the one part of issue 2089 that no product
decision can move, because the wire says what the wire says. A pure function
from the CTCP argument remainder to a typed offer: no socket, no consent, no
storage, no policy.

**It composes rather than repeats.** `Grappa.IRC.CTCP.verb_args/1` stays the
single CTCP framing parser and `parse/1` takes the `args` half it already
returns, so this file never touches `\x01`. The address decodes all the way
to an `:inet.ip_address()` tuple, which is exactly what
`Grappa.Net.Ssrf.safe_public_ip?/1` already takes — a peer-supplied address
is textbook SSRF input, so the eventual dial site reuses the guard hardened
for #75 instead of growing a second one.

**Three refusals, each a safety property rather than a shortcut.**

- *The sizeless historical form.* Without a declared size a receiver cannot
  check a byte cap BEFORE dialling, so the cap degrades from a precondition
  to a hope; and the right-to-left split that recovers an unquoted spaced
  filename stops being decidable.
- *Port 0 with no trailing token.* A passive offer missing its token can be
  neither dialled nor answered, so calling it well-formed would hand the
  caller an unusable struct.
- *Non-strict address literals.* `:inet.parse_strict_address/1` only,
  matching `Grappa.Net.Ssrf`'s posture: a short or octal form must never be
  quietly decoded into a loopback address behind the guard's back.

**The filename comes back verbatim**, traversal shapes included. Nothing
downstream may use a peer filename as a path — `Uploads.storage_path/2`
derives every on-disk name from a base32 slug and raises otherwise — so
sanitising here would build a second, weaker guard beside the real one.

`CHAT`, `RESUME` and `ACCEPT` return `{:unsupported_verb, verb}` rather than
`:malformed`. Whether grappa answers a resume is an open product question,
and a parser is the wrong place to settle it; naming the verb is truthful
whichever way it lands.

## Two measurements worth reading before the ruling

Both are in the DESIGN_NOTES entry, because they would otherwise be
re-derived wrongly in opposite directions.

**1. #1280's stated reason forbids the INBOUND leg, and receiving is
outbound.** Entry #1280 rules DCC out "permanently", but the reason it
records is *"accepting **inbound** P2P connections from arbitrary IRC
nicks"*. In `DCC SEND` the offerer listens and the receiver dials out — so
grappa **receiving** a file sits outside that rationale entirely, while
grappa **sending** one sits squarely inside it. Receive-only is therefore
not a reversal of #1280. The issue does not cite #1280 at all, so this was
not visible from the ticket. Rider: **passive/reverse DCC inverts the
roles** (the receiver listens), so "receive-only" does not imply "no
listener" unless passive offers are refused outright — an edge the issue
does not list.

**2. The existing upload store cannot be the destination.** The issue's
shape says the bytes land in it "as if the user had uploaded it". Measured:
`UploadsController`'s `@mime_categories` is a **closed** MIME allowlist and
a DCC offer carries **no MIME at all**; `GET /uploads/:slug` is **public and
unauthenticated** by design; and #1280's last paragraph already reserves
that route for *"content the operator's own users chose to publish — never a
proxy for arbitrary third-party URLs."* `Grappa.Avatars` is the precedent
and went the other way for the same reason — own context, own cap, own TTL,
own reaper — because a shared data model with a type flag across two trust
domains is a boundary violation, not reuse. The HTTP read path in the issue
survives; the store does not.

## Gates

`scripts/check.sh` green at branch HEAD: Credo strict `found no issues`,
Sobelow, Dialyzer `Total errors: 0`, ExUnit `8 doctests, 68 properties,
7329 tests, 0 failures`, bats. `scripts/design-notes-gate.sh` reports
`1 new entry heading(s), separator and marker present`.

New tests: 30 examples + 3 properties in `test/grappa/irc/dcc_test.exs`.
They are not a mirror — one of them caught a real bug in the parser during
development (`SEND f 0 1 1`, an active offer from 0.0.0.0, was being read as
a passive one because its own filename landed in the address slot).

## Not claimed

- **No interop evidence.** No real `DCC SEND` from a real client was ever
  observed for this work. The parser is validated against the protocol as
  read, not against a live sender.
- `scripts/integration.sh` was not run: this branch adds no runtime, no HTTP
  surface and no e2e path.
- No `protocol_version` change — there is no wire-shape change here. The
  first DCC event will need one.
- No mutation testing.
