### PR TITLE
fix(2088): serve cicchetto/public/sounds/, and end the forgotten-allowlist class

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54137,3 +54137,109 @@ quote precisely because it is one. Colour only: muted, never hidden.
 - Out of scope, as the issue says: turning the reply into a structured field
   with its own wire representation. This is a colour on a region that was
   already identified.
+<!-- entry #2088 -->
+
+---
+
+## 2026-09-12 — #2088: the fourth forgotten allowlist entry, and the walk that ends the class
+
+`cicchetto/public/sounds/` shipped with #1480 and every one of its five
+file-backed samples answered `200 text/html; charset=utf-8` — the SPA shell,
+under an `.mp3` URL. `@cic_static_only` in `lib/grappa_web/endpoint.ex`
+matches the first path segment and did not name `sounds`.
+
+That is the FOURTH time: #485 (the icon set), #1739 (`radio-logos/`), #1906
+(`badge-96.png`), now this. All four are the same move — add something under
+`cicchetto/public/`, leave the allowlist alone — and all four were measured
+with the same fingerprint. A list forgotten four times is the defect; the
+missing word is the symptom, so the line was worth about a minute and the
+rest of this entry is about the other half.
+
+### The discriminant is the content-type, never the status
+
+The SPA history fallback answers `200` to any path it has never heard of,
+and owes it: a hard refresh on `/theme/:id` must get the shell. So a probe
+that checks `200` reads GREEN on a broken asset. Staging measured a
+non-existent path and a real mp3 as byte-identical answers — same status,
+same length, same content-type. Only `content-type` separates them.
+
+This is why the new walk is rooted at a COPY of `cicchetto/public/` plus a
+synthetic `index.html`, rather than at `cicchetto/public/` itself. That
+directory has no `index.html`, so a missing allowlist entry there would
+surface as a `404` — and the test would then be pinning a mechanism
+production does not have, quietly moving the discriminant back onto the
+status. The copy reproduces the real shape: allowlisted → own bytes,
+forgotten → `200 text/html`.
+
+### The walk
+
+`spa_serving_test.exs` now walks every regular file under
+`cicchetto/public/` and fails on any that does not come back `200` with a
+non-HTML content-type. The failure names each path and what it actually got,
+so the message is the staging table.
+
+`Path.wildcard/1` skips dotfiles, which keeps a stray `.DS_Store` from
+failing the walk. An empty walk is refuted explicitly: a missing bind mount
+or a moved directory would otherwise read GREEN while proving nothing. The
+per-asset tests above it stay — they pin EXACT content types
+(`image/svg+xml`, `font/woff2`, `application/manifest+json`) where the walk
+only pins "not the shell", and the two vite-GENERATED top-level entries
+(`assets/`, `manifest.webmanifest`) have no counterpart under `public/` at
+all, so only the named tests reach them.
+
+### The bind mount is load-bearing
+
+`cicchetto/public` had to join `WORKTREE_VOLUMES` in `scripts/_lib.sh`. The
+walk's INPUT SET is that directory, and a worktree run bind-mounts only an
+enumerated list on top of main's `./:/app`. Without the override, a branch
+that adds a public asset walks MAIN's older tree: the new entry is invisible
+and the lockstep test reads GREEN on the very branch introducing the drift.
+Same failure `Dockerfile.release` hit in #1945, in the opposite direction.
+The red proved the mount: `sounds/` exists only on this branch, and the
+failure named all six files under it.
+
+### MEASURED: this fix is inert on a hot deploy
+
+The issue flagged, explicitly unproven, that `Plug.Static.init/1`'s compiled
+matcher is cached in `:persistent_term` keyed on the ROOT and not on the
+allowlist. Measured, in-process, against the real endpoint:
+
+```
+A current allowlist:              200 ["audio/mpeg"]
+B cache entry keyed on root:      true
+C stale matcher, same root:       200 ["text/html; charset=utf-8"]
+D :code.load_file(Endpoint) = {:module, _}; cache survived reload: true
+E after that reload:              200 ["text/html; charset=utf-8"]
+```
+
+C seeds the cache with opts compiled from an older `:only` at the SAME root
+while the loaded module already carries `sounds` — and the URL goes straight
+back to the shell. D and E show a beam reload does not disturb the entry.
+`HotReload.reload_from/1` only purges and loads beams (it names
+`persistent_term` nowhere), and `Cic.Bundle.boot/1` writes only the ROOT key,
+so even `/admin/cic-bundle-changed` re-booting the same path leaves the stale
+matcher in place.
+
+**So an allowlist change needs a RESTART, or it ships and does nothing.**
+The two-line cure — fold the list (or a compile-time `phash2` of it) into the
+cache key so a reloaded module misses and rebuilds — was deliberately NOT
+taken here: it is a hot-path change to a shared caching seam, it is the same
+shape as `cached_session_opts/0` next door, and it wants its own slice rather
+than riding a one-word allowlist fix.
+
+### What this does NOT claim
+
+- Nothing was verified on production or staging after the fix. The cure is
+  measured only in the unit suite.
+- The service-worker question is still open and still unmeasured.
+  `vite.config.ts` precaches `**/*.{...,mp3,...}` and its `globIgnores` names
+  only `radio-logos/**`, so the five samples ARE in the precache manifest. A
+  client that installed a worker while those URLs answered `text/html` may
+  therefore hold the shell cached under an `.mp3` key, and because workbox
+  revisions are content-derived and the bytes did not change, it is not
+  obvious that a new build evicts it. That is a mechanism sketched from the
+  config, not an observation — no browser was involved.
+- Whether the client falls back to a synthesised voice when a sample fails to
+  decode was not investigated.
+- The walk proves the endpoint serves the bytes. It says nothing about
+  whether any of them is a playable mp3.

--- a/lib/grappa_web/endpoint.ex
+++ b/lib/grappa_web/endpoint.ex
@@ -74,7 +74,22 @@ defmodule GrappaWeb.Endpoint do
   # glyph on, and the platform's answer to an HTML document where it expected
   # an image is to draw its own fallback in the status bar. Measured before
   # this line existed: `text/html; charset=utf-8`, index.html.
-  @cic_static_only ~w(assets backgrounds fonts radio-logos manifest.webmanifest
+  #
+  # issue 2088 added `sounds/` — the five file-backed notification samples
+  # #1480 ships (the four synthesised presets are oscillator recipes and
+  # fetch nothing, which is why only five of nine went silent). FOURTH
+  # instance of the class, measured on staging exactly like the three
+  # above: `/sounds/xp-ding.mp3` -> `200 text/html; charset=utf-8`, and a
+  # path that exists nowhere answered the same 200 — the status never
+  # discriminated, only the content-type did.
+  #
+  # A list forgotten four times is itself the defect, so the lockstep is
+  # no longer a promise in this comment: `spa_serving_test.exs` walks
+  # every file under `cicchetto/public/` and fails on the first one that
+  # comes back as the shell. A fifth entry added below without that walk
+  # going green is a contradiction the suite will not let through.
+  @cic_static_only ~w(assets backgrounds fonts radio-logos sounds
+                      manifest.webmanifest
                       icon.svg icon-192.png icon-512.png
                       icon-192-maskable.png icon-512-maskable.png
                       apple-touch-icon.png favicon.ico badge-96.png)

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -114,10 +114,17 @@ if [ "$SRC_ROOT" != "$REPO_ROOT" ]; then
         -v "$SRC_ROOT/Dockerfile.release:/app/Dockerfile.release:ro"
         #   bin/         → operator_help_drift_test.exs (#1086)
         -v "$SRC_ROOT/bin:/app/bin:ro"
-        #   cicchetto/e2e/ → keepalive_idle_ordering_test.exs (#1030). The
-        #   only cic path a server-side test reads; cicchetto/src above is
-        #   mounted for a different reason and does not cover it.
+        #   cicchetto/e2e/ → keepalive_idle_ordering_test.exs (#1030).
+        #   cicchetto/src above is mounted for a different reason and does
+        #   not cover it.
         -v "$SRC_ROOT/cicchetto/e2e:/app/cicchetto/e2e:ro"
+        #   cicchetto/public/ → spa_serving_test.exs (issue 2088). The walk
+        #   that keeps the endpoint's static allowlist in lockstep reads THIS
+        #   directory as its input set, so without the override a worktree
+        #   adding a new public asset walks MAIN's older tree instead: the
+        #   new entry is invisible and the lockstep test reads GREEN on the
+        #   very branch that introduced the drift.
+        -v "$SRC_ROOT/cicchetto/public:/app/cicchetto/public:ro"
     )
 fi
 

--- a/test/grappa_web/spa_serving_test.exs
+++ b/test/grappa_web/spa_serving_test.exs
@@ -20,6 +20,12 @@ defmodule GrappaWeb.SpaServingTest do
   # `:cic_dist_root`. Booted at app start like the real dist dir.
   defp html_conn, do: put_req_header(build_conn(), "accept", "text/html")
 
+  # The source of truth for "a root-level public asset": vite copies this
+  # tree into the dist verbatim, so every file under it becomes a URL.
+  # Needs its own worktree bind in `scripts/_lib.sh` — without it a
+  # worktree run walks MAIN's copy.
+  @public_root Path.expand("../../cicchetto/public", __DIR__)
+
   describe "static asset serving (Plug.Static from the cic dist)" do
     test "GET /assets/<hashed>.js serves the built asset" do
       conn = get(build_conn(), "/assets/index-TESTHASH.js")
@@ -139,6 +145,87 @@ defmodule GrappaWeb.SpaServingTest do
       assert conn.resp_body =~ "test service worker"
       assert [cache_control] = get_resp_header(conn, "cache-control")
       assert cache_control =~ "no-cache"
+    end
+  end
+
+  describe "the allowlist stays in lockstep with cicchetto/public/ (issue 2088)" do
+    # The per-asset tests above each pin ONE entry, which is why the same
+    # regression has now landed four times: #485 (the icon set),
+    # #1739 (`radio-logos/`), #1906 (`badge-96.png`), issue 2088
+    # (`sounds/`). Every one of them added something to
+    # `cicchetto/public/`, left `@cic_static_only` alone, and shipped the
+    # asset as `content-type: text/html`. The defect is the LIST, not the
+    # entry — so this walks the whole of `cicchetto/public/` and requires
+    # each file to come back as its own bytes.
+    #
+    # Rooted at a COPY of `cicchetto/public/` plus a synthetic
+    # `index.html`, because the shell is what makes the symptom
+    # `200 text/html` instead of `404`: rooting straight at
+    # `cicchetto/public/` (no index.html of its own) would turn a missing
+    # allowlist entry into a 404 and quietly move the discriminant from
+    # the content-type onto the status, which is the one reading the
+    # production measurement rules out.
+    #
+    # Not covered here, on purpose: the top-level entries vite GENERATES
+    # rather than copies (`assets/`, `manifest.webmanifest`) have no
+    # counterpart under `cicchetto/public/`. They are pinned by name in
+    # the per-asset tests above.
+    setup do
+      original = Bundle.root()
+      root = Path.join(System.tmp_dir!(), "cic-public-#{System.unique_integer([:positive])}")
+      File.cp_r!(@public_root, root)
+      File.write!(Path.join(root, "index.html"), ~s(<!doctype html><div id="cic-app-root">))
+
+      on_exit(fn ->
+        Bundle.boot(original)
+        File.rm_rf!(root)
+      end)
+
+      Bundle.boot(root)
+      :ok
+    end
+
+    test "every file under cicchetto/public/ is served as its own bytes, not the SPA shell" do
+      paths = public_asset_paths()
+
+      # An empty walk would read GREEN while proving nothing — the shape a
+      # missing bind mount or a moved directory takes.
+      refute paths == []
+
+      served =
+        Map.new(paths, fn path ->
+          conn = get(build_conn(), path)
+          {path, {conn.status, conn |> get_resp_header("content-type") |> List.first()}}
+        end)
+
+      shell =
+        Map.filter(served, fn {_, {status, content_type}} ->
+          status != 200 or String.starts_with?(content_type || "", "text/html")
+        end)
+
+      assert shell == %{}, """
+      These files exist under cicchetto/public/ — so vite copies them into
+      the dist and a browser can request them — but the endpoint answers
+      with the SPA shell instead of the file:
+
+      #{Enum.map_join(shell, "\n", fn {path, {status, ctype}} -> "  #{path} -> #{status} #{ctype}" end)}
+
+      Their first path segment is missing from `@cic_static_only` in
+      lib/grappa_web/endpoint.ex. Add it there, with a comment saying what
+      the asset is for.
+      """
+    end
+
+    test "a path with no public/ entry behind it still gets the shell (the control)" do
+      # Proves the assertion above discriminates: 200 is NOT the signal.
+      # This path is answered with the same 200 as a working asset, and
+      # that is CORRECT — the history fallback owes a shell to any
+      # client-side route it has never heard of.
+      conn = get(build_conn(), "/zzz-no-such-public-entry/nope.mp3")
+
+      assert conn.status == 200
+      assert ["text/html" <> _] = get_resp_header(conn, "content-type")
+      assert conn.resp_body =~ "cic-app-root"
     end
   end
 
@@ -285,5 +372,18 @@ defmodule GrappaWeb.SpaServingTest do
       # where the operator can read it and an anonymous client cannot.
       refute conn.resp_body =~ tmp
     end
+  end
+
+  # Every URL `cicchetto/public/` contributes to the dist, as the endpoint
+  # sees it: a leading-slash path per regular file, recursively.
+  # `Path.wildcard/1` skips dotfiles, which keeps a stray `.DS_Store` from
+  # failing the walk.
+  defp public_asset_paths do
+    @public_root
+    |> Path.join("**/*")
+    |> Path.wildcard()
+    |> Enum.filter(&File.regular?/1)
+    |> Enum.map(&("/" <> Path.relative_to(&1, @public_root)))
+    |> Enum.sort()
   end
 end


### PR DESCRIPTION
For issue 2088.

## The one-word half

`@cic_static_only` in `lib/grappa_web/endpoint.ex` matches the first path
segment and did not name `sounds`, so the five file-backed samples #1480
ships answered `200 text/html; charset=utf-8` under their `.mp3` URLs. The
four synthesised presets are oscillator recipes that fetch nothing, which is
why exactly five of the nine went silent.

## The half that matters

This is the FOURTH instance: #485 (the icon set), #1739 (`radio-logos/`),
#1906 (`badge-96.png`). Same move every time — add something under
`cicchetto/public/`, leave the allowlist alone. A list forgotten four times
IS the defect.

`spa_serving_test.exs` now walks every regular file under
`cicchetto/public/` and fails on any that does not come back `200` with a
non-HTML content-type. The failure message names each path and what it
actually got.

**The discriminant is the content-type, never the status.** The history
fallback owes a 200 to any path it has never heard of, so a probe that
checks the status reads green on a broken asset — staging measured a made-up
path and a real mp3 as byte-identical answers. The walk is therefore rooted
at a COPY of `cicchetto/public/` plus a synthetic `index.html`: rooting at
the directory itself (no `index.html` of its own) would turn a forgotten
entry into a 404 and pin a mechanism production does not have.

`cicchetto/public` joins `WORKTREE_VOLUMES` in `scripts/_lib.sh` because it
is the walk's INPUT SET. A worktree run mounts only an enumerated list over
main's `./:/app`, so without it a branch adding a public asset walks MAIN's
older tree — invisible entry, green test, on the branch introducing the
drift. Same trap `Dockerfile.release` hit in #1945.

## TDD

Red first, and red for the right reason — the six files under `sounds/` and
nothing else, reproducing the staging table byte for byte:

```
/sounds/PROVENANCE.md      -> 200 text/html; charset=utf-8
/sounds/icq-uh-oh.mp3      -> 200 text/html; charset=utf-8
/sounds/xp-balloon.mp3     -> 200 text/html; charset=utf-8
/sounds/xp-ding.mp3        -> 200 text/html; charset=utf-8
/sounds/xp-exclamation.mp3 -> 200 text/html; charset=utf-8
/sounds/xp-notify.mp3      -> 200 text/html; charset=utf-8
```

The other 58 files passed in that same run, so the walk's positive side is
proved by the same red. The red also proves the bind mount: `sounds/` exists
only on this branch, and without the override no `/sounds/*` line could have
appeared.

Negative control, committed alongside: `/zzz-no-such-public-entry/nope.mp3`
answers `200 text/html` and that is CORRECT. Positive control for the
content-type axis: the existing `/manifest.webmanifest` ->
`application/manifest+json` assertion.

## MEASURED: this fix is inert on a hot deploy

The issue flagged, explicitly unproven, that `Plug.Static.init/1`'s compiled
matcher is cached in `:persistent_term` keyed on the ROOT and not on the
allowlist. Measured in-process against the real endpoint:

```
A current allowlist:         200 ["audio/mpeg"]
B cache entry keyed on root: true
C stale matcher, same root:  200 ["text/html; charset=utf-8"]
D :code.load_file(Endpoint) = {:module, _}; cache survived reload: true
E after that reload:         200 ["text/html; charset=utf-8"]
```

C seeds the cache with opts compiled from an older `:only` at the SAME root
while the loaded module already carries `sounds` — and the URL goes straight
back to the shell. `HotReload.reload_from/1` names `persistent_term` nowhere
and `Cic.Bundle.boot/1` writes only the root key, so even
`/admin/cic-bundle-changed` re-booting the same path leaves the stale matcher
in place.

**An allowlist change needs a RESTART, or it ships and does nothing.** The
two-line cure (fold the list, or a compile-time `phash2` of it, into the
cache key) was deliberately NOT taken here: it is a hot-path change to a
shared caching seam with a sibling of the same shape (`cached_session_opts/0`)
and it wants its own slice.

## Gates

- `scripts/check.sh` — `rc=0`; 8 doctests, 65 properties, 7301 tests, 0
  failures; wireTypes/wireSchema in sync; bats green.
- `scripts/design-notes-gate.sh` — `rc=0`, 1 new entry heading, separator and
  marker present.
- Integration/e2e NOT run — the stack lane was not requested.

## What this does NOT claim

- Nothing was verified on prod or staging after the fix.
- The service-worker precache question stays open. `vite.config.ts`
  precaches `**/*.{...,mp3,...}` and its `globIgnores` names only
  `radio-logos/**`, so the samples ARE in the precache manifest and a client
  that installed a worker while those URLs answered `text/html` may hold the
  shell cached under an `.mp3` key. That is a mechanism read off the config —
  no browser was involved, no eviction behaviour was observed.
- Whether the client falls back to a synthesised voice when a sample fails to
  decode was not investigated.
- The walk proves the endpoint serves the bytes. It says nothing about
  whether any of them is a playable mp3.
