### PR TITLE
cic: unread rollup badge on the archive launcher (2096)

### DIFF
--- a/cicchetto/e2e/tests/issue2096-archive-launcher-unread-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue2096-archive-launcher-unread-badge.spec.ts
@@ -1,0 +1,152 @@
+// issue 2096 — the unread rollup badge on the archive launcher.
+//
+// Reported by Fairy: an archived window holding unread was invisible until you
+// opened the ArchiveModal AND expanded the right network group. #532 B put
+// per-row badges INSIDE the modal; the launcher that opens it carried nothing.
+//
+// What this pins, in ONE continuously-open rail menu, so every transition is
+// observed LIVE rather than across reloads:
+//
+//   1. baseline — whatever the shared backend already holds, read off the
+//      badge itself (the suite shares one account across specs, so an
+//      absolute `0` would be a hostage to whatever ran before);
+//   2. THE CONTROL — a peer message lands in a channel the operator is still
+//      IN. The unread is real (the +1 in step 3 proves cic counted it), and
+//      the badge must NOT move: an ACTIVE window has its own surface and is
+//      not the archive's business. Without this reading, step 3 would only
+//      say "a number appeared", not "the subtraction works";
+//   3. APPEARS — PART the channel. Same unread, no new message, the window
+//      simply stops having a nav surface, and the rollup gains exactly 1;
+//   4. DISAPPEARS — JOIN it back. Still the same unread, the surface returns,
+//      the rollup falls back to the baseline.
+//
+// Steps 3 and 4 are what makes this spec a real one rather than a green mirror
+// of the code: the badge is DERIVED from `/me`'s seed minus what the nav
+// draws (`lib/archiveRollup.ts`), so a rollup wired to anything else — the
+// raw seed, a boot-time snapshot, the modal's lazily-loaded list — fails at
+// 2, at 4, or at both.
+//
+// Both form factors, because `RailActions` is ONE component mounted by both
+// branches of Shell's `isMobile()` split (#473). The desktop entry runs on the
+// `chromium` project by subtraction; the `@touch` twin runs on
+// `chromium-pixel-touch`. NOT `@webkit`: the claim here is "the rail menu on a
+// phone-shaped viewport shows the badge", and WebKit tap semantics are a
+// different axis (issue 1831) that this badge does not touch.
+
+import type { Page } from "@playwright/test";
+import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  assertMessagePersisted,
+  awaitPartEcho,
+  joinChannel,
+  partChannel,
+  restoreReadCursorToTail,
+} from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specLiveNick, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+const WITNESS = "#2096 — the line that must show up behind the archive door";
+
+test.afterEach(async () => {
+  const vjt = specUser();
+  // Restore the seed-time joined state and a tail cursor: this spec PARTs the
+  // shared autojoin channel and leaves an unread behind, and neither may
+  // poison a sibling spec (or this one under --repeat-each). Both idempotent,
+  // both guarded so a mid-test failure cannot cascade.
+  await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL).catch(() => {});
+  await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL).catch(() => {});
+});
+
+// The archive launcher's MESSAGE pill, as a number — 0 when no badge renders.
+//
+// Scoped to `.sidebar-msg-unread` and not to the whole cluster on purpose: the
+// events pill is a separate tier (#265/#532) whose value depends on the
+// operator's `show_event_badge` preference and on own-presence rows, and this
+// spec's claim is strictly about the message rollup. `openRailMenu` is
+// idempotent, so polling through it is safe and keeps the menu open across
+// every reading.
+async function archiveBadgeMessages(page: Page): Promise<number> {
+  await openRailMenu(page);
+  const pill = page.locator(
+    ".rail-actions-menu [data-testid='rail-archive-unread'] .sidebar-msg-unread",
+  );
+  if ((await pill.count()) === 0) return 0;
+  const text = (await pill.first().innerText()).trim();
+  const parsed = Number.parseInt(text, 10);
+  return Number.isNaN(parsed) ? -1 : parsed;
+}
+
+async function expectArchiveBadge(page: Page, expected: number): Promise<void> {
+  await expect
+    .poll(() => archiveBadgeMessages(page), { timeout: 10_000, intervals: [100, 200, 500] })
+    .toBe(expected);
+}
+
+async function runBadgeJourney(page: Page): Promise<void> {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+
+  // Clean baseline on the channel itself, so the +1 below is OUR peer line and
+  // not a leftover from a sibling spec.
+  await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+
+  // Focus the channel once (hydrates its pane + the per-channel topic), then
+  // step off to the server window: a focused window suppresses its own badge,
+  // and the server window has no compose, so it cannot produce client chatter
+  // of its own. Addressed by the SLUG, which `sidebarWindow` resolves to
+  // `$server` alongside the legacy `"Server"` label — a third hand-copy of
+  // that constant is the drift #1646 pinned the e2e tree against.
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await selectChannel(page, NETWORK_SLUG, NETWORK_SLUG, { awaitWsReady: false });
+
+  // 1 — BASELINE, read off the badge. The shared account may already hold
+  // archived unread from a sibling spec; the claim is the DELTA.
+  await openRailMenu(page);
+  const baseline = await archiveBadgeMessages(page);
+  expect(baseline).toBeGreaterThanOrEqual(0);
+
+  const peer = await IrcPeer.connect({ nick: `i2096-peer` });
+  try {
+    await peer.join(CHANNEL);
+    peer.privmsg(CHANNEL, WITNESS);
+    // Server-side barrier: the line exists. Without this the "badge did not
+    // move" reading below could be a message that never arrived.
+    await assertMessagePersisted({
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      channel: CHANNEL,
+      sender: peer.nick,
+      body: WITNESS,
+    });
+
+    // 2 — THE CONTROL. The unread is in a channel the operator is still IN, so
+    // it has a nav row of its own and the archive rollup must not claim it.
+    await expectArchiveBadge(page, baseline);
+
+    // 3 — APPEARS. PART only removes the surface; the unread is untouched.
+    await partChannel(vjt.token, NETWORK_SLUG, CHANNEL);
+    await awaitPartEcho(vjt.token, NETWORK_SLUG, CHANNEL, await specLiveNick());
+    await expectArchiveBadge(page, baseline + 1);
+
+    // 4 — DISAPPEARS. JOIN gives the surface back; still no message read.
+    await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL);
+    await expectArchiveBadge(page, baseline);
+  } finally {
+    await peer.disconnect("#2096 done");
+  }
+}
+
+test("#2096 — the archive launcher badge counts a window ONLY while it is archived", async ({
+  page,
+}) => {
+  await runBadgeJourney(page);
+});
+
+test("@touch #2096 — the same badge, on the mobile rail drawer", async ({ page }) => {
+  // Same component, same derivation: `openRailMenu` opens the members drawer
+  // first on a phone viewport, then the launcher. If the badge only ever
+  // worked on the desktop rail, this entry is where that shows.
+  await runBadgeJourney(page);
+});

--- a/cicchetto/src/RailActions.tsx
+++ b/cicchetto/src/RailActions.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "@solidjs/router";
 import { type Component, createEffect, createSignal, For, onCleanup, Show } from "solid-js";
 import { refreshInCardHead, refreshSlot } from "./admin/refreshSlot";
 import { archiveSlugForSelection } from "./lib/archiveContext";
+import { archivedUnread } from "./lib/archiveRollup";
 import { activeAudio, playerHidden, showPlayer } from "./lib/audioPlayer";
 import { type ChannelKey, channelKey } from "./lib/channelKey";
 import { conversationMuteKey, isConversationMuted } from "./lib/conversationMute";
@@ -538,6 +539,22 @@ const RailActions: Component<Props> = (props) => {
               {"\u{1F4C2}"}
             </span>
             <span class="rail-action-label">archive</span>
+            {/* issue 2096 — the rollup of what is unread BEHIND this door.
+                Same two badge classes the sidebar and the modal's own rows
+                use, so messages and events stay distinguishable instead of
+                collapsing into one dot. Derived from the `/me` seed cic
+                already holds (lib/archiveRollup.ts) — no fetch, and no
+                eager archive load: `loadArchive` stays lazy per group. */}
+            <Show when={archivedUnread().messages > 0 || archivedUnread().events > 0}>
+              <span class="rail-action-unread" data-testid="rail-archive-unread">
+                <Show when={archivedUnread().messages > 0}>
+                  <span class="sidebar-msg-unread">{archivedUnread().messages}</span>
+                </Show>
+                <Show when={archivedUnread().events > 0}>
+                  <span class="sidebar-events-unread">{archivedUnread().events}</span>
+                </Show>
+              </span>
+            </Show>
           </button>
 
           {/* #71 INC-2 — settings cog. ALWAYS rendered; the cluster-wide

--- a/cicchetto/src/__tests__/RailActions.test.tsx
+++ b/cicchetto/src/__tests__/RailActions.test.tsx
@@ -150,6 +150,15 @@ vi.mock("../lib/archiveContext", () => ({
   archiveSlugForSelection: () => roomsSlugHolder.value,
 }));
 
+// issue 2096 — the archive launcher's rollup badge. Only the MEMO is stubbed
+// (the reactive read); the `> 0` render gate under test stays the component's
+// own, so a regression that drops the gate still fails here. The derivation
+// behind the memo is covered as a pure fn in `archiveRollup.test.ts`.
+const archiveRollupHolder = vi.hoisted(() => ({ value: { messages: 0, events: 0 } }));
+vi.mock("../lib/archiveRollup", () => ({
+  archivedUnread: () => archiveRollupHolder.value,
+}));
+
 const openHomePanel = vi.fn();
 const openListPanel = vi.fn();
 const openThemesPanel = vi.fn();
@@ -198,6 +207,7 @@ beforeEach(() => {
   mutedHolder.value = {};
   refreshHolder.value = null;
   inCardHeadHolder.value = false;
+  archiveRollupHolder.value = { messages: 0, events: 0 };
   dismissConfirm();
 });
 
@@ -311,6 +321,52 @@ describe("RailActions (#473)", () => {
     openMenu();
     fireEvent.click(screen.getByTestId("mobile-panel-archive"));
     expect(openArchivePanel).toHaveBeenCalledWith(setters);
+  });
+
+  // issue 2096 — Fairy's report: an archived window holding unread had no
+  // surface until the modal was open AND the right group expanded. The
+  // launcher now carries the rollup.
+  describe("archive unread rollup badge (issue 2096)", () => {
+    it("renders NO badge when the archive holds nothing unread", () => {
+      render(() => <RailActions setters={setters} />);
+      openMenu();
+      expect(screen.getByTestId("mobile-panel-archive")).toBeInTheDocument();
+      expect(screen.queryByTestId("rail-archive-unread")).toBeNull();
+    });
+
+    it("renders the message count on the archive button when the archive has unread", () => {
+      archiveRollupHolder.value = { messages: 3, events: 0 };
+      render(() => <RailActions setters={setters} />);
+      openMenu();
+      const badge = screen.getByTestId("rail-archive-unread");
+      expect(badge).toHaveTextContent("3");
+      // On the archive button itself, not loose in the drawer — the badge has
+      // to name which door it belongs to.
+      expect(screen.getByTestId("mobile-panel-archive")).toContainElement(badge);
+    });
+
+    it("keeps messages and events as two DISTINCT badges", () => {
+      // #532's rule carried up: presence churn is its own tier and must not
+      // collapse into the message dot. The two sidebar pill classes are the
+      // shared visual language, so assert the classes and not just the text.
+      archiveRollupHolder.value = { messages: 2, events: 7 };
+      const { container } = render(() => <RailActions setters={setters} />);
+      openMenu();
+      const msg = container.querySelector(".rail-action-unread .sidebar-msg-unread");
+      const events = container.querySelector(".rail-action-unread .sidebar-events-unread");
+      expect(msg).toHaveTextContent("2");
+      expect(events).toHaveTextContent("7");
+    });
+
+    it("renders the events badge ALONE when the archive holds only presence churn", () => {
+      // The gate is the SUM, not the message count: a window whose entire
+      // unread is join/part noise still has to be findable.
+      archiveRollupHolder.value = { messages: 0, events: 4 };
+      const { container } = render(() => <RailActions setters={setters} />);
+      openMenu();
+      expect(screen.getByTestId("rail-archive-unread")).toHaveTextContent("4");
+      expect(container.querySelector(".rail-action-unread .sidebar-msg-unread")).toBeNull();
+    });
   });
 
   it("gates rooms on a network context (archiveSlugForSelection null ⇒ hidden)", () => {

--- a/cicchetto/src/__tests__/archiveRollup.test.ts
+++ b/cicchetto/src/__tests__/archiveRollup.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import type { ArchiveSuppression } from "../lib/archive";
+import { type ArchiveNetworkFacts, rollupArchivedUnread } from "../lib/archiveRollup";
+import { type ChannelKey, channelKey } from "../lib/channelKey";
+import { DEFAULT_CHANTYPES } from "../lib/chantypes";
+import { normalizeNick } from "../lib/nickEquals";
+import { SERVER_WINDOW_NAME } from "../lib/windowKinds";
+
+// issue 2096 — the archive launcher's rollup badge.
+//
+// The whole point of the derivation is that the numbers are ALREADY on the
+// client: `/me`'s `unread_counts` seed carries every window with a read
+// cursor, ARCHIVED ONES INCLUDED (measured on the artefact — see
+// DESIGN_NOTES 2026-09-12). What cic lacks is not the counts but the
+// membership, and membership is `seed − active`, which cic also already
+// holds. So this fn answers "of the windows I have unread for, which ones
+// have no surface in the nav?" and sums those.
+//
+// Pure, on the model of `orderUnreadWindows` (lib/activeWindows.ts): plain
+// data in, plain data out, so the subtraction is testable without a
+// reactive context. The `archivedUnread` memo feeds it the live signals.
+//
+// The invariant every case below defends: the rollup must equal the sum of
+// the badges `ArchiveModal` draws behind the launcher. A badge that counts
+// a window the modal does not list is a number the operator cannot chase.
+
+const ck = channelKey;
+
+const suppression = (
+  parts: Partial<{ channels: string[]; queries: string[]; pseudo: string[] }>,
+): ArchiveSuppression => ({
+  // The production builder folds with `normalizeNick`; so does the test, or
+  // the compare would be testing the test's own spelling.
+  channels: new Set((parts.channels ?? []).map((n) => normalizeNick(n, "ascii"))),
+  queries: new Set((parts.queries ?? []).map((n) => normalizeNick(n, "ascii"))),
+  pseudo: new Set((parts.pseudo ?? []).map((n) => normalizeNick(n, "ascii"))),
+});
+
+const facts = (sup: ArchiveSuppression | null): ArchiveNetworkFacts => ({
+  casemapping: "ascii",
+  chantypes: DEFAULT_CHANTYPES,
+  suppression: sup,
+});
+
+// One network ("net") unless a case says otherwise.
+const oneNetwork =
+  (sup: ArchiveSuppression | null) =>
+  (slug: string): ArchiveNetworkFacts | null =>
+    slug === "net" ? facts(sup) : null;
+
+const counts = (pairs: Array<[string, number]>): Record<ChannelKey, number> => {
+  const out: Record<ChannelKey, number> = {};
+  for (const [name, n] of pairs) out[ck("net", name)] = n;
+  return out;
+};
+
+describe("rollupArchivedUnread", () => {
+  it("is zero when there is no unread at all", () => {
+    expect(
+      rollupArchivedUnread({
+        messages: {},
+        events: {},
+        factsForSlug: oneNetwork(suppression({})),
+      }),
+    ).toEqual({ messages: 0, events: 0 });
+  });
+
+  it("sums messages and events over windows the nav does not draw", () => {
+    expect(
+      rollupArchivedUnread({
+        messages: counts([
+          ["#gone", 3],
+          ["oldpeer", 4],
+        ]),
+        events: counts([["#gone", 2]]),
+        factsForSlug: oneNetwork(suppression({})),
+      }),
+    ).toEqual({ messages: 7, events: 2 });
+  });
+
+  it("keeps messages and events on SEPARATE totals", () => {
+    // #532's rule, carried up to the rollup: presence churn is its own tier
+    // and must not inflate the message number.
+    expect(
+      rollupArchivedUnread({
+        messages: counts([["#gone", 1]]),
+        events: counts([["#gone", 90]]),
+        factsForSlug: oneNetwork(suppression({})),
+      }),
+    ).toEqual({ messages: 1, events: 90 });
+  });
+
+  it("subtracts a channel the operator is still in", () => {
+    expect(
+      rollupArchivedUnread({
+        messages: counts([
+          ["#live", 5],
+          ["#gone", 1],
+        ]),
+        events: {},
+        factsForSlug: oneNetwork(suppression({ channels: ["#live"] })),
+      }),
+    ).toEqual({ messages: 1, events: 0 });
+  });
+
+  it("subtracts a query window that is open", () => {
+    expect(
+      rollupArchivedUnread({
+        messages: counts([
+          ["livepeer", 5],
+          ["oldpeer", 1],
+        ]),
+        events: {},
+        factsForSlug: oneNetwork(suppression({ queries: ["livepeer"] })),
+      }),
+    ).toEqual({ messages: 1, events: 0 });
+  });
+
+  it("subtracts a pseudo-row window (failed / kicked / pending / parked)", () => {
+    expect(
+      rollupArchivedUnread({
+        messages: counts([
+          ["#kicked", 5],
+          ["#gone", 1],
+        ]),
+        events: {},
+        factsForSlug: oneNetwork(suppression({ pseudo: ["#kicked"] })),
+      }),
+    ).toEqual({ messages: 1, events: 0 });
+  });
+
+  it("checks a channel against the channel set and a nick against the query set", () => {
+    // The two sets are NOT interchangeable: a nick listed among live
+    // channels must not silence the DM of the same spelling, or the
+    // subtraction would be a bare union pretending to be kind-aware.
+    expect(
+      rollupArchivedUnread({
+        messages: counts([["oldpeer", 6]]),
+        events: {},
+        factsForSlug: oneNetwork(suppression({ channels: ["oldpeer"] })),
+      }),
+    ).toEqual({ messages: 6, events: 0 });
+  });
+
+  it("folds the compare, so casing cannot leak an archived window back in", () => {
+    // #372/#1861 — the live row carries DISPLAY casing, the key is folded.
+    expect(
+      rollupArchivedUnread({
+        messages: counts([["#Foo", 9]]),
+        events: {},
+        factsForSlug: oneNetwork(suppression({ channels: ["#FOO"] })),
+      }),
+    ).toEqual({ messages: 0, events: 0 });
+  });
+
+  it("never counts the $server pseudo-channel", () => {
+    // `Scrollback.list_archive/3` excludes it unconditionally, so the modal
+    // never draws a row for it and the rollup must not out-count the modal.
+    expect(
+      rollupArchivedUnread({
+        messages: counts([
+          [SERVER_WINDOW_NAME, 40],
+          ["#gone", 1],
+        ]),
+        events: counts([[SERVER_WINDOW_NAME, 40]]),
+        factsForSlug: oneNetwork(suppression({})),
+      }),
+    ).toEqual({ messages: 1, events: 0 });
+  });
+
+  it("skips a slug cic knows no network for", () => {
+    // GH #105 — an unbound-but-retained network still seeds `unread_counts`,
+    // but `ArchiveModal` iterates `networks()` and draws no group for it. No
+    // group, no row, no contribution.
+    expect(
+      rollupArchivedUnread({
+        messages: counts([["#gone", 3]]),
+        events: {},
+        factsForSlug: () => null,
+      }),
+    ).toEqual({ messages: 0, events: 0 });
+  });
+
+  it("counts EVERYTHING on a network whose nav draws no row at all", () => {
+    // issue 1985 — a parked network is dropped by the desktop Sidebar's ONE
+    // `<For>`, so the correct subtraction is the empty set even for windows
+    // `channelsBySlug` still lists. `visibleArchiveForNetwork` returns the
+    // entries untouched there; the rollup has to agree or the badge and the
+    // modal disagree on the very network the archive is the only door to.
+    expect(
+      rollupArchivedUnread({
+        messages: counts([
+          ["#autojoin-but-parked", 2],
+          ["#gone", 1],
+        ]),
+        events: {},
+        factsForSlug: oneNetwork(null),
+      }),
+    ).toEqual({ messages: 3, events: 0 });
+  });
+
+  it("rolls up across networks", () => {
+    const messages: Record<ChannelKey, number> = {
+      [ck("alpha", "#a")]: 2,
+      [ck("beta", "#b")]: 5,
+    };
+    expect(
+      rollupArchivedUnread({
+        messages,
+        events: {},
+        factsForSlug: (slug) =>
+          slug === "alpha" || slug === "beta" ? facts(suppression({})) : null,
+      }),
+    ).toEqual({ messages: 7, events: 0 });
+  });
+
+  it("counts a window present only in the events map", () => {
+    // The two maps are independent projections of the same seed; a window
+    // whose entire unread is presence churn appears in one and not the other.
+    expect(
+      rollupArchivedUnread({
+        messages: {},
+        events: counts([["#gone", 4]]),
+        factsForSlug: oneNetwork(suppression({})),
+      }),
+    ).toEqual({ messages: 0, events: 4 });
+  });
+});

--- a/cicchetto/src/__tests__/selection.test.ts
+++ b/cicchetto/src/__tests__/selection.test.ts
@@ -112,6 +112,34 @@ describe("selection store", () => {
     expect(selection.serverSeedCounts()).toBe(first);
   });
 
+  // issue 2096 — the destructive archive delete has to take the count with the
+  // rows. Asserted on the derived memos, not just on the backing map: the
+  // badge reads the memos.
+  it("clearServerSeedCount drops the key from the seed AND from the memos", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const selection = await import("../lib/selection");
+    const key = channelKey("freenode", "#purged");
+    selection.setServerSeedCount(key, { messages: 4, events: 2 });
+    expect(selection.messagesUnread()[key]).toBe(4);
+
+    selection.clearServerSeedCount(key);
+
+    expect(selection.serverSeedCounts()[key]).toBeUndefined();
+    expect(selection.messagesUnread()[key]).toBeUndefined();
+    expect(selection.eventsUnread()[key]).toBeUndefined();
+  });
+
+  it("clearServerSeedCount is a no-op for a key that was never seeded", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const selection = await import("../lib/selection");
+    selection.setServerSeedCount(channelKey("freenode", "#kept"), { messages: 1, events: 0 });
+    const before = selection.serverSeedCounts();
+
+    selection.clearServerSeedCount(channelKey("freenode", "#never"));
+
+    expect(selection.serverSeedCounts()).toBe(before);
+  });
+
   it("selecting a channel fires loadInitialScrollback exactly once across re-selections", async () => {
     localStorage.setItem("grappa-token", "tok");
     const api = await import("../lib/api");

--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -87,6 +87,11 @@ vi.mock("../lib/selection", () => ({
   // missing assertion: the three `setReconnecting` arms below went red on
   // it, two statements before the line they were testing.
   noteConnectionState: vi.fn(),
+  // issue 2096 — the archive_purged arm now drops the server seed for the
+  // purged key as well. Same reason as `noteConnectionState` above: this file
+  // mocks selection wholesale, so an absent port is a TypeError two statements
+  // before the assertion, not a missing assertion.
+  clearServerSeedCount: vi.fn(),
 }));
 
 vi.mock("../lib/bundleHash", () => ({
@@ -1987,6 +1992,37 @@ describe("userTopic", () => {
       expect(sb.purgeScrollback).toHaveBeenCalledWith(key);
       expect(rb.clearSeen).toHaveBeenCalledWith(key);
       expect(archive.loadArchive).toHaveBeenCalledWith("bahamut-test");
+    });
+
+    it("issue 2096 — also drops the server unread SEED for the purged key", async () => {
+      // The seed is written by `/me` and by the join reply and by nothing
+      // else, so without this the deleted window's count stands until the
+      // next cold load. Harmless while no surface summed seed keys with no
+      // window behind them; the archive launcher's rollup badge is that
+      // surface, and a count nothing can clear is worse than no count.
+      const selection = await import("../lib/selection");
+      const { channelKey } = await import("../lib/channelKey");
+
+      channelMock.fireEvent({
+        kind: "archive_purged",
+        network_slug: "bahamut-test",
+        target: "#bofh",
+      });
+
+      expect(selection.clearServerSeedCount).toHaveBeenCalledWith(
+        channelKey("bahamut-test", "#bofh"),
+      );
+    });
+
+    it("issue 2096 — the refresh-only sibling does NOT drop the seed", async () => {
+      // `archive_changed` (a PART) moves a window into the archive with its
+      // rows and its unread INTACT — that unread is precisely what the badge
+      // exists to surface. Only the DESTRUCTIVE delete clears.
+      const selection = await import("../lib/selection");
+
+      channelMock.fireEvent({ kind: "archive_changed", network_slug: "bahamut-test" });
+
+      expect(selection.clearServerSeedCount).not.toHaveBeenCalled();
     });
 
     it("works for query-shaped targets too (peer-nick DM purge)", async () => {

--- a/cicchetto/src/lib/archive.ts
+++ b/cicchetto/src/lib/archive.ts
@@ -107,6 +107,19 @@ export const loadArchive = exports_.loadArchive;
 export const clearArchive = exports_.clearArchive;
 export const setArchiveModalOpen = exports_.setArchiveModalOpen;
 
+/**
+ * The folded names an archive surface must NOT show for one network, split by
+ * the set that owns each: channels the operator is in, query windows that are
+ * open, and the pseudo-rows this form factor's nav draws.
+ *
+ * Built by `archiveSuppressionForNetwork`; spent by `archiveTargetSuppressed`.
+ */
+export type ArchiveSuppression = {
+  channels: Set<string>;
+  queries: Set<string>;
+  pseudo: Set<string>;
+};
+
 // UX-2 — shared archive-visibility filter. Pre-UX-2 lived inline in
 // `Sidebar.tsx` as `visibleArchiveForNetwork/2`; UX-2 lifted it here so
 // the (then-two) archive surfaces could share one verb. #473 collapsed
@@ -153,6 +166,32 @@ export const setArchiveModalOpen = exports_.setArchiveModalOpen;
 export function visibleArchiveForNetwork(slug: string, networkId: number): ArchiveEntry[] {
   const entries = archivedBySlug()[slug] ?? [];
   if (entries.length === 0) return entries;
+  const suppressed = archiveSuppressionForNetwork(slug, networkId);
+  if (suppressed === null) return entries;
+  const casemapping = casemappingForNetwork(networkId);
+  return entries.filter(
+    (entry) =>
+      !archiveTargetSuppressed(suppressed, normalizeNick(entry.target, casemapping), entry.kind),
+  );
+}
+
+/**
+ * The three folded name sets an archive surface subtracts for one network —
+ * or `null` when the nav of this form factor draws NO row for the network at
+ * all, in which case the correct subtraction is the empty set.
+ *
+ * issue 2096 — extracted from `visibleArchiveForNetwork` because the archive
+ * grew a SECOND consumer: the launcher's rollup badge (`lib/archiveRollup.ts`)
+ * answers the same "does the nav already draw this window?" question over the
+ * unread SEED's keys instead of over the fetched archive list. Two statements
+ * of the subtraction would drift the first time a window shape is added, and
+ * the badge would then count a window the modal does not list — a number the
+ * operator cannot chase. One verb, two consumers.
+ */
+export function archiveSuppressionForNetwork(
+  slug: string,
+  networkId: number,
+): ArchiveSuppression | null {
   // issue 1985 — the premise stated above, applied whole: subtract what the
   // nav draws. A parked network is dropped at the ONE `<For>` in the desktop
   // Sidebar, so the nav draws NONE of its rows and the correct subtraction is
@@ -169,7 +208,7 @@ export function visibleArchiveForNetwork(slug: string, networkId: number): Archi
   // The predicate is `navDrawsNetwork` and not a local `isNetworkParked`
   // call: the form-factor half (mobile still draws these rows) belongs with
   // the rest of the nav reconciliation, not copied in here.
-  if (!navDrawsNetwork(slug)) return entries;
+  if (!navDrawsNetwork(slug)) return null;
   // #372: fold every comparison key with `normalizeNick` — the single client
   // mirror of the server fold. A service that replied as `DebugServ` archives
   // under that casing while the open window is `debugserv`; a raw `Set.has`
@@ -182,30 +221,49 @@ export function visibleArchiveForNetwork(slug: string, networkId: number): Archi
   // state, so both sides of each compare move together; on `:ascii` (all of
   // production) the behaviour is byte-for-byte what #372 shipped.
   const casemapping = casemappingForNetwork(networkId);
-  const liveChannels = new Set(
-    (channelsBySlug()?.[slug] ?? []).map((c) => normalizeNick(c.name, casemapping)),
-  );
-  const liveQueries = new Set(
-    (queryWindowsByNetwork()[networkId] ?? []).map((qw) =>
-      normalizeNick(qw.targetNick, casemapping),
+  return {
+    channels: new Set(
+      (channelsBySlug()?.[slug] ?? []).map((c) => normalizeNick(c.name, casemapping)),
     ),
-  );
-  // Reuse the ONE shared pseudo-row projection — folding its names
-  // (#372/#525/#1861) for the archive's own compare. See the block comment
-  // above for why this MUST NOT re-derive from raw windowState.
-  //
-  // #402: subtract what the nav of THIS form factor actually draws, not the
-  // whole projection. On mobile there is no Sidebar and the BottomBar draws
-  // only `:invited`, so subtracting `pending`/`failed`/`kicked`/`parked`
-  // there left the window with no surface at all. `navPseudoChannelsForNetwork`
-  // owns that narrowing for the navs too, so the two cannot drift.
-  const pseudoNames = new Set(
-    navPseudoChannelsForNetwork(slug, networkId).map((row) => normalizeNick(row.name, casemapping)),
-  );
-  return entries.filter((entry) => {
-    const folded = normalizeNick(entry.target, casemapping);
-    if (pseudoNames.has(folded)) return false;
-    if (entry.kind === "channel") return !liveChannels.has(folded);
-    return !liveQueries.has(folded);
-  });
+    queries: new Set(
+      (queryWindowsByNetwork()[networkId] ?? []).map((qw) =>
+        normalizeNick(qw.targetNick, casemapping),
+      ),
+    ),
+    // Reuse the ONE shared pseudo-row projection — folding its names
+    // (#372/#525/#1861) for the archive's own compare. See the block comment
+    // above `visibleArchiveForNetwork` for why this MUST NOT re-derive from
+    // raw windowState.
+    //
+    // #402: subtract what the nav of THIS form factor actually draws, not the
+    // whole projection. On mobile there is no Sidebar and the BottomBar draws
+    // only `:invited`, so subtracting `pending`/`failed`/`kicked`/`parked`
+    // there left the window with no surface at all.
+    // `navPseudoChannelsForNetwork` owns that narrowing for the navs too, so
+    // the two cannot drift.
+    pseudo: new Set(
+      navPseudoChannelsForNetwork(slug, networkId).map((row) =>
+        normalizeNick(row.name, casemapping),
+      ),
+    ),
+  };
+}
+
+/**
+ * Does the nav already draw a surface for this (already folded) target?
+ *
+ * `kind` is load-bearing and the two sets are NOT interchangeable: a nick
+ * that happens to spell a live channel must not silence the DM of the same
+ * spelling. Collapsing them into one union would be a bare union pretending
+ * to be kind-aware.
+ */
+export function archiveTargetSuppressed(
+  suppressed: ArchiveSuppression,
+  foldedTarget: string,
+  kind: ArchiveEntry["kind"],
+): boolean {
+  if (suppressed.pseudo.has(foldedTarget)) return true;
+  return kind === "channel"
+    ? suppressed.channels.has(foldedTarget)
+    : suppressed.queries.has(foldedTarget);
 }

--- a/cicchetto/src/lib/archiveRollup.ts
+++ b/cicchetto/src/lib/archiveRollup.ts
@@ -1,0 +1,168 @@
+import { createMemo } from "solid-js";
+import {
+  type ArchiveSuppression,
+  archiveSuppressionForNetwork,
+  archiveTargetSuppressed,
+} from "./archive";
+import { type ChannelKey, decodeChannelKey } from "./channelKey";
+import { isChannelName } from "./chantypes";
+import { type Casemapping, casemappingForNetwork, chantypesForNetwork } from "./isupport";
+import { moduleRoot } from "./moduleRoot";
+import { networkBySlug } from "./networks";
+import { normalizeNick } from "./nickEquals";
+import { eventsUnread, messagesUnread } from "./selection";
+import { SERVER_WINDOW_NAME } from "./windowKinds";
+
+// issue 2096 — the unread rollup behind the archive launcher.
+//
+// ## Where the numbers come from, and why nothing new is fetched
+//
+// Fairy's report: an archived window holding unread is invisible until you
+// open the modal and expand the right network group. The modal itself has
+// shown per-row badges since #532 B, keyed off `/me`'s `unread_counts` seed —
+// so the counts were never the missing half. The issue offered two ways to
+// get a rollup (eager-load every network's archive list; ship a server-side
+// aggregate) and vjt's first ruling took the second.
+//
+// Both premises turned out to be wrong in the same place, and the measurement
+// is on the artefact rather than on the query (DESIGN_NOTES 2026-09-12):
+// `ReadCursor.bulk_unread_split/3` is driven purely from `read_cursors`, with
+// NO active-window filter, so the seed cic already holds carries every window
+// with a cursor — ARCHIVED ONES INCLUDED. Read off a real `GET /me` body with
+// a live session: the envelope listed an archived channel and an active DM,
+// while `GET /networks/:slug/archive` listed the archived channel and a
+// cursor-less one the envelope did not carry. Neither set is a subset of the
+// other, so the envelope is not a mirror of the listing — it genuinely
+// carries the archived window. vjt re-ruled on that measurement: derive
+// client-side, no wire change, no `protocol_version` bump, `loadArchive`
+// stays lazy.
+//
+// So the missing half is MEMBERSHIP, not counts, and membership is
+// `seed − what the nav already draws` — which cic holds too
+// (`channelsBySlug`, `queryWindowsByNetwork`, the pseudo-row projection).
+// Deriving it also makes the badge LIVE for free: open an archived window and
+// it becomes active, drops out of the set, and the badge falls. A boot-time
+// aggregate could not have done that without a second push.
+//
+// ## Shape
+//
+// Pure fn + thin memo, exactly like `orderUnreadWindows` / `activeWindows`
+// (lib/activeWindows.ts): the subtraction is plain data in, plain data out so
+// it is testable without a reactive context, and the memo only wires the live
+// signals to it.
+//
+// ## Mute
+//
+// Untouched, deliberately. "The mute always wins" is the rule for the
+// on-screen AFFORDANCE (`activeWindows.ts`, #1018/#866 Q2) and it leaves the
+// COUNTS intact — the sidebar badges and the modal's own rows keep rendering a
+// muted window's numbers. This is a count badge, so it inherits that rule by
+// doing nothing; a rollup that subtracted mutes would be a SECOND rule, and
+// one that no other badge in the tree obeys.
+
+/** The launcher's two totals. Messages and events stay separate tiers (#265). */
+export type ArchiveRollup = {
+  messages: number;
+  events: number;
+};
+
+/** Per-network facts the subtraction needs, resolved once per slug. */
+export type ArchiveNetworkFacts = {
+  casemapping: Casemapping;
+  chantypes: readonly string[];
+  /** `null` when the nav draws no row for this network (issue 1985). */
+  suppression: ArchiveSuppression | null;
+};
+
+export type ArchiveRollupInput = {
+  /** Per-window message-scoped unread, `selection.messagesUnread`. */
+  messages: Record<ChannelKey, number>;
+  /** Per-window presence/control unread, `selection.eventsUnread`. */
+  events: Record<ChannelKey, number>;
+  /**
+   * Per-network facts, or `null` for a slug cic draws no archive group for.
+   *
+   * GH #105 — an unbound-but-retained network keeps seeding `unread_counts`
+   * while `ArchiveModal` iterates `networks()` and renders no group for it. No
+   * group, no row, so no contribution: the badge must not out-count the door
+   * it sits on.
+   */
+  factsForSlug: (slug: string) => ArchiveNetworkFacts | null;
+};
+
+/**
+ * Sum the unread of every window that has NO surface in the nav — i.e. the
+ * windows `ArchiveModal` would list.
+ *
+ * The invariant: this must equal the sum of the badges the modal draws behind
+ * the launcher. It cannot over-count by construction — a key here carries
+ * unread, unread implies rows, and `Scrollback.list_archive/3` returns every
+ * non-active target that has rows — with the two exceptions handled below
+ * (`$server`, which the server excludes unconditionally, and a slug with no
+ * rendered group).
+ */
+export function rollupArchivedUnread(input: ArchiveRollupInput): ArchiveRollup {
+  const { messages, events, factsForSlug } = input;
+  // One resolve per slug, not per key: `factsForSlug` reaches three stores and
+  // a window can repeat a slug dozens of times.
+  const factsBySlug = new Map<string, ArchiveNetworkFacts | null>();
+  let unreadMessages = 0;
+  let unreadEvents = 0;
+
+  for (const rawKey of new Set([...Object.keys(messages), ...Object.keys(events)])) {
+    const key = rawKey as ChannelKey;
+    const keyMessages = messages[key] ?? 0;
+    const keyEvents = events[key] ?? 0;
+    if (keyMessages === 0 && keyEvents === 0) continue;
+
+    // Codebase audit cic M4 — the paired decoder, never an open-coded split.
+    const decoded = decodeChannelKey(key);
+    if (decoded === null) continue;
+    const { slug, name } = decoded;
+
+    // `list_archive/3` excludes the `$server` pseudo-channel unconditionally
+    // (system surface, never archived per the intent doc), so the modal never
+    // draws a row for it and neither may this.
+    if (name === SERVER_WINDOW_NAME) continue;
+
+    if (!factsBySlug.has(slug)) factsBySlug.set(slug, factsForSlug(slug));
+    const facts = factsBySlug.get(slug) ?? null;
+    if (facts === null) continue;
+
+    if (facts.suppression !== null) {
+      const folded = normalizeNick(name, facts.casemapping);
+      const kind = isChannelName(name, facts.chantypes) ? "channel" : "query";
+      if (archiveTargetSuppressed(facts.suppression, folded, kind)) continue;
+    }
+
+    unreadMessages += keyMessages;
+    unreadEvents += keyEvents;
+  }
+
+  return { messages: unreadMessages, events: unreadEvents };
+}
+
+// Reactive, memoised rollup for the `RailActions` archive launcher. Every
+// input is a live signal, so the badge follows a read, a JOIN, a PART, an
+// archive delete and a network parking with no refetch of its own.
+const root = moduleRoot(() => {
+  const archivedUnread = createMemo(
+    (): ArchiveRollup =>
+      rollupArchivedUnread({
+        messages: messagesUnread(),
+        events: eventsUnread(),
+        factsForSlug: (slug) => {
+          const net = networkBySlug(slug);
+          if (net === undefined) return null;
+          return {
+            casemapping: casemappingForNetwork(net.id),
+            chantypes: chantypesForNetwork(net.id),
+            suppression: archiveSuppressionForNetwork(slug, net.id),
+          };
+        },
+      }),
+  );
+  return { archivedUnread };
+});
+
+export const archivedUnread = root.archivedUnread;

--- a/cicchetto/src/lib/selection.ts
+++ b/cicchetto/src/lib/selection.ts
@@ -358,6 +358,32 @@ const exports = identityScopedStore((onIdentityChange) => {
   };
 
   /**
+   * Drop the seed for one window — the rows it counted are GONE.
+   *
+   * issue 2096. The seed is written by `/me` and by the join reply and by
+   * nothing else, so a destructive
+   * `DELETE /networks/:slug/archive/:target` left its count standing until the
+   * next cold load. That was invisible while nothing rendered it: the archive
+   * row disappears with the listing refresh, the sidebar draws no row for an
+   * archived window, and `windowCandidates()` never enumerates one. The
+   * launcher's rollup badge (`lib/archiveRollup.ts`) is the first surface that
+   * sums seed keys with no window behind them, so the stale entry became a
+   * number the operator could neither clear nor chase.
+   *
+   * Deliberately narrower than `readCursor`'s posture in the same handler,
+   * which does NOT clear (see `userTopic.ts`): a cursor is cross-device state
+   * the server owns, while this map is a local projection of counts whose rows
+   * the server just deleted. Dropping it loses nothing another device needs.
+   */
+  const clearServerSeedCount = (key: ChannelKey): void => {
+    setServerSeedCountsRaw((prev) => {
+      if (!(key in prev)) return prev;
+      const { [key]: _dropped, ...rest } = prev;
+      return rest;
+    });
+  };
+
+  /**
    * Bulk-hydrate the seed map from the `/me` envelope's
    * `unread_counts` nested map (`%{slug => %{chan => {messages,
    * events}}}`). Replaces the entire map — same cold-load semantic as
@@ -1029,6 +1055,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     closeToPreviousWindow,
     selectStatusWindow,
     setServerSeedCount,
+    clearServerSeedCount,
     applySeedEnvelope,
     setCursorIfAdvances,
     followQueryNick,
@@ -1046,6 +1073,7 @@ export const isActiveSelection = exports.isActiveSelection;
 export const closeToPreviousWindow = exports.closeToPreviousWindow;
 export const selectStatusWindow = exports.selectStatusWindow;
 export const setServerSeedCount = exports.setServerSeedCount;
+export const clearServerSeedCount = exports.clearServerSeedCount;
 export const applySeedEnvelope = exports.applySeedEnvelope;
 export const setCursorIfAdvances = exports.setCursorIfAdvances;
 export const followQueryNick = exports.followQueryNick;

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -39,7 +39,12 @@ import { clearSeen } from "./reconnectBackfill";
 import { setReconnecting } from "./reconnectingStatus";
 import { applyRecoverProgress, applyRecoverResult } from "./recoverProgress";
 import { purgeScrollback } from "./scrollback";
-import { noteConnectionState, selectedChannel, setSelectedChannel } from "./selection";
+import {
+  clearServerSeedCount,
+  noteConnectionState,
+  selectedChannel,
+  setSelectedChannel,
+} from "./selection";
 import { setServerReply } from "./serverReplyModal";
 import { applyServerSettings } from "./serverSettings";
 import { joinUser } from "./socket";
@@ -1300,6 +1305,14 @@ moduleRoot(() => {
             const key = channelKey(payload.network_slug, payload.target);
             purgeScrollback(key);
             clearSeen(key);
+            // issue 2096 — and the server `unread_counts` SEED for the key
+            // too, whose rows were just deleted. It is written by `/me` and
+            // the join reply and by nothing else, so without this it stands
+            // until the next cold load. Invisible until the archive launcher
+            // grew a rollup badge that sums seed keys with no window behind
+            // them; then it is a number with nothing left to read. Distinct
+            // from the read cursor immediately below, which stays ON PURPOSE.
+            clearServerSeedCount(key);
             void loadArchive(payload.network_slug);
           }
           return;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2583,6 +2583,18 @@ html.resize-dragging * {
   color: inherit;
 }
 
+/* issue 2096 — unread rollup cluster on a rail action (today: the archive
+   launcher). Same shape as `.archive-modal-unread`, which clusters the SAME
+   sidebar pills (.sidebar-msg-unread / -events-unread) at a row's trailing
+   edge — the rollup and the per-row badges behind the door have to read as
+   one thing. `margin-left: auto` against the row's `justify-content:
+   flex-start`, exactly like the launcher's ▸ caret. */
+.rail-action-unread {
+  display: inline-flex;
+  align-items: center;
+  margin-left: auto;
+}
+
 /* #682 — the rail's radio surface, mounted directly above `.rail-actions` in
    BOTH Shell rail branches. Static position on purpose: the picker below is
    absolute against `.shell-members` (already `position: relative` for the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54470,3 +54470,115 @@ on the response, or on server state.** And the reason the second red could be
 read at all is that the stages had been split one commit earlier (vjt's
 review): one collapsed assertion had reported "no upload happened", "the answer
 could not be read" and "the answer was wrong" with the same empty string.
+<!-- entry #2096 -->
+
+---
+
+## 2026-09-12 — #2096: the archive rollup was already on the wire
+
+Fairy reported an archived window holding unread being invisible until you
+opened `ArchiveModal` AND expanded the right network group. The issue framed
+two ways to put a rollup on the launcher: eager-load every network's archive
+list on the client, or ship a server-side aggregate beside `/me`'s
+`unread_counts` seed. vjt ruled for the second; both premises were wrong in the
+same place, and the third option is what shipped.
+
+### The seed already carries archived windows, measured on the artefact
+
+`ReadCursor.bulk_unread_split/3` is driven purely from `read_cursors ⋈
+networks ⋈ messages`. There is no active-window filter anywhere in it, so the
+envelope carries EVERY window with a non-nil cursor — archived ones included.
+#532 B has been rendering the modal's per-row badges off exactly that seed
+since June, which is the same fact shipped.
+
+That was a code read, so it was taken to the far end of the tube before
+anything was built. A throwaway ConnCase test with a LIVE session against the
+fake ircd (the only shape in which `build_active_keyset` is not degenerate:
+without a session it falls on `{:error, :no_session}`, the keyset is empty and
+every target reads as archived) read two decoded HTTP bodies in one run —
+`GET /networks/:slug/archive` as the ORACLE for "is this archived", `GET /me`
+as the subject. Result:
+
+    oracle  GET /archive      : ["#m2096-archived", "#m2096-nocursor"]
+    subject GET /me unread_counts: {"#m2096-archived": 1, "m2096-peer": 1}
+
+Three controls, all asserted before any number was printed. POSITIVE: the DM
+`m2096-peer` is ACTIVE (open query window + live session), the oracle agrees,
+and it IS in the envelope — so the reader is pointed at the right place.
+NEGATIVE A: `#m2096-nocursor` has rows but no cursor, the oracle calls it
+ARCHIVED, and it is NOT in the envelope — so the envelope is not a mirror of
+the listing. NEGATIVE B: an invented key appears in neither. Neither set is a
+subset of the other, which is the strongest form the non-degeneracy can take.
+
+### Why that changes the ruling rather than just the cost
+
+vjt re-ruled on the measurement: derive client-side, no wire change, no
+`protocol_version` bump, and `loadArchive` stays lazy per group. Three things
+carried it.
+
+The missing half was never the counts — it was MEMBERSHIP, and membership is
+`seed − what the nav already draws`, which cic also already holds
+(`channelsBySlug` fans out to every network at boot; `query_windows_list` is
+pushed whole at user-topic join). Deriving beats duplicating (design
+discipline 1).
+
+A server aggregate at `/me` would have put a synchronous `GenServer.call` per
+network back on the cold-load path — `Session.list_channels/2` is
+`call_session` — which is precisely the work #498 took off it.
+
+And it would have been a BOOT-TIME SNAPSHOT. Nothing re-emits it when the
+operator opens the archived window, so the badge could not fall without a
+second push. The derivation is live for free: open the window, it becomes
+active, it leaves the set.
+
+### Shape
+
+`lib/archiveRollup.ts` — pure `rollupArchivedUnread(input)` plus a thin memo,
+the same split as `orderUnreadWindows` / `activeWindows`. The subtraction verb
+came OUT of `visibleArchiveForNetwork` into `archiveSuppressionForNetwork` +
+`archiveTargetSuppressed` (`lib/archive.ts`) rather than being restated: the
+archive now has two consumers asking the same question of different inputs
+(the fetched list vs the seed's keys), and two statements of it would drift the
+first time a window shape is added — at which point the badge counts a window
+the modal does not list, a number the operator cannot chase.
+
+`$server` is skipped (`list_archive/3` excludes it unconditionally) and so is a
+slug cic renders no group for (GH #105 unbound-but-retained networks still seed
+the envelope). With those two exceptions the rollup cannot over-count by
+construction: a key with unread has rows, and every non-active target with rows
+is in the listing.
+
+### One real bug the badge exposed
+
+`serverSeedCounts` is written by `/me` and the join reply and by nothing else,
+so a destructive `DELETE /networks/:slug/archive/:target` left its count
+standing until the next cold load. Invisible while nothing summed seed keys
+with no window behind them — the modal row goes with the listing refresh, the
+sidebar draws no archived window, `windowCandidates()` never enumerates one.
+The rollup is the first surface that does, so `archive_purged` now also calls
+`clearServerSeedCount(key)`. The read cursor in the same handler still does
+NOT clear, for the reasons already written there: a cursor is cross-device
+state the server owns; this map is a local projection of counts whose rows the
+server just deleted.
+
+### Mute, and three limits stated rather than discovered later
+
+The mute is untouched on purpose. "The mute always wins" is the rule for the
+on-screen AFFORDANCE and it leaves the COUNTS intact — the sidebar badges and
+the modal's own rows render a muted window's numbers. A count badge inherits
+that by doing nothing; subtracting mutes here would be a SECOND rule that no
+other badge obeys. The badge is also NOT dimmed when every contributor is
+muted (#1077's per-window treatment): "all of them are muted" is a different
+predicate from "this one is", and inventing it is the same second rule.
+
+Mentions are NOT a third pill. The issue and the rollup name messages and
+events; a mention is always also a content row, so `mentions > 0` implies
+`messages > 0` and omitting the pill can never hide the existence of unread —
+it loses a severity signal, nothing more.
+
+And the badge sits INSIDE the collapsed drawer: `RailActions` renders its menu
+under `<Show when={expanded() || open()}>`, and `expanded()` is true only on
+home (#1040). So on every other window the rollup is visible one tap in, not
+zero. That is one layer better than "open the modal and expand the group" and
+it is what the issue asked for; a dot on `rail-actions-launcher` itself is a
+separate decision, deliberately not taken here.


### PR DESCRIPTION
Closes #2096.

Fairy's report: an archived window holding unread was invisible until you opened `ArchiveModal` **and** expanded the right network group. #532 B put per-row badges inside the modal; the launcher that opens it carried nothing.

## The wire shape: NONE. No `protocol_version` bump.

That is a **change from the first ruling on the issue**, and it came from a measurement this branch took before building anything.

The issue framed two directions — eager-load every network's archive list, or ship a server-side aggregate beside the `/me` `unread_counts` seed — and vjt ruled for the second. Both premises were wrong in the same place: **the seed already carries archived windows.** `ReadCursor.bulk_unread_split/3` is driven purely from `read_cursors ⋈ networks ⋈ messages`, with no active-window filter anywhere in it.

That was a code read, so it was taken to the far end of the tube. A throwaway `ConnCase` with a **live session** against the fake ircd (without one `build_active_keyset` falls on `{:error, :no_session}`, the keyset is empty, every target reads as archived and the control collapses into the subject) read two decoded HTTP bodies in one run — `GET /networks/:slug/archive` as the **oracle** for "is this archived", `GET /me` as the **subject**:

```
oracle  GET /archive          : ["#m2096-archived", "#m2096-nocursor"]
subject GET /me unread_counts : {"#m2096-archived": 1, "m2096-peer": 1}
```

Three controls, all asserted before any number printed:

| | window | oracle says | in `unread_counts` |
|---|---|---|---|
| **POSITIVE** | `m2096-peer` — open query window, live session | ACTIVE | ✅ yes — the reader is in the right place |
| **NEGATIVE A** | `#m2096-nocursor` — rows, no cursor | ARCHIVED | ❌ no — the envelope is **not** a mirror of the listing |
| **NEGATIVE B** | `#m2096-nonesuch` — invented | absent | ❌ no |
| **SUBJECT** | `#m2096-archived` — rows + cursor | ARCHIVED | ✅ **yes** |

Neither set is a subset of the other. vjt re-ruled on that measurement: **derive client-side, no wire change, no bump, `loadArchive` stays lazy per group.**

Two further reasons the aggregate was dropped. It would have put a synchronous `GenServer.call` per network back on the `/me` cold-load path (`Session.list_channels/2` is `call_session`) — the work #498 removed. And it would have been a **boot-time snapshot**: nothing re-emits it when the operator opens the archived window, so the badge could not fall without a second push. The derivation is live for free.

## What changed

- **`lib/archive.ts`** — the subtraction comes out of `visibleArchiveForNetwork` into `archiveSuppressionForNetwork/2` + `archiveTargetSuppressed/3`. Behaviour-identical; the archive now has two consumers asking one question of different inputs, and two statements of it would drift.
- **`lib/archiveRollup.ts`** (new) — pure `rollupArchivedUnread` + a thin memo, the `orderUnreadWindows`/`activeWindows` split. Skips `$server` (`list_archive/3` excludes it) and any slug cic renders no group for (GH #105). It cannot over-count by construction otherwise: a key with unread has rows, and every non-active target with rows is in the listing.
- **`RailActions.tsx` + `default.css`** — the badge, on the same component both form factors mount. Two pills, `sidebar-msg-unread` / `sidebar-events-unread`, clustered like `.archive-modal-unread`.
- **`lib/selection.ts` + `lib/userTopic.ts`** — one real bug the badge exposed: a destructive archive DELETE left its seed count standing until the next cold load. Invisible while nothing summed seed keys with no window behind them. `archive_purged` now also calls `clearServerSeedCount`. The read cursor there still does not clear, for the reasons already written at that site.

## Mute

Untouched. "The mute always wins" governs the **affordance** and leaves the **counts** intact — the sidebar and the modal's own rows render a muted window's numbers. A count badge inherits that by doing nothing; subtracting mutes here would be a second rule no other badge obeys.

## Gates

| gate | result |
|---|---|
| `bun.sh run test` | **7159 passed / 353 files**, rc=0 |
| `bun.sh run check` | 5 stages, 0 failed (lock drift · test location · biome · tsc src · tsc e2e) |
| `design-notes-gate.sh` | `1 new entry heading(s), separator and marker present` |
| `scripts/check.sh` | see the comment below — it was still running when this was opened |
| **e2e** | **NOT RUN HERE.** Needs the exclusive runner lane; CI gives the verdict. |

## Limits stated, not discovered later

- **The e2e is not green on this host.** It is written and it asserts the visible outcome on both form factors — baseline, then a peer message into a channel the operator is **still in** (the control: the badge must not move), then PART (appears, +1), then JOIN (disappears) — all in one continuously-open rail menu. But it has never executed. CI owns that verdict.
- **The measurement's substrate is a fake ircd and `Phoenix.ConnTest`**, not production. The instrument was temporary and is not in this branch; the tree is clean.
- **No mention pill.** A mention is always also a content row, so `mentions > 0` implies `messages > 0`: omitting it cannot hide the existence of unread, only a severity signal.
- **No dimming when every contributor is muted.** "All of them are muted" is a different predicate from #1077's per-window "this one is", and inventing it is the same second rule.
- **The badge lives one tap inside the collapsed drawer.** `RailActions` renders its menu under `<Show when={expanded() || open()}>` and `expanded()` is true only on home (#1040). Better than "open the modal and expand the group", which is what the issue asked for; a dot on `rail-actions-launcher` itself is a separate decision, deliberately not taken here.