### PR TITLE
cic: stop an animated jump from driving the scroll pager (issue 2091)

### DIFF
--- a/cicchetto/e2e/tests/issue2091-jump-does-not-page.spec.ts
+++ b/cicchetto/e2e/tests/issue2091-jump-does-not-page.spec.ts
@@ -1,0 +1,282 @@
+// issue 2091 — one arrow tap, counted in a real browser.
+//
+// 🔴 READ THIS BEFORE TRUSTING THIS SPEC AS EVIDENCE. It is GREEN with the cure
+// and MEASURED GREEN WITHOUT IT. It does not discriminate the fix, and nobody
+// should cite it as proof the fix works — the discriminating evidence is the
+// frame-replay bench in `src/__tests__/ScrollbackPane.test.tsx`, which counts
+// the pane's CALLS to the paging verbs and goes red without the cure.
+//
+// What this spec IS, then. The issue's acceptance asks for HTTP requests per
+// tap, counted in a real browser, before and after. That number is this file's
+// output and the answer is ZERO ON BOTH SIDES, on a 3000-row corpus with both
+// pagers still armed. The defect is real — the asymmetry is read in the code
+// and the bench counts up to 5 pager calls for one tap — but those calls do not
+// become requests here: a smooth scroll over tens of thousands of pixels moves
+// far enough per frame that no `scroll` event lands inside a 200px band, and
+// the verbs' in-flight guard plus exhausted latch absorb what is left. The
+// reported "hundreds of requests" is not reproduced in this substrate. That is
+// a result, not a gap in the spec, and it is why the number lives here in a
+// file that says so rather than in a commit message that implies otherwise.
+//
+// What it still guards, and can still go red on:
+//   * the acceptance property itself — a tap must not fetch. It holds today for
+//     reasons partly outside the cure, and a future change that makes the jump
+//     anchor lazy, or widens a band, breaks it here first.
+//   * the cure's most dangerous failure mode — suppressing the THRESHOLDS
+//     rather than the CALLER. The positive control below scrolls the same
+//     region with a real wheel and requires paging to happen. A gate written
+//     against `distance` instead of against who scrolled turns that red.
+//
+// ── two fixture findings, both measured, both load-bearing ──────────────────
+// (1) It was first written against the shared spec-subject's seeded autojoin
+// channel (200 rows, `specSubject.ts:SEED_COUNT`) and that was VACUOUS for a
+// second reason: with a 50-row REST page the scroll-to-top that sets the scene
+// drains the corpus, both exhausted latches set, and from then on no pager can
+// fire for ANY caller. Hence `SEED_ROWS` far above what one gesture can drain —
+// the pagers must still be ARMED at the tap, or the zero has two explanations.
+// (2) The positive control does NOT wheel until `scrollTop <= 200`. That
+// condition is UNREACHABLE while the backfill pager is armed, which is exactly
+// the state the control needs: every page it pulls is PREPENDED and
+// `applyPrependPreserve` restores the reader's row by the height delta, pushing
+// scrollTop back down by a page. Measured: the pane sat around 1048px through
+// 80 notches of −600. What proves the wheel landed is that the BUFFER GREW.
+//
+// Chromium only: the gesture is layout-driven and the assertion is about the
+// scroll engine, so this rides the same one-engine precedent as the other
+// scroll-geometry specs (#168, #243, #360).
+
+import type { Page, Request } from "@playwright/test";
+import { loginAs, scrollbackLine, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
+import { assertMessagePersisted, GRAPPA_BASE_URL, type SeededUser } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { forwardPageDiagnostics } from "../fixtures/pageDiagnostics";
+import { getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const SCROLL_TO_BOTTOM = '[data-testid="scroll-to-bottom"]';
+const BADGE = '[data-testid="scroll-to-bottom-badge"]';
+// Well past what one gesture can drain at a 50-row REST page: the point is that
+// the backfill pager is still ARMED when the tap happens. Seeding cost is
+// linear and small (the 200-row baseline provisions in ~200ms).
+const SEED_ROWS = 3000;
+const PASSWORD = "test-password-not-secret";
+
+// Narrow pane, short viewport: the corpus overflows it many times over, so the
+// jump has real distance to animate across. A jump with no travel would sweep
+// no threshold band and the spec would pass without exercising the defect.
+test.use({ viewport: { width: 900, height: 400 } });
+
+// Both pagers issue GET on the channel's messages collection: `?before=<id>`
+// (backfill) and `?after=<id>` (forward). Anything else the pane fetches —
+// cursor POSTs, avatars, the WS — is a different verb and must not be counted,
+// or the number stops being "pages fetched by this gesture".
+function isPagingRequest(req: Request): boolean {
+  if (req.method() !== "GET") return false;
+  const url = req.url();
+  if (!url.includes("/messages")) return false;
+  return url.includes("before=") || url.includes("after=");
+}
+
+function countPagingRequests(page: Page): { reset: () => void; urls: () => string[] } {
+  let seen: string[] = [];
+  page.on("request", (req) => {
+    if (isPagingRequest(req)) seen.push(req.url());
+  });
+  return {
+    reset: () => {
+      seen = [];
+    },
+    urls: () => [...seen],
+  };
+}
+
+// The same `/admin/test/subject` provisioning verb `specSubject.ts` uses (dev +
+// test only, admin-gated), asked for a much deeper channel. A separate subject
+// rather than a deeper shared one: SEED_ROWS would otherwise be paid by every
+// spec in the suite for the benefit of this one.
+async function provisionDeepSubject(
+  name: string,
+  channel: string,
+): Promise<{ user: SeededUser; nick: string }> {
+  const admin = getSeededAdmin();
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/test/subject`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${admin.token}` },
+    body: JSON.stringify({
+      name,
+      password: PASSWORD,
+      network_slug: NETWORK_SLUG,
+      nick: name,
+      autojoin_channels: [channel],
+      seed: [{ name: channel, seed_count: SEED_ROWS, seed_sender: "seed-bot" }],
+    }),
+  });
+  if (res.status !== 201) {
+    throw new Error(`provisionDeepSubject(${name}) failed: ${res.status} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { token: string; subject: unknown };
+  return {
+    user: {
+      name,
+      password: PASSWORD,
+      identifier: `${name}@grappa.test`,
+      token: body.token,
+      subjectJson: JSON.stringify(body.subject),
+    },
+    nick: name,
+  };
+}
+
+async function teardownDeepSubject(name: string): Promise<void> {
+  const admin = getSeededAdmin();
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/test/subject/${name}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${admin.token}` },
+  });
+  if (res.status !== 204) {
+    throw new Error(`teardownDeepSubject(${name}) failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+async function scrollToTop(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (el === null) return;
+    el.scrollTop = 0;
+    el.dispatchEvent(new Event("scroll"));
+  });
+}
+
+async function scrollTopOf(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    return el === null ? -1 : Math.round(el.scrollTop);
+  });
+}
+
+// A CONDITION, not a delay: two consecutive reads with the same scrollTop mean
+// the smooth jump has stopped moving, so every frame it was ever going to emit
+// has already re-entered onScroll and the count is final.
+async function waitForScrollToSettle(page: Page): Promise<void> {
+  let prev: number | null = null;
+  await expect
+    .poll(
+      async () => {
+        const top = await scrollTopOf(page);
+        const settled = prev !== null && top === prev;
+        prev = top;
+        return settled;
+      },
+      { timeout: 20_000, intervals: [250] },
+    )
+    .toBe(true);
+}
+
+test.describe("issue 2091 — the arrow jumps without downloading the buffer", () => {
+  test("a mention-jump tap issues no paging request, while a human scroll over the same region still pages", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    forwardPageDiagnostics(page);
+
+    const stamp = Date.now() % 100000;
+    const subjectName = `i91${stamp}`;
+    const channel = `#i2091-${stamp}`;
+    const peerNick = `i91p${stamp}`;
+
+    const { user, nick } = await provisionDeepSubject(subjectName, channel);
+    const mention = `${nick}: i2091 ping below the fold`;
+    let peer: IrcPeer | null = null;
+    try {
+      await loginAs(page, user);
+      await selectChannel(page, NETWORK_SLUG, channel, { ownNick: nick });
+
+      peer = await IrcPeer.connect({ nick: peerNick });
+      await peer.join(channel);
+      // ONE mention, deliberately: it becomes the newest row, so scrolling up
+      // puts it below the fold, and a single send keeps the peer well clear of
+      // bahamut's flood penalty.
+      peer.privmsg(channel, mention);
+      await assertMessagePersisted({
+        token: user.token,
+        networkSlug: NETWORK_SLUG,
+        channel,
+        sender: peerNick,
+        body: mention,
+        timeoutMs: 20_000,
+      });
+      await expect(scrollbackLine(page, "privmsg", "i2091 ping below the fold")).toBeVisible({
+        timeout: 20_000,
+      });
+
+      const paging = countPagingRequests(page);
+
+      // Setup, not measurement: a direct DOM write that parks the pane at the
+      // top of what is loaded, with the mention far below the fold. Its own
+      // paging happens before the counter is reset.
+      await scrollToTop(page);
+      await waitForScrollToSettle(page);
+
+      // Preconditions, asserted rather than assumed: the pane is off the tail
+      // and the badge sees the mention below the fold, so the tap takes the
+      // mention-jump branch and not the snap-to-tail one.
+      await expect(page.locator(SCROLL_TO_BOTTOM)).toBeVisible({ timeout: 15_000 });
+      await expect(page.locator(BADGE)).toHaveText("1", { timeout: 15_000 });
+      const topBeforeTap = await scrollTopOf(page);
+
+      // ── the measurement ──────────────────────────────────────────────────
+      paging.reset();
+      await page.locator(SCROLL_TO_BOTTOM).click({ timeout: 15_000 });
+      await waitForScrollToSettle(page);
+      const duringTap = paging.urls();
+
+      // The gesture's visible outcome still happened. Without this, the count
+      // could be satisfied by a tap that did nothing at all.
+      expect(
+        await scrollTopOf(page),
+        "the tap must actually move the pane, or a zero fetch count is meaningless",
+      ).toBeGreaterThan(topBeforeTap);
+      await expect(page.locator(BADGE)).toHaveCount(0, { timeout: 15_000 });
+
+      expect(
+        duringTap,
+        `one arrow tap must fetch nothing — the anchor was already rendered. Got: ${duringTap.join(", ")}`,
+      ).toEqual([]);
+
+      // ── the positive control, same pane, same state ──────────────────────
+      // Deliberately NOT "wheel until scrollTop reaches the backfill band".
+      // MEASURED: that condition is unreachable while the backfill pager is
+      // armed, which is exactly the state this control needs. Every page
+      // `maybeLoadOlder` pulls is PREPENDED, and `applyPrependPreserve` then
+      // restores the reader's row by the height delta — pushing scrollTop back
+      // DOWN by a page's worth. The pane hovered around 1048px through 80
+      // notches of −600 and the assertion failed on a fixture premise that
+      // cannot hold, not on the product. What proves the wheel was delivered is
+      // that the pane MOVED and the buffer GREW.
+      const rowsBeforeWheel = await scrollbackLines(page).count();
+      paging.reset();
+      await page.locator('[data-testid="scrollback"]').hover();
+      for (let i = 0; i < 40; i++) {
+        await page.mouse.wheel(0, -600);
+      }
+      await waitForScrollToSettle(page);
+
+      // Split from the paging assertion so a red names which half broke: this
+      // one failing means the wheel never reached the pane (a harness problem,
+      // and the count below would be meaningless); it passing with the count
+      // still zero means the cure gated the thresholds instead of the caller (a
+      // product problem, and the tap's zero above would mean nothing either).
+      expect(
+        await scrollbackLines(page).count(),
+        "the human wheel must actually pull older rows in, or the control below proves nothing",
+      ).toBeGreaterThan(rowsBeforeWheel);
+      expect(
+        paging.urls().length,
+        "a human scroll back through the top of the buffer must still page — the suppression is scoped to the programmatic jump, not to the thresholds",
+      ).toBeGreaterThan(0);
+    } finally {
+      if (peer !== null) await peer.disconnect("issue 2091 done");
+      await teardownDeepSubject(subjectName);
+    }
+  });
+});

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -1477,6 +1477,40 @@ const ScrollbackPane: Component<Props> = (props) => {
   // NOT inherit the leaving pane's input timestamp).
   const [lastInputEventAtMs, setLastInputEventAtMs] = createSignal<number | null>(null);
 
+  // issue 2091 — the sibling of the gate above, for the scrolls WE cause.
+  // `lastInputEventAtMs` answers "did the operator drive this scroll?" from the
+  // ABSENCE of an input event, which is enough for the cursor-settle block but
+  // not for the pagers: an operator who wheels and then taps the floating button
+  // inside the recency window would still look like input. This is the positive
+  // half — "the scroll events arriving right now are the applier's own" — made
+  // by `applyMentionJump` (the only writer that animates, see there) and read by
+  // both paging blocks in `onScroll`. An animated jump is never paging intent:
+  // the anchor it flies to is already rendered, so nothing between here and
+  // there needs loading to complete it.
+  const [programmaticScrollAtMs, setProgrammaticScrollAtMs] = createSignal<number | null>(null);
+  let programmaticScrollTimer: number | undefined;
+  // Re-armed by each frame of the animation it covers, so the flag lives exactly
+  // as long as the scroll it describes and needs no duration guessed up front.
+  // `SCROLL_SETTLE_DEBOUNCE_MS` is reused rather than minting a second number:
+  // it already names "scroll has gone quiet" and the operator-input clear below
+  // makes an over-long tail harmless — the operator's own first event takes the
+  // pagers back before the timer would.
+  const armProgrammaticScroll = (): void => {
+    setProgrammaticScrollAtMs(Date.now());
+    if (programmaticScrollTimer !== undefined) window.clearTimeout(programmaticScrollTimer);
+    programmaticScrollTimer = window.setTimeout(
+      () => setProgrammaticScrollAtMs(null),
+      SCROLL_SETTLE_DEBOUNCE_MS,
+    );
+  };
+  const releaseProgrammaticScroll = (): void => {
+    if (programmaticScrollTimer !== undefined) {
+      window.clearTimeout(programmaticScrollTimer);
+      programmaticScrollTimer = undefined;
+    }
+    setProgrammaticScrollAtMs(null);
+  };
+
   // BUGHUNT-2 B7: per-window visible-tail snapshot, captured on every
   // onScroll. The leave-arm in `on(key, …)` below reads from this map
   // for `prevKey` — by the time that effect fires, Solid has already
@@ -2362,6 +2396,9 @@ const ScrollbackPane: Component<Props> = (props) => {
       if (scrollSettleTimer !== undefined) {
         window.clearTimeout(scrollSettleTimer);
       }
+      // issue 2091 — the claim's own timer, cleared beside the settle timer it
+      // borrows its duration from.
+      releaseProgrammaticScroll();
     });
   });
 
@@ -3539,6 +3576,10 @@ const ScrollbackPane: Component<Props> = (props) => {
     if (!listRef) return;
     logScrollDecision("interrupt-smooth", [], null, "interrupt-smooth");
     listRef.scrollTo({ top: listRef.scrollTop });
+    // issue 2091 — the animation this claim covered has just been cancelled, so
+    // the claim goes with it. Releasing here rather than letting it lapse matters
+    // because the arriving pane re-anchors immediately after this point.
+    releaseProgrammaticScroll();
   };
 
   // #608 — the W8 mention-jump applier entrypoint. Tapping the floating button
@@ -3556,7 +3597,24 @@ const ScrollbackPane: Component<Props> = (props) => {
     const intent: ScrollIntent = { kind: "mention-jump", key: k, lifetime: "one-shot" };
     const { winner, reason } = resolveIntent([intent], k);
     logScrollDecision("mention-jump", [intent], winner, reason);
-    if (winner) anchor.scrollIntoView({ behavior: "smooth", block: "center" });
+    if (!winner) return;
+    // issue 2091 — the ONE claim, and this is the only writer that makes it.
+    // A smooth scroll emits one native `scroll` per frame, so without it every
+    // frame landing inside a pager's threshold band fetches with nobody behind
+    // it. Every other applier write is instant: one event, no sweep.
+    //
+    // The claim was first tried at `dispatchScrollWrite`, to cover the whole
+    // dispatch surface in one place rather than one example of it. MEASURED, it
+    // moved 3 previously-green specs (#608 + #1094, the `applyPrependPreserve`
+    // cases) and the cause is the claim's LIFETIME, not its breadth: those cases
+    // dispatch a bare `scroll` with no preceding input event, so a mount-time
+    // tail-follow write left a claim standing that swallowed the operator's very
+    // next scroll-to-top. Covering the dispatch surface therefore needs the claim
+    // correlated to the write that made it, not a time window — more than the one
+    // clear exception that would have been worth it here. Narrowed back to the
+    // animated writer, which is the only one that sweeps a band at all.
+    armProgrammaticScroll();
+    anchor.scrollIntoView({ behavior: "smooth", block: "center" });
   };
 
   // #608 (STEP 3) — the window-activation applier entrypoint (W2/W3), the LAST
@@ -3692,7 +3750,13 @@ const ScrollbackPane: Component<Props> = (props) => {
   // and the initial-mount run.
   createEffect(
     on(lastInputEventAtMs, (ts) => {
-      if (ts !== null) setMarkerActivationPending(false);
+      if (ts === null) return;
+      setMarkerActivationPending(false);
+      // issue 2091 — the operator taking over ends our claim on the scroll, for
+      // the same reason it hands back marker authority one line above: from here
+      // the events are theirs and the pagers are theirs. This is what keeps the
+      // claim from outliving the animation and swallowing a real scroll.
+      releaseProgrammaticScroll();
     }),
   );
 
@@ -3905,11 +3969,23 @@ const ScrollbackPane: Component<Props> = (props) => {
     // changes.
     recomputeMentionsBelow();
 
+    // issue 2091 — is this event OURS? The applier claimed the write that caused
+    // it; re-arm here so the claim spans the whole animation (one `scroll` per
+    // frame keeps it alive) and lapses on its own once the frames stop. The badge
+    // recompute above stays OUTSIDE the gate on purpose: it is a geometry read
+    // with no fetch, and the badge must keep decrementing as the jump clears its
+    // target past the fold — that is the gesture's visible outcome.
+    const programmatic = programmaticScrollAtMs() !== null;
+    if (programmatic) armProgrammaticScroll();
+
     // CP14 B2: scroll-up triggers loadMore. Delegated to the shared
     // `maybeLoadOlder` closure (also used by the #230 wheel-underfill path)
     // — the top-of-buffer gate + loadMore call + scroll-position preservation
     // on prepend all live there (CLAUDE.md implement-once).
-    maybeLoadOlder();
+    // issue 2091 — skipped while the scroll is ours. NOT a threshold change: the
+    // gate is on WHO scrolled, so the operator's own scroll-to-top through the
+    // same band pages exactly as before.
+    if (!programmatic) maybeLoadOlder();
 
     // #161: scroll-to-bottom triggers forward-paging — the mirror image of
     // the scroll-to-top loadMore above. After #156's anchored fetch a
@@ -3924,7 +4000,9 @@ const ScrollbackPane: Component<Props> = (props) => {
     // viewport, so the operator's view doesn't shift (loadMore prepends
     // above the viewport, which is why it needs the height-delta correction
     // and this does not).
-    if (distance <= LOAD_MORE_THRESHOLD_PX) {
+    // issue 2091 — same gate as loadMore above, same reason: an animated jump
+    // sweeping into this band is not the operator arriving at the tail.
+    if (!programmatic && distance <= LOAD_MORE_THRESHOLD_PX) {
       // loadNewer appends below the fold and preserves the view. We do NOT clear
       // the marker latch here (unlike loadMore): this BOTTOM boundary is hit by
       // a cold-mount's own tail scroll before the cursor hydrates, and clearing
@@ -3946,8 +4024,16 @@ const ScrollbackPane: Component<Props> = (props) => {
     //
     // forward-only gate in setCursorIfAdvances (selection.ts) drops
     // the POST when candidate <= current cursor — scroll-up from the
-    // tail is harmless. loadMore block above runs independently on
-    // the same scroll event; the two are unrelated.
+    // tail is harmless.
+    //
+    // issue 2091 — this note used to end "loadMore block above runs
+    // independently on the same scroll event; the two are unrelated". They are
+    // related now, and the asymmetry between them WAS the defect: both blocks
+    // ask "did the operator cause this scroll?", this one from the absence of a
+    // recent input event, the pagers from the applier's positive claim. Two
+    // gates rather than one because they answer for different windows of time —
+    // this one spans a gesture (1500ms of recency), theirs spans a single
+    // animation — but neither may fire on a scroll the pane caused itself.
     const inputAt = lastInputEventAtMs();
     const recentInput = inputAt !== null && Date.now() - inputAt < INPUT_EVENT_RECENCY_MS;
     if (!recentInput) return;

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -22,7 +22,7 @@ import {
 import { readingAtTailKey } from "../lib/readingAtTail";
 // #230 — the mocked `loadMore` (see vi.mock("../lib/scrollback")) so the
 // wheel-up-on-underfill trigger can be asserted directly.
-import { loadMore } from "../lib/scrollback";
+import { loadMore, loadNewer } from "../lib/scrollback";
 // #1156 — the shared point-carrying touch helper (the #230 block below has its
 // own clientY-only one, scoped to that describe).
 import { fireTouch as fireTouchPoint } from "./helpers/touchEvents";
@@ -2294,6 +2294,155 @@ describe("ScrollbackPane", () => {
       screen.getByTestId("scroll-to-bottom").click();
 
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+    });
+  });
+
+  // issue 2091 — a PROGRAMMATIC scroll must not be read as paging intent.
+  //
+  // The defect is an asymmetry inside ONE `onScroll` body: the cursor-settle
+  // block is gated on recent operator input (`lastInputEventAtMs`), while the
+  // two blocks that FETCH — `maybeLoadOlder()` and the `loadNewer` forward
+  // pager under `distance <= LOAD_MORE_THRESHOLD_PX` — are not. A smooth
+  // mention-jump emits one native `scroll` per animation frame, so every frame
+  // that lands inside a threshold band calls a pager with no operator behind it.
+  //
+  // The band is what bounds the cost, which is why these cases drive the
+  // animation ACROSS it rather than asserting a total: an anchor mid-buffer
+  // never crosses one and was never expensive. The pos ctrl is the other half —
+  // the cure must gate on WHO scrolled, never on the thresholds themselves, so
+  // the identical frame sequence with an operator behind it must still page.
+  describe("issue 2091 — a programmatic jump does not drive the scroll pager", () => {
+    const ROWS = 400;
+    const SCROLL_HEIGHT = 4000;
+    let origScrollIntoView: typeof Element.prototype.scrollIntoView;
+
+    beforeEach(() => {
+      origScrollIntoView = Element.prototype.scrollIntoView;
+    });
+    afterEach(() => {
+      Element.prototype.scrollIntoView = origScrollIntoView;
+    });
+
+    const seedRows = (n: number): ScrollbackMessage[] =>
+      Array.from({ length: n }, (_, i) => ({
+        id: i + 1,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: i + 1,
+        kind: "privmsg" as const,
+        // The second-to-last row mentions the own nick, so the #360 msg+1
+        // anchoring has a row AFTER it to anchor on (its real shape).
+        sender: i === n - 2 ? "bob" : "alice",
+        body: i === n - 2 ? "hey vjt" : "filler",
+        meta: {},
+      }));
+
+    // A real browser emits ONE native `scroll` per animation frame; jsdom emits
+    // none. Replaying the frames by hand is what puts the animation's re-entry
+    // into `onScroll` under test at all.
+    const animate = (list: HTMLDivElement, from: number, to: number, frames: number): void => {
+      for (let f = 1; f <= frames; f++) {
+        list.scrollTop = Math.round(from + ((to - from) * f) / frames);
+        list.dispatchEvent(new Event("scroll"));
+      }
+    };
+
+    // Overflowing pane, scrolled up (so the floating button renders), with the
+    // mention below the fold and its anchor near the LOADED tail — the #156
+    // shape, where the forward pager's band actually sits.
+    const mountScrolledUp = async (startTop: number): Promise<HTMLDivElement> => {
+      setUserNick("vjt");
+      setScrollback({ "freenode #grappa": seedRows(ROWS) });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+      Object.defineProperty(list, "clientHeight", { value: 100, configurable: true });
+      Object.defineProperty(list, "scrollHeight", { value: SCROLL_HEIGHT, configurable: true });
+      Object.defineProperty(list, "scrollTop", {
+        value: startTop + 50,
+        writable: true,
+        configurable: true,
+      });
+      const mention = list.querySelector<HTMLElement>(
+        `.scrollback-line[data-msg-id="${ROWS - 1}"]`,
+      );
+      const anchor = list.querySelector<HTMLElement>(`.scrollback-line[data-msg-id="${ROWS}"]`);
+      if (mention === null || anchor === null) throw new Error("mention rows not rendered");
+      Object.defineProperty(mention, "offsetTop", { value: 3800, configurable: true });
+      Object.defineProperty(anchor, "offsetTop", { value: 3810, configurable: true });
+      // Scroll DOWN (establishes lastScrollTop) then UP → the button renders.
+      list.dispatchEvent(new Event("scroll"));
+      list.scrollTop = startTop;
+      list.dispatchEvent(new Event("scroll"));
+      await waitFor(() => expect(screen.queryByTestId("scroll-to-bottom")).not.toBeNull());
+      return list;
+    };
+
+    it("does not forward-page while the mention-jump animation sweeps the tail band", async () => {
+      const list = await mountScrolledUp(1000);
+      vi.mocked(loadMore).mockClear();
+      vi.mocked(loadNewer).mockClear();
+      Element.prototype.scrollIntoView = () => {
+        animate(list, 1000, SCROLL_HEIGHT - 100, 60);
+      };
+
+      screen.getByTestId("scroll-to-bottom").click();
+
+      expect(vi.mocked(loadNewer)).not.toHaveBeenCalled();
+      expect(vi.mocked(loadMore)).not.toHaveBeenCalled();
+    });
+
+    // The OTHER pager. A jump that begins near the top of the buffer sweeps the
+    // scroll-to-top band on its first frames, so the backfill needs the same
+    // gate — without this case that leg of the cure ships untested.
+    it("does not backfill while the animation leaves the scroll-to-top band", async () => {
+      const list = await mountScrolledUp(100);
+      vi.mocked(loadMore).mockClear();
+      Element.prototype.scrollIntoView = () => {
+        animate(list, 100, SCROLL_HEIGHT - 100, 60);
+      };
+
+      screen.getByTestId("scroll-to-bottom").click();
+
+      expect(vi.mocked(loadMore)).not.toHaveBeenCalled();
+    });
+
+    it("still backfills when a HUMAN scrolls into the scroll-to-top band", async () => {
+      const list = await mountScrolledUp(1000);
+      vi.mocked(loadMore).mockClear();
+
+      list.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }));
+      animate(list, 1000, 0, 30);
+
+      expect(vi.mocked(loadMore)).toHaveBeenCalled();
+    });
+
+    it("still forward-pages when a HUMAN scrolls through the same band", async () => {
+      const list = await mountScrolledUp(1000);
+      vi.mocked(loadMore).mockClear();
+      vi.mocked(loadNewer).mockClear();
+
+      // The operator's own wheel stamps `lastInputEventAtMs`; the frames that
+      // follow are the SAME ones the animation replays above.
+      list.dispatchEvent(new WheelEvent("wheel", { deltaY: 120 }));
+      animate(list, 1000, SCROLL_HEIGHT - 100, 60);
+
+      expect(vi.mocked(loadNewer)).toHaveBeenCalled();
+    });
+
+    it("resumes paging when the operator takes over mid-animation", async () => {
+      const list = await mountScrolledUp(1000);
+      vi.mocked(loadNewer).mockClear();
+      Element.prototype.scrollIntoView = () => {
+        // Half the animation, then the operator grabs the pane and drives the
+        // rest themselves — from there on the pager is theirs again.
+        animate(list, 1000, 3400, 30);
+        list.dispatchEvent(new WheelEvent("wheel", { deltaY: 120 }));
+        animate(list, 3400, SCROLL_HEIGHT - 100, 30);
+      };
+
+      screen.getByTestId("scroll-to-bottom").click();
+
+      expect(vi.mocked(loadNewer)).toHaveBeenCalled();
     });
   });
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54243,3 +54243,97 @@ than riding a one-word allowlist fix.
   decode was not investigated.
 - The walk proves the endpoint serves the bytes. It says nothing about
   whether any of them is a playable mp3.
+<!-- entry #2091 -->
+
+---
+
+## 2026-09-12 — issue 2091: a programmatic scroll is not paging intent, and what one tap actually costs
+
+vjt, from a live client: tapping the floating scroll-to-bottom arrow on a
+channel with thousands of unread "causes hundreds of requests". The arrow is
+the jump-to-mention control (#360) and keeps that role; the animation may
+stay. What had to stop was the fetching.
+
+**The defect is an asymmetry inside ONE function body.** In
+`ScrollbackPane.onScroll`, the cursor-settle block is gated on recent operator
+input (`lastInputEventAtMs`) precisely because "programmatic scrolls fired by
+`scrollToActivation` emit DOM `scroll` events but no preceding pointerdown /
+wheel / touchmove / keydown". Three lines above it, the two blocks that FETCH
+— `maybeLoadOlder()` and the `loadNewer` forward pager under
+`distance <= LOAD_MORE_THRESHOLD_PX` — had no such gate. A smooth
+`scrollIntoView` emits one native `scroll` per animation frame, so every frame
+landing inside a pager's threshold band called a pager with nobody behind it.
+The precedent for the fix was already three lines below the bug.
+
+**The cure is the POSITIVE half of the question the settle block asks.**
+`lastInputEventAtMs` infers "not the operator" from the ABSENCE of an input
+event, which is enough for the cursor but not for the pagers: an operator who
+wheels and then taps the button inside the 1500ms recency window still looks
+like input, so reusing that gate would have suppressed nothing in the commonest
+real sequence. Instead `applyMentionJump` CLAIMS the scroll it is about to
+cause; both paging blocks honour the claim; it is released by the operator
+taking over (`on(lastInputEventAtMs)`, beside the marker-authority hand-back it
+mirrors), by the key-change cancel, and by its own quiescence timer. The gate
+is on WHO scrolled and never on the thresholds, so a human scrolling the same
+region pages exactly as before.
+
+**The altitude was decided by measurement, not by taste, and the first answer
+was wrong.** The claim was first made at `dispatchScrollWrite`, to cover the
+whole applier dispatch surface rather than one example of it — "fix root
+causes, not examples". On the full cic unit suite that moved three
+previously-green specs (#608 + #1094, the `applyPrependPreserve` cases): base
+7118 passed / 0 failed, seam 3 failed, narrow 7123 passed / 0 failed. The cause
+is the claim's LIFETIME rather than its breadth — those cases dispatch a bare
+`scroll` with no preceding input event, so a mount-time tail-follow write left
+a claim standing that swallowed the operator's very next scroll-to-top.
+Covering the dispatch surface honestly needs the claim correlated to the write
+that made it, not a time window. **Apply:** when a gate is widened to a shared
+seam, the thing that breaks is rarely the seam's breadth — it is how long the
+state the seam sets is allowed to stand. Measure the blast radius before
+believing the altitude argument; the rule that says to fix the class does not
+say the class is reachable with the mechanism in hand.
+
+**The reported magnitude is NOT reproduced, and that is a result.** The cost
+does not scale with the buffer: it is bounded by how many animation frames fall
+inside a 200px band. Measured on a frame-replay bench, one tap costs 5 pager
+CALLS in the worst geometry (anchor near the loaded tail), 1 when the animation
+starts near the top of the buffer, and **0** with the anchor mid-buffer — and
+the verbs' own in-flight guard plus exhausted latch collapse a burst further
+before it reaches the wire. The issue itself declares the "hundreds" figure
+unmeasured. The defect does not depend on it: the asymmetry is read in the
+code and stands on its own.
+
+**Left OPEN, deliberately: the forward-pager ratchet.** `loadNewer` merges a
+page, which grows `rows()`, which can fire the length-effect's tail-follow,
+which scrolls, which can page again. It is the one plausible route to a large
+number. On the bench it self-limited at 2 pages, which is evidence it exists
+and no evidence about where it stops in the field; this change does not address
+it, and the tail-follow write is exactly the one the narrow claim does not
+cover.
+
+**Two benches, two different quantities — and only one of them
+discriminates.** The vitest bench counts the PANE'S CALLS to the paging verbs
+against a mocked store, with the animation's frames replayed by hand because
+jsdom animates nothing; it goes red without the cure and is the evidence the
+fix works. The e2e
+(`e2e/tests/issue2091-jump-does-not-page.spec.ts`) counts HTTP REQUESTS in
+chromium, which is the issue's own acceptance wording, and its answer is
+**ZERO ON BOTH SIDES** — measured by reverting the cure and re-running, on a
+3000-row corpus with both pagers still armed. The pane's 5 calls do not become
+5 requests: a smooth scroll across tens of thousands of pixels moves far enough
+per frame that no `scroll` event lands inside a 200px band, and the verbs'
+in-flight guard plus exhausted latch absorb the rest. **So the acceptance
+number exists and it is zero, before the fix as well.** The spec is kept, and
+says so in its own header, because it still guards the property and because its
+positive control catches the cure's worst failure mode — gating the THRESHOLDS
+instead of the CALLER.
+
+**Apply, and it cost three fixtures to learn:** a spec that counts something
+must be shown to be capable of counting it, and the only proof is running it
+against the defect. Two of the three fixtures here were green for reasons that
+had nothing to do with the code under test — the first drained its own 200-row
+corpus during setup and latched both pagers before the gesture, and the second
+asserted a precondition (`scrollTop <= 200` after a human wheel) that is
+UNREACHABLE while the backfill pager is armed, since every page it pulls is
+prepended and `applyPrependPreserve` pushes scrollTop back down by a page.
+Neither would have announced itself; both reported green.


### PR DESCRIPTION
`ScrollbackPane.onScroll` had an asymmetry inside one function body. The
cursor-settle block is gated on recent operator input (`lastInputEventAtMs`)
precisely because "programmatic scrolls emit DOM `scroll` events but no
preceding pointerdown / wheel / touchmove / keydown". Three lines above it, the
two blocks that FETCH — `maybeLoadOlder()` and the `loadNewer` forward pager
under `distance <= LOAD_MORE_THRESHOLD_PX` — had no such gate. A smooth
mention-jump emits one native `scroll` per animation frame, so every frame
landing inside a pager's threshold band called a pager with nobody behind it.
The precedent for the fix was already three lines below the bug.

The arrow keeps its role as the jump-to-mention control, the animation stays,
the #360 iOS msg+1 anchoring is untouched, and nothing in `mentionScroll` is
deleted.

## What proves the fix, and what does NOT

**Proves it — the unit bench.** `ScrollbackPane.test.tsx` replays the animation
frame by frame and counts the pane's CALLS to the paging verbs. It is RED
without the cure (`expected "vi.fn()" to not be called at all, but actually
been called 5 times`) and green with it. Three positive controls ride along: a
human wheel through the same band still forward-pages, a human wheel into the
scroll-to-top band still backfills, and an operator who grabs the pane
MID-animation gets the pagers back.

**Does NOT prove it — the e2e.** `issue2091-jump-does-not-page.spec.ts` is
green with the cure **and measured green without it** — established by
reverting the cure and re-running, not assumed. It does not discriminate this
change and must not be cited as evidence that it works. Its header says so in
the first paragraph. It is kept because its positive control is live: a real
wheel over the same region must still page, which is what goes red if the
suppression is ever written against `distance` instead of against who scrolled.

## The reported magnitude is not reproduced

"Hundreds of requests" does not reproduce, in either bench, and issue 2091
itself declares that figure unmeasured.

- Frame bench: the cost does not scale with the buffer. It is bounded by how
  many animation frames fall inside a 200px band — 5 pager calls for one tap in
  the worst geometry, 1 when the animation starts near the top, and **0** with
  the anchor mid-buffer.
- Real browser, 3000-row corpus, both pagers still armed: **zero HTTP paging
  requests per tap, before and after the cure.** The pane's calls do not become
  requests — a smooth scroll across tens of thousands of pixels moves far
  enough per frame that no `scroll` event lands inside the band, and the verbs'
  in-flight guard plus exhausted latch absorb the rest.

The defect does not depend on that figure: the asymmetry is read in the code
and pinned by a test that goes red without the fix.

## Left OPEN — the forward-pager ratchet

`loadNewer` merges a page, which grows `rows()`, which can fire the
length-effect's tail-follow, which scrolls, which can page again. It is the one
plausible route to a large number. On the bench it self-limited at 2 pages,
which is evidence it exists and no evidence about where it stops in the field.
**Not closed, not excluded** — and the tail-follow write is exactly the one the
claim taken here does not cover.

## Altitude: the narrow flag, and the measurement that chose it

The claim was first made at `dispatchScrollWrite`, to cover the whole applier
dispatch surface rather than one example of it. Measured on the full cic unit
suite:

| branch | Tests | failed |
|---|---|---|
| base | 7118 | 0 |
| seam (`dispatchScrollWrite`) | — | **3** (#608 + #1094, the `applyPrependPreserve` cases) |
| narrow (`applyMentionJump`) | 7123 | 0 |

The cause is the claim's LIFETIME, not its breadth: those cases dispatch a bare
`scroll` with no preceding input event, so a mount-time tail-follow write left
a claim standing that swallowed the operator's very next scroll-to-top.
Covering the dispatch surface needs the claim correlated to the write that made
it rather than to a time window — more than the one clear exception it would
have been worth here.

The cold-mount forward page (where #161 legitimately discovers the gap left by
the #156 anchored load) **holds by construction**: `applyActivation` calls
`scrollToActivation` directly and never passes through `dispatchScrollWrite`,
so the narrow claim cannot reach it.

## Two fixture findings, both measured

Recorded because both reported green for reasons unrelated to the code under
test, and neither would have announced itself.

1. The e2e first ran on the shared spec-subject's 200-row channel. With a
   50-row REST page, the scroll-to-top that sets the scene drains the corpus
   and latches both exhausted flags before the gesture — after which no pager
   can fire for any caller. Proven vacuous by running it without the cure and
   watching it pass. Hence a 3000-row corpus.
2. The positive control does not wheel until `scrollTop <= 200`. That condition
   is unreachable while the backfill pager is armed — every page it pulls is
   prepended and `applyPrependPreserve` restores the reader's row by the height
   delta, pushing scrollTop back down by a page (measured: ~1048px through 80
   notches of −600). The control now asserts the BUFFER GREW.

## Gates

| gate | result |
|---|---|
| `bun.sh run check` | `rc=0`, 5/5 stages (lock drift first) |
| `bun.sh run test` | `rc=0`, 352 files / 7123 tests / 0 failed |
| `design-notes-gate.sh` | `rc=0`, separator + marker present |
| `union-rebase.sh` | `rc=0`, `docs/DESIGN_NOTES.md +94 −0 — contribution intact` |
| `integration.sh` (full) | `rc=1`, 977 passed / 2 failed — both triaged below |

Rebased onto `origin/main` `3fd4bebb1`, `behind=0`.

**The two integration reds, attributed rather than dismissed:**

- `issue1964-upload-confirm-preview` — **pre-existing**. Reproduced with this
  branch's only production file reverted to base: still red. Not this change.
- `issue1766-hide-bottom-bar` (webkit-iphone-15) — **does not reproduce in
  isolation with the cure**: 6/6 green over `--repeat-each 3`, three of them on
  the very project that failed. Flake or full-suite cascade; which of the two
  was NOT established here.

This branch's own spec passed in the full suite (#264, chromium).

## Not claimed

No measurement on m42. The frame bench's 60 frames are a chosen number, not the
browser's frame count — it models the animation rather than running it.
`README.md` and `NON-GOALS.md` untouched.
