### PR TITLE
cic(pwa): salt the sample precache revisions so a poisoned install repairs itself (issue 2098)

### DIFF
--- a/cicchetto/e2e/tests/issue2098-sound-precache-salt.spec.ts
+++ b/cicchetto/e2e/tests/issue2098-sound-precache-salt.spec.ts
@@ -1,0 +1,111 @@
+// issue 2098 — the notification samples are precached from STABLE urls
+// (`sounds/<name>.mp3`, not content-hashed like `assets/*`) with a revision
+// that is the md5 of the file, unchanged since #1480. Workbox refetches a
+// precache entry only when its url+revision pair moves, so an install that
+// cached the SPA shell under those urls during the #2088 window (`sounds` was
+// missing from `@cic_static_only`, so the request answered 200 `text/html`)
+// kept feeding HTML into `decodeAudioData` through every later deploy, and the
+// only field cure was deleting and reinstalling the PWA.
+//
+// The fix salts those revisions with the build version, so the entry changes
+// identity at each cut and the next load after a deploy refetches it. That
+// wiring lives in ONE line of `vite.config.ts` (`manifestTransforms`), and
+// nothing else can see it: the unit test (`src/__tests__/precacheSalt.test.ts`)
+// proves the transform, while deleting the line it is wired into leaves every
+// other gate green. This spec is that gate — it reads the SHIPPED service
+// worker and asserts the identity actually carries the cut.
+//
+// Bare @playwright/test (NOT ../fixtures/test), same reasoning as
+// `issue274-pwa-icons.spec.ts`: every check here is a stateless static fetch,
+// so it needs no login and must not pay the scoped fixture's reset teardown.
+import { expect, test } from "@playwright/test";
+
+// A workbox precache entry as injected into the SW bundle, e.g.
+// `{"revision":"e39942a3a28e2608c1fe0200b39b55af-1.5.5","url":"sounds/x.mp3"}`.
+// Matched off the served bytes rather than imported, precisely so a build that
+// stopped emitting the shape fails here instead of passing on our own types.
+const PRECACHE_ENTRY = /\{"revision":(null|"[^"]*"),"url":"([^"]*)"\}/g;
+
+// The content hash workbox derives, before any salt: 32 lowercase hex digits.
+const BARE_MD5 = /^[0-9a-f]{32}$/;
+
+type Entry = { revision: string | null; url: string };
+
+function precacheEntries(sw: string): Entry[] {
+  return [...sw.matchAll(PRECACHE_ENTRY)].map(([, revision, url]) => ({
+    revision: revision === "null" ? null : JSON.parse(revision ?? '""'),
+    url: url ?? "",
+  }));
+}
+
+test.describe("issue 2098 sound precache entries carry the cut", () => {
+  test("every served sound revision is its content hash salted with the served version", async ({
+    request,
+  }) => {
+    const shell = await request.get("/");
+    expect(shell.status(), "GET /").toBe(200);
+    const version = /<meta[^>]+name="cicchetto-version"[^>]+content="([^"]+)"/.exec(
+      await shell.text(),
+    )?.[1];
+    // Non-vacuous: without the version there is nothing to assert the salt
+    // against, and an absent meta must not read as "no drift".
+    expect(version, "<meta cicchetto-version> on the served shell").toBeTruthy();
+
+    const res = await request.get("/service-worker.js");
+    expect(res.status(), "GET /service-worker.js").toBe(200);
+    const entries = precacheEntries(await res.text());
+
+    // Non-vacuous: prove we parsed a real precache manifest, not an empty
+    // match set off a 404 page or a renamed SW.
+    expect(entries.length, "precache entries parsed off the served SW").toBeGreaterThan(10);
+
+    const sounds = entries.filter((e) => e.url.startsWith("sounds/"));
+    expect(sounds.map((e) => e.url).sort(), "the five samples are precached").toEqual([
+      "sounds/icq-uh-oh.mp3",
+      "sounds/xp-balloon.mp3",
+      "sounds/xp-ding.mp3",
+      "sounds/xp-exclamation.mp3",
+      "sounds/xp-notify.mp3",
+    ]);
+
+    // THE contract: the content hash, then the cut. A revision that is still a
+    // bare md5 is the pre-fix shape — that entry would never change identity
+    // again. The tail is rejoined rather than indexed because an unreleased
+    // build's version is itself dashed (`X.Y.Z-<sha>`).
+    for (const sound of sounds) {
+      const [hash, ...cut] = (sound.revision ?? "").split("-");
+      expect(BARE_MD5.test(hash ?? ""), `${sound.url} revision opens with a content hash`).toBe(
+        true,
+      );
+      expect(cut.join("-"), `${sound.url} revision carries the served cut`).toBe(version);
+    }
+  });
+
+  // The salt is scoped on purpose: the icons and the webmanifest are equally
+  // stable-urled, but they were never served as the shell (they have always
+  // been in `@cic_static_only`), so no install holds a poisoned copy and
+  // salting them would re-download them every cut for nothing. This asserts
+  // the scope, so a future widening is a deliberate edit rather than a drift.
+  test("the salt does not spread to the icons or to content-hashed assets", async ({ request }) => {
+    const res = await request.get("/service-worker.js");
+    expect(res.status(), "GET /service-worker.js").toBe(200);
+    const entries = precacheEntries(await res.text());
+
+    const icons = entries.filter((e) => e.url.endsWith(".png"));
+    expect(icons.length, "icon entries present").toBeGreaterThan(0);
+    for (const icon of icons) {
+      expect(BARE_MD5.test(icon.revision ?? ""), `${icon.url} keeps a bare content revision`).toBe(
+        true,
+      );
+    }
+
+    // `assets/*` carry the hash in the filename, so workbox marks them
+    // uniquely versioned with a null revision — a salt here would be a
+    // pointless cache-bust of an immutable url.
+    const hashed = entries.filter((e) => e.url.startsWith("assets/"));
+    expect(hashed.length, "content-hashed asset entries present").toBeGreaterThan(0);
+    for (const asset of hashed) {
+      expect(asset.revision, `${asset.url} revision`).toBeNull();
+    }
+  });
+});

--- a/cicchetto/src/__tests__/precacheSalt.test.ts
+++ b/cicchetto/src/__tests__/precacheSalt.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { CUT_SALTED_PRECACHE_PREFIX, saltPrecacheRevisions } from "../lib/precacheSalt";
+
+// issue 2098 — a precache entry is keyed by URL + revision, and Workbox
+// refetches an entry only when that pair changes. The five notification
+// samples are served from STABLE urls (`sounds/<name>.mp3`, not content-hashed
+// like `assets/*`), and their revision is the md5 of the file content, which
+// has not moved since #1480. Measured on a real build of 055c8362: across a
+// 1.5.5 -> 1.5.6 cut the ONLY manifest entry that changes is `index.html`; all
+// five mp3 entries are byte-identical. So an install that cached the SPA shell
+// under those urls during the #2088 window (`sounds` was missing from
+// `@cic_static_only`, so `GET /sounds/x.mp3` answered 200 text/html, 2467
+// bytes) keeps feeding 2467 bytes of HTML into `decodeAudioData` forever: the
+// SW re-installs on every deploy and walks straight past those entries.
+//
+// Salting the revision with the build's version makes the entry change
+// IDENTITY at every cut, so the next load after a deploy refetches it and the
+// poisoned body is replaced with no user gesture. That is vjt's ruling on the
+// issue (2026-09-12) and the acceptance test it states.
+//
+// These fixtures are the REAL manifest of that build (urls, md5 revisions and
+// sizes as emitted), not invented shapes — a fixture that lies about the shape
+// would let a transform pass here and no-op on the artefact.
+const MANIFEST = [
+  { revision: "e39942a3a28e2608c1fe0200b39b55af", url: "sounds/icq-uh-oh.mp3", size: 12537 },
+  { revision: "c27db1a021b82b56c998d3ff74e0b0a4", url: "sounds/xp-ding.mp3", size: 5447 },
+  { revision: "5aef24c9a2ad3f94da0cfa6994fb0998", url: "sounds/xp-balloon.mp3", size: 3335 },
+  { revision: "63482faf1109b06a665794e9cc4f9252", url: "sounds/xp-exclamation.mp3", size: 10636 },
+  { revision: "094e50f8380024cb02d75b50178c90f0", url: "sounds/xp-notify.mp3", size: 11969 },
+  { revision: "a11edaaa691b362051db6f5c008e78c3", url: "index.html", size: 2467 },
+  { revision: "f83e733b447a66414227ef70f1c6cad4", url: "icon-512.png", size: 4852 },
+  { revision: null, url: "assets/index-BZIN26f2.js", size: 1_000_000 },
+] as const;
+
+const soundsOf = (entries: readonly { url: string; revision: string | null }[]) =>
+  entries.filter((e) => e.url.startsWith(CUT_SALTED_PRECACHE_PREFIX));
+
+describe("precache salt — issue 2098 sound entries change identity per cut", () => {
+  it("salts every sound revision with the build version", () => {
+    const salted = soundsOf(saltPrecacheRevisions(MANIFEST, "1.5.6"));
+
+    expect(salted).toHaveLength(5);
+    for (const entry of salted) {
+      expect(entry.revision).toMatch(/-1\.5\.6$/);
+    }
+    expect(salted.find((e) => e.url === "sounds/xp-ding.mp3")?.revision).toBe(
+      "c27db1a021b82b56c998d3ff74e0b0a4-1.5.6",
+    );
+  });
+
+  // THE acceptance test vjt states on the issue: the entry must change
+  // identity at every cut, not only when the file's bytes change. The mp3
+  // bytes are identical in both arms here — only the cut moves.
+  it("gives the same file a different identity at a different cut", () => {
+    const before = soundsOf(saltPrecacheRevisions(MANIFEST, "1.5.5"));
+    const after = soundsOf(saltPrecacheRevisions(MANIFEST, "1.5.6"));
+
+    expect(before).toHaveLength(5);
+    expect(after).toHaveLength(before.length);
+    for (const [i, entry] of before.entries()) {
+      const twin = after[i];
+      // Pins the pairing before comparing, so a short `after` array would fail
+      // here rather than make the inequality below pass vacuously.
+      expect(twin?.url).toBe(entry.url);
+      expect(twin?.revision).not.toBe(entry.revision);
+    }
+  });
+
+  // The flip side, and the reason the salt is the VERSION and not a timestamp:
+  // two builds of one cut must agree, or every rebuild re-downloads the 43 KB
+  // and the precache stops being reproducible.
+  it("is deterministic within one cut", () => {
+    expect(saltPrecacheRevisions(MANIFEST, "1.5.6")).toEqual(
+      saltPrecacheRevisions(MANIFEST, "1.5.6"),
+    );
+  });
+
+  it("leaves every non-sound entry untouched, order and arity preserved", () => {
+    const out = saltPrecacheRevisions(MANIFEST, "1.5.6");
+
+    expect(out).toHaveLength(MANIFEST.length);
+    expect(out.map((e) => e.url)).toEqual(MANIFEST.map((e) => e.url));
+    for (const [i, entry] of out.entries()) {
+      if (entry.url.startsWith(CUT_SALTED_PRECACHE_PREFIX)) continue;
+      expect(entry).toEqual(MANIFEST[i]);
+    }
+  });
+
+  // A null revision means the URL is already content-addressed (`assets/*`
+  // carry the hash in the filename). Salting one would cache-bust an immutable
+  // url on every cut for nothing — and would make the entry no longer match
+  // what Workbox considers uniquely versioned.
+  it("never gives a content-hashed (null-revision) entry a revision", () => {
+    const out = saltPrecacheRevisions(MANIFEST, "1.5.6");
+
+    expect(out.find((e) => e.url === "assets/index-BZIN26f2.js")?.revision).toBeNull();
+  });
+
+  // Both guards below exist because the failure mode of this transform is
+  // SILENCE: it would keep emitting a well-formed manifest while the identity
+  // stopped moving, which is exactly the bug it removes.
+  it("refuses a blank version instead of emitting a constant salt", () => {
+    expect(() => saltPrecacheRevisions(MANIFEST, "")).toThrow(/version/i);
+    expect(() => saltPrecacheRevisions(MANIFEST, "   ")).toThrow(/version/i);
+  });
+
+  it("refuses a manifest carrying no salted entry at all", () => {
+    const noSounds = MANIFEST.filter((e) => !e.url.startsWith(CUT_SALTED_PRECACHE_PREFIX));
+
+    expect(() => saltPrecacheRevisions(noSounds, "1.5.6")).toThrow(
+      new RegExp(CUT_SALTED_PRECACHE_PREFIX),
+    );
+  });
+});

--- a/cicchetto/src/lib/precacheSalt.ts
+++ b/cicchetto/src/lib/precacheSalt.ts
@@ -1,0 +1,91 @@
+// issue 2098 — make the notification samples' precache entries change
+// IDENTITY at every cut, so a poisoned install repairs itself on the first
+// load after a deploy.
+//
+// Workbox keys a precache entry by `url` + `revision` and refetches only the
+// entries whose pair moved. Everything under `assets/` carries its content
+// hash in the FILENAME, so it arrives here with `revision: null` and a new
+// build simply gives it a new url. The five samples do not: they are served
+// from the stable `sounds/<name>.mp3` and their revision is the md5 of the
+// file, unchanged since #1480. So every deploy re-installs the SW (its bytes
+// move with the hashed asset urls) and walks straight past them.
+//
+// That is only a cache-efficiency detail until something poisons the cached
+// body, and something did: until #2088/#2092 `sounds` was missing from the
+// endpoint's `@cic_static_only`, so `GET /sounds/<name>.mp3` answered with the
+// SPA shell (200, `text/html`, 2467 bytes). An install that precached during
+// that window feeds 2467 bytes of HTML into `decodeAudioData` forever — the
+// server fix cannot reach it, because the client never asks again. Confirmed
+// in the field on iOS: with the server serving correct `audio/mpeg`, the PWA
+// was still silent until it was deleted and reinstalled.
+//
+// vjt's ruling (issue 2098, 2026-09-12) is to salt the revision, and states
+// the acceptance test this module is written against: the entry must change
+// identity AT EVERY CUT, not only when the file's bytes change. The salt is
+// therefore the build's version (`GRAPPA_VERSION`, the repo-root VERSION file
+// via infra/packaging/version.sh) — a value that is stable within a cut, so
+// two builds of one release still agree and the samples are not re-downloaded
+// on every rebuild.
+//
+// Scope is the samples and NOT every revisioned entry, measured rather than
+// assumed: the icons, `favicon.ico` and `manifest.webmanifest` are equally
+// stable-urled, but they were never outside `@cic_static_only`, so no install
+// can hold a poisoned copy of them — and `spa_serving_test.exs` now walks
+// every file under `cicchetto/public/` so none can silently leave that list
+// again. Salting them too would re-download 22.4 KiB per cut against a
+// hypothetical. Widening is this one constant.
+export const CUT_SALTED_PRECACHE_PREFIX = "sounds/";
+
+// The shape this transform needs from a Workbox manifest entry. Kept
+// structural (not an import from `workbox-build`) so the unit tests and the
+// browser-target tsconfig never pull a build-only package into their graph;
+// `vite.config.ts` passes the real `ManifestEntry & { size: number }` and its
+// extra fields ride through untouched.
+export type PrecacheEntry = {
+  revision: string | null;
+  url: string;
+};
+
+// Both refusals below go to stderr BEFORE they are thrown, and that is not
+// belt-and-braces. Measured on this build path with the prefix deliberately
+// perturbed: rollup reports a throw from a plugin hook as `error during
+// build:` followed by the STACK only — the frame `at saltPrecacheRevisions`
+// appears, the message does not (0 occurrences in the whole build log). A
+// guard whose reason never reaches the operator makes them open this file to
+// learn what a bare `Error` meant.
+function refuse(message: string): never {
+  console.error(message);
+  throw new Error(message);
+}
+
+// Return the manifest with every `sounds/` entry's revision suffixed by
+// `version`; throws when `version` is blank or when the manifest carries no
+// such entry, because both cases would emit a well-formed manifest whose
+// identity had quietly stopped moving — the very defect this removes.
+export function saltPrecacheRevisions<E extends PrecacheEntry>(
+  entries: readonly E[],
+  version: string,
+): E[] {
+  if (version.trim() === "") {
+    refuse(
+      "precacheSalt: refusing to salt with a blank version — the revision would be constant across cuts, which is the issue 2098 defect it exists to remove.",
+    );
+  }
+
+  let salted = 0;
+  const out = entries.map((entry) => {
+    if (entry.revision === null || !entry.url.startsWith(CUT_SALTED_PRECACHE_PREFIX)) {
+      return entry;
+    }
+    salted += 1;
+    return { ...entry, revision: `${entry.revision}-${version}` };
+  });
+
+  if (salted === 0) {
+    refuse(
+      `precacheSalt: no precache entry under "${CUT_SALTED_PRECACHE_PREFIX}" with a content revision — the samples either left the precache globs or moved to content-hashed urls, and this transform is now a silent no-op. Fix the prefix or drop the transform.`,
+    );
+  }
+
+  return out;
+}

--- a/cicchetto/vite.config.ts
+++ b/cicchetto/vite.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 import solid from "vite-plugin-solid";
+// issue 2098 — the precache-revision salt that makes the notification samples
+// change identity at every cut. Lives in `src/lib/` for the same reason the
+// icon set below does: it is shared build-time logic, and there it is
+// unit-testable by the cic vitest run (`__tests__/precacheSalt.test.ts`). It
+// imports nothing, so it drags no SolidJS graph into this config.
+import { saltPrecacheRevisions } from "./src/lib/precacheSalt";
 // S18: the manifest icon set is the single source of truth shared with the
 // service-worker's Web Push notification icon (`src/lib/pwaIcons.ts`), so a
 // rename can't silently drift the SW into a 404 path.
@@ -254,6 +260,18 @@ export default defineConfig({
         // case. They are ordinary same-origin assets with the endpoint's
         // default caching; the browser keeps them across a session either way.
         globIgnores: ["radio-logos/**"],
+        // issue 2098 — Workbox refetches a precache entry only when its
+        // url+revision pair moves, and the samples have neither a hashed url
+        // nor a moving revision, so an install that cached the SPA shell under
+        // `sounds/*.mp3` during the #2088 window stays silent through every
+        // subsequent deploy. Salting their revision with the build version
+        // gives them a new identity at each cut, so the poisoned body is
+        // refetched on the first load after the deploy with no user gesture.
+        // The full argument, the measured scope and the two loud guards are in
+        // `src/lib/precacheSalt.ts`; vjt's ruling is on the issue.
+        manifestTransforms: [
+          (entries) => ({ manifest: saltPrecacheRevisions(entries, CIC_VERSION) }),
+        ],
       },
     }),
   ],

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54582,3 +54582,75 @@ home (#1040). So on every other window the rollup is visible one tap in, not
 zero. That is one layer better than "open the modal and expand the group" and
 it is what the issue asked for; a dot on `rail-actions-launcher` itself is a
 separate decision, deliberately not taken here.
+<!-- entry #2098 -->
+
+---
+
+## 2026-09-12 — #2098: the sample precache entry never changed identity
+
+A PWA install that cached the SPA shell under `sounds/*.mp3` stayed silent
+through every later deploy, and the only field cure was deleting and
+reinstalling the app. Two facts combine: until #2088/#2092 `sounds` was missing
+from `@cic_static_only`, so those urls answered 200 `text/html`; and Workbox
+keys a precache entry by url+revision, where the samples' url is stable and
+their revision is the md5 of a file unchanged since #1480. The server fix
+cannot reach such an install, because the client never asks again.
+
+Measured here rather than reasoned, on a real build of 055c8362. The precache
+manifest is injected into `dist/service-worker.js` as one array: 28 entries,
+19 distinct urls. The five samples' revisions are exactly the md5 of the files
+in `public/sounds/`, and `dist/index.html` is 2467 bytes — the size vjt saw
+served for an mp3, so the poisoned body is the shell. Building twice across a
+simulated cut (VERSION 1.5.5 → 1.5.6) moves exactly ONE manifest entry,
+`index.html`; all five mp3 entries are byte-identical. That is the defect, and
+the positive control is in the same diff: something did change, so the harness
+is not blind.
+
+vjt ruled to salt the revision, and the ruling's own acceptance test is the
+sharp edge: the entry must change identity AT EVERY CUT, not only when the
+file's bytes change. It names two admissible routes, and one of them does not
+satisfy that test — moving the samples behind hashed urls makes identity track
+CONTENT, so it would repair the poisoned installs once and then never move
+again. The salt was chosen on that ground, not on cost; the hashed-url route is
+in fact cheaper (zero recurring bytes).
+
+Cost, measured against the estimate: the five samples are 43924 bytes
+(42.9 KiB), re-fetched once per cut, which is what "43 KB" in the issue refers
+to. The salt is the build VERSION and not a timestamp, so two builds of one
+release still agree and a rebuild does not churn the precache.
+
+Scope is the samples, and that is a measurement too. The icons, `favicon.ico`
+and `manifest.webmanifest` are equally stable-urled and equally unable to move,
+but they have always been in `@cic_static_only` — verified entry by entry
+against `cicchetto/public/`, all 12 present — so no install can hold a poisoned
+copy of them, and `spa_serving_test.exs` now walks that directory so none can
+silently leave the list again. Salting them too would re-download 22.4 KiB per
+cut against a hypothetical. Widening is one constant, deliberately left narrow.
+
+### The guard was mute, and that is why it prints
+
+Both refusals (`refuse/1`) write to stderr before they throw. With the prefix
+deliberately perturbed to `suoni/`, the build died at the right place — the
+stack names `saltPrecacheRevisions` inside workbox's `transformManifest` — but
+the message did NOT appear: zero occurrences of its text in the whole build
+log, against a positive control that found the frame. Rollup reports a throw
+from a plugin hook as the stack alone. A guard whose reason never reaches the
+operator makes them open the file to learn what a bare `Error` meant, so the
+reason is printed explicitly; re-measured after the change, it appears.
+
+### What is NOT asserted
+
+No browser ran. The repair itself — a poisoned install refetching on the first
+load after a deploy — is INFERRED from Workbox's url+revision key, not
+observed: there is no e2e lane on this slice, and a precache identity cannot be
+watched by installing a PWA headlessly anyway. The field half (an iOS PWA still
+silent against a correctly serving origin) is vjt's measurement, reproduced
+here only as far as the artefact. The e2e spec written alongside asserts the
+salt on the SERVED service worker and has never been executed on this host; its
+verdict is CI's.
+
+One observation recorded and not acted on: nine of the 28 manifest entries are
+duplicate urls carrying identical revisions (the icons and the webmanifest,
+listed both by `includeAssets` and by the glob). Workbox dedupes an identical
+url+revision pair, so this costs nothing today; it is noted so the next reader
+of that array does not mistake it for a symptom of this bug.


### PR DESCRIPTION
Closes nothing automatically — see issue 2098.

## The defect, re-measured here

A precache entry is keyed by `url` + `revision`, and Workbox refetches only the
entries whose pair moved. The five notification samples are served from stable
urls (`sounds/<name>.mp3`) with a revision that is the md5 of a file unchanged
since #1480, so they never move. An install that cached the SPA shell under
those urls during the #2088 window keeps feeding HTML into `decodeAudioData`
forever; the server fix (#2092) cannot reach it, because the client never asks
again. vjt confirmed it in the field: correct `audio/mpeg` from the origin, iOS
PWA still silent, cured only by deleting and reinstalling the app.

Measured on a real build of `055c8362`, before touching anything:

| measurement | result |
|---|---|
| precache manifest location | one array injected into `dist/service-worker.js` |
| entries / distinct urls | 28 / 19 |
| revision of the 5 samples | **exactly the md5** of `public/sounds/*.mp3` (all five) |
| `dist/index.html` size | **2467 bytes** — the body vjt saw served for an mp3 |
| build at 1.5.5 vs 1.5.6 | **only `index.html` changes**; all 5 mp3 entries byte-identical |
| negative control in the manifest | `assets/*` carry `revision: null` (hashed urls) |

The two-cut diff is the diagnosis, and it carries its own positive control:
something *did* change across the cut, so the harness is not blind.

## The fix

`manifestTransforms` salts the samples' revision with the build version
(`GRAPPA_VERSION`, already read by `vite.config.ts` for the `<meta>` tag), so
the entry changes identity at every cut and the first load after a deploy
refetches it — no user gesture, nothing to discover. Verified on the artefact:

```
{"revision":"c27db1a021b82b56c998d3ff74e0b0a4-1.5.5","url":"sounds/xp-ding.mp3"}
{"revision":"c27db1a021b82b56c998d3ff74e0b0a4-1.5.6","url":"sounds/xp-ding.mp3"}
```

Cost, measured against the estimate on the issue: the samples are **43924
bytes (42.9 KiB)**, re-fetched once per cut. The salt is the version and not a
timestamp, so two builds of one release still agree.

**Scope is the samples only, and that is measured too.** The icons, favicon and
webmanifest are equally stable-urled, but all 12 `public/` entries are present
in `@cic_static_only` and `spa_serving_test.exs` now walks that directory, so
no install can hold a poisoned copy of them. Salting them would spend 22.4 KiB
per cut on a hypothetical. Widening is one constant.

## Where the ruling is in tension with itself

The ruling admits two routes — salt the revision, or move the samples behind
hashed urls — and then states the acceptance test: *the entry must change
identity at every cut, not only when the file's bytes change*. **A hashed url
tracks content, so it does not satisfy that test**: it would repair the
poisoned installs once and then never move again. The salt was chosen on that
ground, not on cost — the route not taken is in fact the cheaper one (zero
recurring bytes). Flagging rather than silently picking.

## The guard was mute

With the prefix deliberately perturbed, the build died in the right place but
its message never reached the log — rollup reports a plugin-hook throw as the
stack alone (0 hits for the message text, against a positive control that found
the `saltPrecacheRevisions` frame). Both refusals now print before they throw;
re-measured after the change, the reason appears.

## Gates, on this HEAD, post-rebase onto `6560c15d7`

| gate | result |
|---|---|
| `scripts/bun.sh run build` | rc=0 |
| `scripts/bun.sh run check` | rc=0 — 5 stages, 0 failed |
| `scripts/bun.sh run test` | rc=0 — **354 files / 7166 tests** |
| `scripts/design-notes-gate.sh` (BASE_REF=origin/main) | `1 new entry heading(s), separator and marker present` |

## What I refuse to assert

- **No browser ran.** The repair itself — a poisoned install refetching on the
  first load after a deploy — is **inferred** from Workbox's url+revision key,
  not observed. No e2e lane was allocated to this slice.
- The e2e spec added here (`issue2098-sound-precache-salt.spec.ts`) has **never
  been executed on this host**; its verdict is CI's. It is the only gate that
  would catch the `manifestTransforms` line being deleted.
- The poisoning window itself (200 `text/html`, 2467 bytes under an mp3 url) is
  vjt's field measurement. I reproduced it only as far as the artefact: the
  shell is 2467 bytes, which is consistent with it, not a re-observation of it.
- No Elixir was touched, so no server-side gate was run; `@cic_static_only` was
  read, not exercised.
- Nine of the 28 manifest entries are duplicate urls with identical revisions
  (icons listed by both `includeAssets` and the glob). Harmless — Workbox
  dedupes an identical pair — noted so it is not mistaken for a symptom.