### PR TITLE
session: retire a withdrawn capability and stop CAP reaching scrollback

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54654,3 +54654,153 @@ duplicate urls carrying identical revisions (the icons and the webmanifest,
 listed both by `includeAssets` and by the glob). Workbox dedupes an identical
 url+revision pair, so this costs nothing today; it is noted so the next reader
 of that array does not mistake it for a symptom of this bug.
+<!-- entry #2097 -->
+
+---
+
+## 2026-09-12 — #2097: a withdrawn capability, and what a CAP line is allowed to be
+
+**The defect.** `caps_active` had one writer — the CAP ACK seam — and no
+removal site, so a registered-phase `CAP DEL` left the session acting on a bit
+that had stopped being true. Two readers consume that bit and both were being
+lied to: `prepare_label/2` kept stamping `@label=` on outbound commands the
+ircd no longer correlates, and `IdentityState.account_identified?/1` kept
+counting an account the ircd had stopped promising to retract. Field instance,
+Solanum/Libera, an oper module reloading:
+`:osmium.libera.chat CAP * DEL ?oper_realhost solanum.chat/realhost`, and the
+same cap back ten minutes later as `CAP * NEW`.
+
+**The target is `*`, not the nick, and the fix inherits the right shape rather
+than inventing one.** The ACK clause already matched the target as `_`, so the
+DEL and NEW clauses do the same and both advertised forms travel one code
+path. A handler keyed on the session nick would have missed the very line that
+filed this; a handler keyed on `*` would miss the other. One clause, no
+branch.
+
+### The surfacing path: the issue declared it unmeasured, and this is the measure
+
+The issue asserted the missing handler (measured) but explicitly NOT where the
+raw line lands — *"measure the actual rendering path before assuming the status
+window is where it lands"*. It does land there, and the chain is now read end
+to end: no Session.Server clause matched, so `delegate/2` handed the line to
+`EventRouter`'s catch-all, which persisted a `:server_event` on `$server` with
+`raw_verb: "CAP"`; `ScrollbackPane.tsx` routes any row carrying `meta.raw_verb`
+to `renderRawEvent`, which has no CAP arm and falls to its default,
+`*** {sender} {verb} {params.join(" ")}`. Substituting the parsed params
+reproduces the reported line character for character. Honest limit: this is a
+derivation that COINCIDES with the field string, not an executed render.
+
+### Retiring the name IS the teardown — per cap, decided, not assumed
+
+* `account-notify` — nothing else to unwind.
+  `IdentityState.account_identified?/1` derives from `caps_active` at call
+  time, on the stated rule that "an account counts only where the ircd promised
+  to retract it". A DEL **is** that promise being withdrawn, so the verdict
+  falls back to the umode axis on the next read. `state.account` stays: it is
+  an observed fact, not a claim of identity.
+* `labeled-response` — outbound labelling stops for free (the gate is on the
+  set), and `labels_pending` is deliberately **not** cleared. Commands already
+  on the wire were labelled while the cap was live and the ircd still answers
+  THOSE labelled, so dropping the map would misroute precisely the replies that
+  are still correlatable. The map cannot grow afterwards, its only writer being
+  gated on the same cap. **Stated cost:** the lazy TTL sweep runs only on the
+  next prime, which never comes once the cap is gone, so a bounded residue
+  lives until the process dies. A one-shot `sweep_stale/3` inside the DEL
+  clause is the tidier alternative and was left on the table rather than taken:
+  it trades a still-valid correlation for a neater map.
+
+### CAP NEW does not activate anything — and the cycle is closed by asking
+
+Per IRCv3 cap-notify, `NEW` advertises that a capability became AVAILABLE;
+enabling one still takes a `CAP REQ` and its ACK. Unioning the NEW blob into
+`caps_active` "for symmetry" would declare active a cap the server never
+granted — this issue's bug wearing the other face. So NEW adds nothing, and
+the cap re-enters the set only through the ACK clause that granted it
+originally.
+
+That leaves a real degradation, recorded here because it was argued and then
+fixed rather than discovered later: with DEL removing and NEW adding nothing,
+a cycled cap would stay retired for the rest of the session even though the
+upstream re-offers it. Better than the stale bit, still worse than whole. The
+ruling took the fork: we re-request. The ask is intersected with
+`@tracked_caps` and **not** with AuthFSM's `@opportunistic_caps` — the two hold
+the same two names today, but `@tracked_caps` means "caps whose ACK this
+process records", so the intersection makes it impossible to request something
+whose grant we would then drop on the floor. The lists are deliberately NOT
+unified: same contents, different meanings, and fusing them would be a shared
+data model between two readings that may legitimately diverge.
+
+### 🔴 The re-REQ is gated on `registered_at`, and the gate guards a session kill
+
+`AuthFSM` matches a CAP ACK in all three `:awaiting_cap_ack*` phases and reads
+it as the answer to ITS request. An ACK elicited by our re-REQ mid-negotiation
+carries no `"sasl"`, so the FSM takes the else branch into
+`cap_unavailable/1` — which **crashes the session** on `auth_method: :sasl`
+(`:sasl_unavailable`) and **silently loses SASL** on `:auto`. A server sending
+`CAP NEW` during negotiation is unusual and entirely permitted, so an ungated
+re-REQ trades a rare upstream behaviour for a failed login.
+
+The FSM phase lives in the Client process, and `Session.Server` had **no**
+registration marker at all: `connected_at` stamps the TCP/TLS connect
+(`:irc_connected`), not 001, and the 001 clause wrote only
+`connection_stable_timer`. Hence one new field, `registered_at`, stamped on
+001, whose only reader is this gate — not a third liveness axis. It is read
+with `Map.get` and written with `Map.put`: a hot-reloaded pre-#2097 process has
+no such key, nil degrades to "skip the re-REQ" (the safe direction), and the
+map-update form would have raised `KeyError` on its next 001. Residual cost: an
+already-registered process that survives a hot reload never re-requests
+anything again. This field is the one piece beyond the ruling's own estimate,
+and the crash above is the whole reason for it.
+
+### One cap-list parser
+
+Two existed with different semantics — `AuthFSM.parse_cap_list/1` dropped the
+IRCv3.2 `=<value>` suffix, the ACK seam's inline copy kept it attached — and
+the DEL clause would have been a third. `parse_cap_list/1` is public now and
+both seams use it; `cap_req/1` followed for the same reason, the shape of a CAP
+line belonging to the module that speaks CAP. `Parser` could not host it (not
+exported from the `Grappa.IRC` boundary) and a new `Grappa.IRC.Cap` would have
+cost a module and an export to buy a name. **Side effect on an existing path:**
+the ACK seam starts tolerating a valued token. **Near-regression avoided:** the
+inline copy also trimmed each token, which the FSM's did not, so the merged
+parser gained the trim — unifying dry would have quietly cost the ACK path its
+tab tolerance.
+
+### The generalisation, and the price that was ruled on
+
+With the three subcommands claimed, what still reached the catch-all was LS,
+NAK, LIST and whatever IRCv3 adds next. `@no_persist_verbs` gains `cap`: the
+list exists to name "verbs with no user-facing content that must never touch
+scrollback", which is the wording the ping/pong entry (issue 210, 2026-07-11)
+put there for the identical disease — same catch-all, same one-line cure.
+Deny-listing the VERB rather than the subcommands is also what answers the
+issue's own "a cap we never negotiated is DELed → drop the line quietly".
+
+**Accepted price, ruled on explicitly rather than discovered:** the
+registration-phase `CAP * LS` blob has been landing in `$server` on every
+connect since the catch-all existed — `IRC.Client` forwards every parsed line
+to the Session before running the FSM step, and no phase gate stands between
+there and the persist. That row stops being written; rows already in scrollback
+are untouched. It rides in its own commit so the generalisation can be reverted
+without disturbing the capability-state fix.
+
+### What the tests establish, and what they do not
+
+The reds were RUN before being claimed, not predicted: with the cure stashed,
+eleven fail; with it, zero. All eleven were the new ones — no collateral. The
+identity test is the sharpest reading, because the same snapshot field reads
+`identified: true` on the parent commit and `false` here.
+
+Two of the new tests were written with a defective positive control (asserting
+a `CAP LS ` line that this fixture's credential never sends, since it
+negotiates no caps at all) and went red for that reason — the control caught
+itself. They now assert that the PONG barrier line is present in the sample,
+which is the stronger control anyway: it proves the observation window COVERS
+the point where a re-REQ would have appeared, which is exactly what an
+assertion of absence needs and a handshake line from before the feed does not
+give.
+
+Not established: nothing was measured against production (m42 is unreachable
+from the agent), and the `CAP LS` leak on every connect is read from the code
+path rather than observed in the field — no user ever reported it. The unit
+test is what makes that claim falsifiable.

--- a/lib/grappa/irc/auth_fsm.ex
+++ b/lib/grappa/irc/auth_fsm.ex
@@ -826,8 +826,16 @@ defmodule Grappa.IRC.AuthFSM do
     end
   end
 
+  @doc """
+  Builds a `CAP REQ` line (CRLF included) asking for `caps`.
+
+  Public for the same reason as `parse_cap_list/1` (issue 2097): the CAP
+  NEW seam in `Grappa.Session.Server` re-requests an opportunistic cap the
+  upstream re-advertises, and the shape of a CAP line belongs to the module
+  that speaks CAP — not re-spelled at the second call site.
+  """
   @spec cap_req([String.t()]) :: String.t()
-  defp cap_req(caps), do: "CAP REQ :#{Enum.join(caps, " ")}\r\n"
+  def cap_req(caps) when is_list(caps), do: "CAP REQ :#{Enum.join(caps, " ")}\r\n"
 
   # SASL not on offer (or NAK'd). Mandatory SASL (`:sasl`) crashes;
   # `:auto` falls back to the PASS-handoff path (PASS already sent at
@@ -952,10 +960,21 @@ defmodule Grappa.IRC.AuthFSM do
     %{state | sasl_fields: fields}
   end
 
-  # Parse a CAP LS / CAP ACK cap-list blob: space-separated cap tokens,
-  # each optionally suffixed with `=<value>` (we drop the value, keeping
-  # only the cap name) — IRCv3.2 cap negotiation only inspects names.
-  #
+  @doc """
+  Parses a CAP cap-list blob into bare capability names.
+
+  The blob is the space-separated token list carried by every cap-bearing
+  subcommand — `CAP LS`, `CAP ACK`, `CAP NEW`, `CAP DEL` — where IRCv3.2
+  allows each token an optional `=<value>` suffix (`sasl=PLAIN,EXTERNAL`).
+  Negotiation only ever inspects names, so the value is dropped.
+
+  Public because the ACK and DEL seams in `Grappa.Session.Server` read the
+  same blob (issue 2097). This module owns CAP negotiation, so the ONE
+  parse of a cap list lives here rather than being re-spelled per reader:
+  before 2097 `Session.Server` carried its own weaker copy that split on
+  whitespace and kept the `=<value>` suffix attached, so a valued token
+  missed the tracked-cap compare there while matching here.
+  """
   # M-irc-3: explicit @spec + nil-reject. `String.split(_, "=", parts: 2)`
   # never returns an empty list for the `trim: true` output, so
   # `List.first/1` never returns nil today — but the type contract
@@ -964,10 +983,10 @@ defmodule Grappa.IRC.AuthFSM do
   # Reject defensively so the cap-name list is `[String.t()]` by
   # construction.
   @spec parse_cap_list(String.t()) :: [String.t()]
-  defp parse_cap_list(blob) do
+  def parse_cap_list(blob) when is_binary(blob) do
     blob
     |> String.split(" ", trim: true)
-    |> Enum.map(fn cap -> cap |> String.split("=", parts: 2) |> List.first() end)
+    |> Enum.map(fn cap -> cap |> String.trim() |> String.split("=", parts: 2) |> List.first() end)
     |> Enum.reject(&is_nil/1)
   end
 end

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -2833,7 +2833,23 @@ defmodule Grappa.Session.EventRouter do
   # ~1/min — continuous protocol noise. `pong` closes that; `ping` is
   # belt-and-braces for a malformed param-less `PING\r\n` that misses the
   # Server clause's `[token | _]` guard and would otherwise fall through.
-  @no_persist_verbs ~w(authenticate pass oper ping pong)a
+  # issue 2097 — `cap` joins the list on vjt's ruling ("core +
+  # generalizzazione"). `Session.Server` claims ACK, DEL and NEW with
+  # dedicated clauses, so what reaches here is LS, NAK, LIST and whatever
+  # subcommand IRCv3 adds next — all of which used to persist a
+  # `:server_event` and render verbatim in the cic status window through
+  # `renderRawEvent`'s default arm. Deny-listing the VERB rather than the
+  # subcommands is the point: CAP is negotiation chatter in every phase, and
+  # the list already exists to say exactly that ("verbs with no user-facing
+  # content that must never touch scrollback", #210).
+  #
+  # Accepted price, ruled on explicitly rather than discovered: the
+  # registration-phase `CAP * LS :multi-prefix sasl …` blob has been landing
+  # in `$server` on EVERY connect since the catch-all existed — `IRC.Client`
+  # forwards every parsed line to the Session before the FSM step, and no
+  # phase gate stands between here and the persist. That row stops being
+  # written. Rows already in scrollback are untouched.
+  @no_persist_verbs ~w(authenticate cap pass oper ping pong)a
 
   defp do_route(%Message{command: command} = _, state)
        when command in @no_persist_verbs,

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -593,8 +593,15 @@ defmodule Grappa.Session.Server do
           auto_away_debounce_ms: non_neg_integer() | :disabled,
           # S4.2: IRCv3 caps confirmed active by upstream CAP ACK. Keys are
           # lowercase cap names (e.g. "labeled-response"). Empty until the
-          # upstream ACKs at least one cap. Caps added on ACK; never removed
-          # (a registered-phase CAP DEL is not handled — out of S4 scope).
+          # upstream ACKs at least one cap. Added on ACK and retired on a
+          # registered-phase CAP DEL (2097): until then this set only ever
+          # grew, so an upstream that withdrew a capability mid-session left
+          # us acting on a bit that had stopped being true. Every reader
+          # derives from the set at call time (the `labeled-response` gate in
+          # `prepare_label/2`, `IdentityState`'s account axis), so retiring
+          # the name IS the teardown for both. A CAP NEW does NOT add: it
+          # advertises that a cap became AVAILABLE, and enabling one still
+          # takes a CAP REQ and its ACK.
           caps_active: MapSet.t(String.t()),
           # S4.2: in-flight label → origin_window correlations for the
           # `labeled-response` cap. Entries are removed on the labeled numeric
@@ -717,6 +724,20 @@ defmodule Grappa.Session.Server do
           # ever connected, process uptime when we died pre-connect.
           started_at: DateTime.t(),
           connected_at: DateTime.t() | nil,
+          # issue 2097 — stamped on 001 RPL_WELCOME, nil until then. NOT a
+          # third liveness axis: the ONLY reader is the CAP NEW re-REQ, which
+          # must never fire while `AuthFSM` still has a CAP REQ outstanding.
+          # An ACK we elicit during negotiation is indistinguishable, to the
+          # FSM, from the ACK of ITS request: `auth_fsm.ex` matches ACK in the
+          # three `:awaiting_cap_ack*` phases, finds no "sasl" in our blob and
+          # calls `cap_unavailable/1` — which CRASHES the session on
+          # `auth_method: :sasl` and silently drops SASL on `:auto`. The FSM
+          # phase lives in the Client process, so this stamp is the cheapest
+          # thing Session.Server can read to know that window has closed.
+          # Read with `Map.get` (never `state.registered_at`): a hot-reloaded
+          # pre-2097 process has no such key, and nil degrades to "skip the
+          # re-REQ", which is the safe direction.
+          registered_at: DateTime.t() | nil,
           # #1088 — EVERY accumulator below that is primed by a `:send_*`
           # request also carries a `:reply_to` key: the `socket_ref` of the
           # WebSocket that asked, or `nil`. It is routing metadata, not
@@ -1285,6 +1306,8 @@ defmodule Grappa.Session.Server do
       # #215 — spawn stamp; `connected_at` fills on `:irc_connected`.
       started_at: DateTime.utc_now(),
       connected_at: nil,
+      # issue 2097 — fills on 001; gates the CAP NEW re-REQ. See the typedoc.
+      registered_at: nil,
       # #543 INC-6 — the derived `::cb` alias this session manages (nil for a
       # non-derived source). Acquired in `do_start_client`, released in
       # `terminate/2`. Pre-resolved by the plan (`Vhosts.derived_source?/2`).
@@ -3370,7 +3393,13 @@ defmodule Grappa.Session.Server do
     # nick we actually registered as (may differ from the configured one).
     SessionLog.emit(:registered, %{state | nick: welcomed_nick}, [])
 
-    delegate(msg, %{state | connection_stable_timer: stable_timer})
+    # issue 2097 — stamp "the CAP negotiation window is closed" for the CAP
+    # NEW re-REQ gate. `Map.put`, never `%{state | registered_at: ...}`: a
+    # live pre-2097 process hot-reloaded mid-session has no such key and the
+    # map-update form would KeyError on its next 001 (the #216 contract).
+    next_state = %{state | connection_stable_timer: stable_timer}
+
+    delegate(msg, Map.put(next_state, :registered_at, DateTime.utc_now()))
   end
 
   # #100 — the connection survived `connection_stable_ms` past 001 without
@@ -3660,13 +3689,111 @@ defmodule Grappa.Session.Server do
       when is_binary(caps_blob) do
     caps_active =
       caps_blob
-      |> String.split(" ", trim: true)
-      |> Enum.map(&String.trim/1)
+      |> AuthFSM.parse_cap_list()
       |> MapSet.new()
       |> MapSet.intersection(@tracked_caps)
       |> MapSet.union(state.caps_active)
 
     {:noreply, %{state | caps_active: caps_active}}
+  end
+
+  # 2097 — CAP DEL: the upstream retiring a capability mid-session. Seen in
+  # the field on Solanum/Libera, an oper module being reloaded:
+  #
+  #   :osmium.libera.chat CAP * DEL ?oper_realhost solanum.chat/realhost
+  #
+  # Note the target: `*`, not our nick. Like the ACK clause above this one
+  # matches the target as `_`, so BOTH advertised forms are claimed by
+  # construction rather than by a second handler — a clause keyed on the
+  # session nick would have missed the very line that filed this.
+  #
+  # `MapSet.difference` needs no intersection with `@tracked_caps`: removing
+  # a name we never tracked is already a no-op, and a cap we never negotiated
+  # being DELed must change nothing AND say nothing.
+  #
+  # Retiring the name IS the whole teardown, for both tracked caps, because
+  # both readers derive at call time:
+  #   * `labeled-response` — `prepare_label/2` stops minting labels the ircd
+  #     no longer honours. `labels_pending` is deliberately NOT cleared: the
+  #     commands already on the wire were labelled while the cap was live and
+  #     the ircd still answers THOSE labelled, so dropping the map would
+  #     misroute precisely the replies we can still correlate. It cannot grow
+  #     after this point (its only writer is gated on the cap), so the
+  #     residue is bounded by what was in flight — at the cost, stated
+  #     plainly, that the S10 lazy TTL sweep only runs on the next prime,
+  #     which never comes once the cap is gone.
+  #   * `account-notify` — `IdentityState.account_identified?/1` counts an
+  #     account only "where the ircd promised to retract it", and this line
+  #     IS that promise being withdrawn, so the identity verdict falls back
+  #     to the umode axis on the very next read. `state.account` stays: it is
+  #     an observed fact, not a claim of identity.
+  #
+  # Claiming the line also stops it reaching the persisting catch-all in
+  # `EventRouter` via `delegate/2`, which is how it was rendering verbatim in
+  # the cic status window. Malformed shape note: like the ACK clause, this
+  # one requires the cap list; a `CAP * DEL` naming nothing is not a thing an
+  # ircd sends and is left to the same fate as a malformed ACK.
+  def handle_info(
+        {:irc, %Message{command: :cap, params: [_, "DEL", caps_blob | _]}},
+        state
+      )
+      when is_binary(caps_blob) do
+    retired = MapSet.new(AuthFSM.parse_cap_list(caps_blob))
+
+    {:noreply, %{state | caps_active: MapSet.difference(state.caps_active, retired)}}
+  end
+
+  # 2097 — CAP NEW: the other half of the cycle observed in the field (the
+  # same cap came back ten minutes after the DEL).
+  #
+  # It adds NOTHING to `caps_active`, and that is the correct handling rather
+  # than an omission: per IRCv3 cap-notify, NEW advertises that a capability
+  # has become AVAILABLE — enabling it still takes a `CAP REQ` and its ACK.
+  # Unioning the NEW blob into the set "for symmetry" would declare active a
+  # cap the server never granted us, which is this issue's bug wearing the
+  # other face. The cap re-enters the set only through the ACK clause above.
+  #
+  # What we DO is ask again (vjt's ruling, issue 2097): without a re-REQ a
+  # cycled cap stays retired for the rest of the session, so the DEL/NEW
+  # round trip would land honest-but-degraded instead of whole.
+  #
+  # The request is intersected with `@tracked_caps` and NOT with AuthFSM's
+  # `@opportunistic_caps`, which today holds the same two names. That is the
+  # semantically load-bearing choice: `@tracked_caps` is exactly "caps whose
+  # ACK this process records", so the intersection makes it impossible to
+  # request something whose grant we would then drop on the floor. Caps
+  # already active are subtracted — a re-advertisement of something we hold
+  # is not news.
+  #
+  # 🔴 GATED ON `registered_at`, and the gate is load-bearing, not hygiene.
+  # `AuthFSM` matches a CAP ACK in all three `:awaiting_cap_ack*` phases and
+  # reads it as the answer to ITS request: an ACK elicited by us mid-
+  # negotiation carries no "sasl", so the FSM would call `cap_unavailable/1`
+  # — which CRASHES the session on `auth_method: :sasl` and silently loses
+  # SASL on `:auto`. A server that sends CAP NEW during negotiation is
+  # unusual and entirely permitted, so the unguarded version trades a rare
+  # upstream behaviour for a failed login. Before 001 we consume the line and
+  # ask nothing.
+  def handle_info(
+        {:irc, %Message{command: :cap, params: [_, "NEW", caps_blob | _]}},
+        state
+      )
+      when is_binary(caps_blob) do
+    wanted =
+      caps_blob
+      |> AuthFSM.parse_cap_list()
+      |> MapSet.new()
+      |> MapSet.intersection(@tracked_caps)
+      |> MapSet.difference(state.caps_active)
+
+    maybe_re_req_caps(state, Map.get(state, :registered_at), Enum.sort(wanted))
+
+    {:noreply, state}
+  end
+
+  # A NEW naming no caps advertises nothing; claim the line and stop.
+  def handle_info({:irc, %Message{command: :cap, params: [_, "NEW" | _]}}, state) do
+    {:noreply, state}
   end
 
   # S5.1 / #216 — 005 RPL_ISUPPORT: fold the advertised tokens into the
@@ -5060,6 +5187,27 @@ defmodule Grappa.Session.Server do
   # sufficient uniqueness for in-flight correlation (bounded, short-lived map).
   @spec generate_label() :: String.t()
   defp generate_label, do: Ecto.UUID.generate()
+
+  # issue 2097 — the CAP NEW re-REQ, lifted out of the clause so each refusal
+  # reads at a clause head instead of inside a nested condition.
+  #
+  # Returns `:ok` and never a state: asking does not make a cap active. The
+  # cap re-enters `caps_active` only when the upstream ACKs, through the same
+  # seam that granted it the first time — so a NAK, a silent drop or a
+  # hostile reply all leave us exactly where the DEL left us.
+  #
+  # First clause is the phase gate (nil `registered_at` = CAP negotiation may
+  # still be open; see the CAP NEW handler for why asking there can kill the
+  # session). Second is the empty ask — a NEW that re-advertises only caps we
+  # do not track, or already hold, sends nothing at all rather than an empty
+  # `CAP REQ :`.
+  @spec maybe_re_req_caps(t(), DateTime.t() | nil, [String.t()]) :: :ok
+  defp maybe_re_req_caps(_, nil, _), do: :ok
+  defp maybe_re_req_caps(_, _, []), do: :ok
+
+  defp maybe_re_req_caps(state, _, caps) do
+    maybe_log_send_failure("cap_re_req", Client.send_line(state.client, AuthFSM.cap_req(caps)))
+  end
 
   # ---------------------------------------------------------------------------
   # S10 — pending-accumulator lazy TTL sweep

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -496,6 +496,73 @@ defmodule Grappa.Session.EventRouterTest do
       assert {:cont, ^state, []} = EventRouter.route(m, state)
     end
 
+    # 2097 — CAP is negotiation chatter and carries no user-facing content,
+    # but only ONE of its subcommands (ACK) has a dedicated Server clause:
+    # LS, NAK, NEW, DEL and LIST all reach this router through the catch-all
+    # delegate and persist a `:server_event` on $server. The field instance
+    # is a Solanum withdrawing an oper cap mid-session, rendered verbatim in
+    # the status window by `renderRawEvent`'s default arm:
+    #
+    #   *** osmium.libera.chat CAP * DEL ?oper_realhost solanum.chat/realhost
+    #
+    # Same disease, same cure and same reason as #210's `ping pong`: a verb
+    # with no user-facing content must never touch scrollback. The deny-list
+    # keys on the VERB, not the subcommand, which is also what answers "a cap
+    # we never negotiated is DELed — drop the line quietly".
+    #
+    # The positive controls for these four live in this same describe: WALLOPS
+    # and KILL still persist, so a deny-list that swallowed everything would
+    # turn those red rather than pass unnoticed.
+    test "CAP DEL deny-list: zero effects (2097, the `*` target seen in the field)" do
+      state = base_state()
+
+      m =
+        msg(
+          :cap,
+          ["*", "DEL", "?oper_realhost solanum.chat/realhost"],
+          {:server, "osmium.libera.chat"}
+        )
+
+      assert {:cont, ^state, []} = EventRouter.route(m, state)
+    end
+
+    # The target is the other axis the field line settles: a handler keyed on
+    # the session nick would miss `*`, and one keyed on `*` would miss the
+    # nick. Both forms are claimed.
+    test "CAP DEL deny-list: zero effects on the session-nick target too (2097)" do
+      state = base_state()
+      m = msg(:cap, ["vjt", "DEL", "labeled-response"], {:server, "osmium.libera.chat"})
+
+      assert {:cont, ^state, []} = EventRouter.route(m, state)
+    end
+
+    # The other half of the DEL/NEW cycle (an oper module reloaded upstream
+    # re-advertises the cap ten minutes later). It leaks through exactly the
+    # same hole.
+    test "CAP NEW deny-list: zero effects (2097, the other half of the cycle)" do
+      state = base_state()
+
+      m =
+        msg(
+          :cap,
+          ["*", "NEW", "?oper_realhost solanum.chat/realhost"],
+          {:server, "osmium.libera.chat"}
+        )
+
+      assert {:cont, ^state, []} = EventRouter.route(m, state)
+    end
+
+    # Not in the issue, same hole: `IRC.Client.process_line/2` forwards EVERY
+    # parsed line to Session.Server before running the FSM step, so the
+    # registration-phase LS blob reaches this catch-all on every single
+    # connect. Deny-listing the verb closes the older leak with the new one.
+    test "CAP LS deny-list: zero effects (2097, the registration-phase blob)" do
+      state = base_state()
+      m = msg(:cap, ["*", "LS", "multi-prefix sasl labeled-response"], {:server, "irc.example.org"})
+
+      assert {:cont, ^state, []} = EventRouter.route(m, state)
+    end
+
     test "{:numeric, _} without dedicated clause returns NO effects (Server owns numeric persist)" do
       # Critical: numerics also flow through EventRouter via Server's
       # numeric handler (server.ex:1555 calls EventRouter.route after

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -2586,6 +2586,329 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  # 2097 — `caps_active` grows and never shrinks: the ACK seam above is its
+  # only writer, and the sole `:cap` clause in the tree lives in `AuthFSM`,
+  # i.e. the REGISTRATION phase. A cap withdrawn mid-session therefore stays
+  # "active" for the life of the process. The field instance is a Solanum
+  # oper module cycling (`CAP * DEL` then, ten minutes later, `CAP * NEW`)
+  # on the `*` target — not on our nick.
+  #
+  # These assert the CONSEQUENCES of the stale bit on the wire and through
+  # the public snapshot, never the MapSet itself: the set is the mechanism,
+  # the label and the identity verdict are what a user actually gets wrong.
+  #
+  # Synchronisation: `IRCServer.feed/2` is asynchronous with respect to a
+  # GenServer call from the test process, so after every fed CAP line we feed
+  # a PING and wait for its PONG. The socket → Client → Session mailbox is
+  # strictly ordered, so observing the PONG proves the CAP line ahead of it
+  # is fully processed — the #210 barrier.
+  describe "registered-phase CAP DEL/NEW (2097)" do
+    test "after CAP * DEL :labeled-response the outbound AWAY carries no @label" do
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
+
+      {server, port} = IRCServer.start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+      :ok = IRCServer.await_handshake(server, 1_000)
+
+      own_nick = SessionStateHelpers.nick(SessionStateHelpers.fetch(pid))
+      origin = %{kind: :channel, target: "#chan"}
+
+      IRCServer.feed(server, ":irc CAP #{own_nick} ACK :labeled-response\r\n")
+      IRCServer.feed(server, "PING :sync-ack\r\n")
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(server, &(&1 == "PONG :sync-ack\r\n"), 1_000)
+
+      # Baseline: the cap is live, so the command IS labelled. Without this
+      # the test could pass on a session that never labelled anything.
+      :ok = Session.set_explicit_away({:user, user.id}, network.id, "brb", origin)
+
+      assert {:ok, labelled} =
+               IRCServer.wait_for_line(server, &String.contains?(&1, "AWAY :brb"), 1_000)
+
+      assert String.starts_with?(labelled, "@label=")
+
+      # The field line's shape, verbatim: the target is `*`, not the nick.
+      IRCServer.feed(server, ":irc CAP * DEL :labeled-response\r\n")
+      IRCServer.feed(server, "PING :sync-del\r\n")
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(server, &(&1 == "PONG :sync-del\r\n"), 1_000)
+
+      :ok = Session.set_explicit_away({:user, user.id}, network.id, "back later", origin)
+
+      assert {:ok, after_del} =
+               IRCServer.wait_for_line(server, &String.contains?(&1, "AWAY :back later"), 1_000)
+
+      assert after_del == "AWAY :back later\r\n"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # The other advertised target. The clause matches it as `_`, exactly as
+    # the ACK seam already did, so both forms travel one code path — this
+    # pins that they keep doing so. vjt's field note is explicit that a
+    # handler keyed on the session nick would have missed the `*` line that
+    # filed the issue; the inverse mistake (keying on `*`) is just as
+    # available to a future refactor, and costs the nick form.
+    test "a CAP DEL addressed to the session nick retires the cap too (2097)" do
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
+
+      {server, port} = IRCServer.start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+      :ok = IRCServer.await_handshake(server, 1_000)
+
+      own_nick = SessionStateHelpers.nick(SessionStateHelpers.fetch(pid))
+      origin = %{kind: :channel, target: "#chan"}
+
+      IRCServer.feed(server, ":irc CAP #{own_nick} ACK :labeled-response\r\n")
+      IRCServer.feed(server, "PING :sync-nick-ack\r\n")
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(server, &(&1 == "PONG :sync-nick-ack\r\n"), 1_000)
+
+      # Baseline, and not a formality: without it a DEL that never reached
+      # the clause would still read green off an ACK that never landed —
+      # green for the wrong reason.
+      :ok = Session.set_explicit_away({:user, user.id}, network.id, "brb", origin)
+
+      assert {:ok, labelled} =
+               IRCServer.wait_for_line(server, &String.contains?(&1, "AWAY :brb"), 1_000)
+
+      assert String.starts_with?(labelled, "@label=")
+
+      IRCServer.feed(server, ":irc CAP #{own_nick} DEL :labeled-response\r\n")
+      IRCServer.feed(server, "PING :sync-nick-del\r\n")
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(server, &(&1 == "PONG :sync-nick-del\r\n"), 1_000)
+
+      :ok = Session.set_explicit_away({:user, user.id}, network.id, "back later", origin)
+
+      assert {:ok, after_del} =
+               IRCServer.wait_for_line(server, &String.contains?(&1, "AWAY :back later"), 1_000)
+
+      assert after_del == "AWAY :back later\r\n"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "after CAP * DEL :account-notify the account stops counting as identity" do
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
+
+      {server, port} = IRCServer.start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      pid = start_session_for(user, network)
+      :ok = IRCServer.await_handshake(server, 1_000)
+
+      own_nick = SessionStateHelpers.nick(SessionStateHelpers.fetch(pid))
+
+      IRCServer.feed(server, ":irc CAP #{own_nick} ACK :account-notify\r\n")
+      IRCServer.feed(server, ":#{own_nick}!u@h ACCOUNT vjtaccount\r\n")
+
+      # Baseline + barrier: the acquisition edge proves the ACK landed and the
+      # account axis is granted (#388).
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :session_identity_changed, identified: true}
+                     },
+                     1_000
+
+      IRCServer.feed(server, ":irc CAP * DEL :account-notify\r\n")
+      IRCServer.feed(server, "PING :sync-del\r\n")
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(server, &(&1 == "PONG :sync-del\r\n"), 1_000)
+
+      # `IdentityState.account_identified?/1` derives from `caps_active` at
+      # call time — "an account counts only where the ircd promised to retract
+      # it". A DEL is that promise being withdrawn, so the verdict the public
+      # snapshot publishes (the same field cic reloads on) must fall back to
+      # the umode axis, which this session has never set.
+      # `identified:` is this snapshot's spelling of the verdict — the
+      # `{:connection_info}` payload calls the same `IdentityState.identified?/1`
+      # value `registered:`, which is a naming split that predates this slice
+      # and is a WIRE field in both, so it is left alone here.
+      assert {:ok, %{identified: false}} =
+               Session.session_snapshot({:user, user.id}, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "a registered-phase CAP DEL/NEW persists NO $server row (2097)" do
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
+
+      {server, port} = IRCServer.start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+      :ok = IRCServer.await_handshake(server, 1_000)
+
+      IRCServer.feed(
+        server,
+        ":osmium.libera.chat CAP * DEL :?oper_realhost solanum.chat/realhost\r\n"
+      )
+
+      IRCServer.feed(
+        server,
+        ":osmium.libera.chat CAP * NEW :?oper_realhost solanum.chat/realhost\r\n"
+      )
+
+      IRCServer.feed(server, "PING :sync-noise\r\n")
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(server, &(&1 == "PONG :sync-noise\r\n"), 1_000)
+
+      # The user-visible absence is the real guard: pre-fix both lines render
+      # in the cic status window through `renderRawEvent`'s default arm.
+      assert [] = Scrollback.fetch({:user, user.id}, network.id, "$server", nil, 10, nil, false)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # PIN: `CAP NEW` advertises that a capability has become AVAILABLE, it
+    # does not enable it — enabling still takes a `CAP REQ` and its ACK
+    # (IRCv3 cap-notify). This holds the line against a handler that
+    # "symmetrically" unions the NEW blob into `caps_active` and starts
+    # stamping labels the ircd never granted.
+    #
+    # The re-REQ does go out here (this session is registered), and this fake
+    # ircd answers nothing — which is precisely the case the pin cares about:
+    # asked-but-not-granted must read exactly like never-asked.
+    test "CAP * NEW does NOT activate a capability that was never ACKed (2097)" do
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
+
+      {server, port} = IRCServer.start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+      :ok = IRCServer.await_handshake(server, 1_000)
+
+      origin = %{kind: :channel, target: "#chan"}
+
+      IRCServer.feed(server, ":irc CAP * NEW :labeled-response\r\n")
+      IRCServer.feed(server, "PING :sync-new\r\n")
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(server, &(&1 == "PONG :sync-new\r\n"), 1_000)
+
+      :ok = Session.set_explicit_away({:user, user.id}, network.id, "brb", origin)
+
+      assert {:ok, line} =
+               IRCServer.wait_for_line(server, &String.contains?(&1, "AWAY :brb"), 1_000)
+
+      assert line == "AWAY :brb\r\n"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # vjt's ruling on the fork (issue 2097): a cap the upstream re-advertises
+    # after retiring it gets asked for again, so the DEL/NEW round trip lands
+    # whole instead of honest-but-degraded. The cap does NOT come back here —
+    # it comes back on the ACK, through the seam that granted it originally.
+    #
+    # Unambiguous by construction, and measured rather than assumed: this
+    # fixture's credential negotiates no caps, so the whole client handshake
+    # on this wire is `NICK` + `USER` and the AuthFSM never issues a REQ of
+    # its own. Any `CAP REQ` here is the re-REQ.
+    test "a CAP NEW re-requests a tracked cap that a DEL retired (2097)" do
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
+
+      {server, port} = IRCServer.start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+      :ok = IRCServer.await_handshake(server, 1_000)
+
+      own_nick = SessionStateHelpers.nick(SessionStateHelpers.fetch(pid))
+
+      IRCServer.feed(server, ":irc CAP #{own_nick} ACK :labeled-response\r\n")
+      IRCServer.feed(server, ":irc CAP * DEL :labeled-response\r\n")
+      IRCServer.feed(server, ":irc CAP * NEW :labeled-response\r\n")
+
+      assert {:ok, "CAP REQ :labeled-response\r\n"} =
+               IRCServer.wait_for_line(server, &(&1 == "CAP REQ :labeled-response\r\n"), 1_000)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # 🔴 The gate, and it guards a session kill rather than a tidiness rule.
+    # `AuthFSM` reads a CAP ACK in its three `:awaiting_cap_ack*` phases as
+    # the answer to ITS request; an ACK we elicit mid-negotiation carries no
+    # "sasl", so the FSM would call `cap_unavailable/1` — crashing the session
+    # on `auth_method: :sasl`, silently losing SASL on `:auto`. This fake ircd
+    # never sends 001, so the session never registers and the re-REQ must stay
+    # in its holster.
+    test "a CAP NEW before 001 asks nothing — the re-REQ phase gate (2097)" do
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {user, network, _} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+
+      :ok = IRCServer.await_handshake(server, 1_000)
+
+      # Same three lines as the registered case; only the phase differs.
+      IRCServer.feed(server, ":irc CAP * ACK :labeled-response\r\n")
+      IRCServer.feed(server, ":irc CAP * DEL :labeled-response\r\n")
+      IRCServer.feed(server, ":irc CAP * NEW :labeled-response\r\n")
+      IRCServer.feed(server, "PING :sync-gate\r\n")
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(server, &(&1 == "PONG :sync-gate\r\n"), 1_000)
+
+      lines = IRCServer.sent_lines(server)
+
+      # Positive control, and it has to be a line sent AFTER the CAP NEW: an
+      # absence proves nothing unless the sample is known to COVER the window
+      # where the thing would have appeared. The PONG is the barrier reply, so
+      # its presence says the accessor saw past the fed NEW.
+      # (The first version of this control asserted a `CAP LS ` line and went
+      # red: this fixture's credential negotiates no caps at all, so the only
+      # handshake traffic is NICK + USER. The control caught itself.)
+      assert "PONG :sync-gate\r\n" in lines
+      refute Enum.any?(lines, &String.starts_with?(&1, "CAP REQ"))
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # The cap from the actual field report is one we do not track. The
+    # intersection with `@tracked_caps` is what keeps us from requesting
+    # something whose ACK this process would then drop on the floor.
+    test "a CAP NEW for an untracked cap asks nothing (2097)" do
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
+
+      {server, port} = IRCServer.start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+      :ok = IRCServer.await_handshake(server, 1_000)
+
+      IRCServer.feed(
+        server,
+        ":osmium.libera.chat CAP * NEW :?oper_realhost solanum.chat/realhost\r\n"
+      )
+
+      IRCServer.feed(server, "PING :sync-untracked\r\n")
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(server, &(&1 == "PONG :sync-untracked\r\n"), 1_000)
+
+      lines = IRCServer.sent_lines(server)
+
+      # Same control as the phase-gate test above: a line sent after the NEW.
+      assert "PONG :sync-untracked\r\n" in lines
+      refute Enum.any?(lines, &String.starts_with?(&1, "CAP REQ"))
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "PING/PONG" do
     test "responds to server PING with matching PONG" do
       {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())


### PR DESCRIPTION
Closes nothing automatically — this is the work for **issue 2097**.

`caps_active` had one writer (the CAP ACK seam) and no removal site, so a
registered-phase `CAP DEL` left the session acting on a bit that had stopped
being true. Field instance, Solanum/Libera, an oper module reloading:

```
*** osmium.libera.chat CAP * DEL ?oper_realhost solanum.chat/realhost
*** osmium.libera.chat CAP * NEW ?oper_realhost solanum.chat/realhost   (ten minutes later)
```

Two commits, deliberately split:

1. **`session: retire a capability the upstream withdraws mid-session`** — the
   capability-state fix, the CAP NEW re-REQ, and one cap-list parser.
2. **`session: stop every CAP subcommand from reaching the scrollback`** — the
   generalisation, kept revertible on its own.

---

## The result worth reading first: the issue's open caveat is closed

The issue asserted the missing handler (measured) but explicitly **not** where
the raw line surfaces — *"measure the actual rendering path for an unhandled
post-registration line before assuming the status window is where it lands —
this issue asserts the missing handler (measured), not the exact surfacing path
(not measured)."*

**It is the status window, and here is the measurement.** No `Session.Server`
clause matched, so `delegate/2` handed the line to `EventRouter`'s catch-all,
which persisted a `:server_event` on `$server` carrying `raw_verb: "CAP"`.
`ScrollbackPane.tsx` routes any row with `meta.raw_verb` to `renderRawEvent`,
which has no CAP arm and falls through to its default,
`*** {sender} {verb} {params.join(" ")}`. Substituting the parsed params
reproduces the reported line character for character.

Honest limit on that claim: it is a derivation over the code path that
**coincides** with the field string, not an executed render. Coinciding is not
executing — but it is more than the issue had, which was a declared assumption.

## Both target forms, by construction

The ACK clause already matched the target as `_`, so the DEL and NEW clauses do
the same: `*` and the session nick travel one code path. A handler keyed on the
nick would have missed the very line that filed this; one keyed on `*` would
miss the other.

## What gets torn down, per cap

* **`account-notify`** — nothing beyond retiring the name.
  `IdentityState.account_identified?/1` derives from `caps_active` at call time
  on the rule that "an account counts only where the ircd promised to retract
  it". A DEL *is* that promise being withdrawn, so the verdict falls back to the
  umode axis on the next read. `state.account` stays: an observed fact, not a
  claim of identity.
* **`labeled-response`** — outbound labelling stops for free. **`labels_pending`
  is deliberately NOT cleared**: commands already on the wire were labelled while
  the cap was live and the ircd still answers *those* labelled, so dropping the
  map would misroute precisely the replies still correlatable. It cannot grow
  afterwards (its only writer is gated on the cap).
  ⚠️ **Stated cost:** the S10 lazy TTL sweep runs only on the next prime, which
  never comes once the cap is gone — so a bounded residue lives until the process
  dies. A one-shot `sweep_stale/3` inside the DEL clause is the tidier
  alternative; **left on the table for this review** rather than taken, because
  it trades a still-valid correlation for a neater map.

## CAP NEW does not activate — and the cycle is closed by asking

Per IRCv3 cap-notify, NEW advertises that a capability became **available**;
enabling one still takes a `CAP REQ` and its ACK. Unioning the NEW blob into
`caps_active` "for symmetry" would declare active a cap the server never
granted — this bug wearing the other face.

📌 **On the record:** with DEL removing and NEW adding nothing, a cycled cap
would stay retired for the rest of the session even though the upstream
re-offers it. Better than the stale bit, still worse than whole. **vjt took the
fork**, so we re-request, and the degradation is mitigated rather than merely
noted. The ask intersects `@tracked_caps` and *not* AuthFSM's
`@opportunistic_caps`: same two names today, but `@tracked_caps` means "caps
whose ACK this process records", which makes it impossible to request something
whose grant we would then drop. The two lists are deliberately **not** unified —
same contents, different meanings.

## 🔴 Scope beyond the ruling: `registered_at`, and the session kill that forces it

The ruling budgeted the fork at ~10 lines. It cost ~15 more, and this is why.

`AuthFSM` matches a CAP ACK in **all three** `:awaiting_cap_ack*` phases and
reads it as the answer to *its* request. An ACK elicited by our re-REQ
mid-negotiation carries no `"sasl"`, so the FSM takes the else branch into
`cap_unavailable/1` — which **crashes the session** on `auth_method: :sasl`
(`:sasl_unavailable`) and **silently loses SASL** on `:auto`. A server sending
CAP NEW during negotiation is unusual and entirely permitted, so an ungated
re-REQ trades a rare upstream behaviour for a failed login.

The FSM phase lives in the Client process, and `Session.Server` had **no**
registration marker at all (`connected_at` stamps the TCP/TLS connect, not 001;
the 001 clause wrote only `connection_stable_timer`). Hence one field,
`registered_at`, stamped on 001, whose **only** reader is this gate — not a
third liveness axis. Read with `Map.get`, written with `Map.put`: a
hot-reloaded process without the key degrades to "skip the re-REQ" (the safe
direction), and the map-update form would have raised `KeyError` on its next
001. Residual cost: an already-registered process surviving a hot reload never
re-requests again.

Ruled on and accepted (vjt): gate stays, lines are the price.

## One cap-list parser

Two existed with different semantics — `AuthFSM.parse_cap_list/1` drops the
IRCv3.2 `=<value>` suffix, the ACK seam's inline copy kept it attached — and the
DEL clause would have been a third. `parse_cap_list/1` is public now and both
seams use it; `cap_req/1` followed for the same reason. `Parser` could not host
it (not exported from the `Grappa.IRC` boundary); a new `Grappa.IRC.Cap` would
cost a module and an export to buy a name.

* ⚠️ **Behaviour change on an EXISTING path:** the ACK seam starts tolerating a
  valued token (`labeled-response=foo`). Previously it kept the suffix attached
  and the tracked-cap compare missed.
* ⚠️ **Near-regression avoided, declared:** the inline copy also trimmed each
  token, which the FSM's parser did not. Unifying dry would have quietly cost
  the ACK path its tab tolerance, so the trim moved **into** the shared parser —
  neither caller loses anything in the merge.

## The generalisation (commit 2), and its accepted price

With the three subcommands claimed, what still reached the catch-all was LS,
NAK, LIST and whatever IRCv3 adds next. `@no_persist_verbs` gains `cap` — the
list exists to name "verbs with no user-facing content that must never touch
scrollback", the exact wording the ping/pong entry (**issue 210**, DESIGN_NOTES
2026-07-11) put there for the identical disease: same catch-all, same one-line
cure. Deny-listing the **verb** rather than the subcommands is also what answers
the issue's own "a cap we never negotiated is DELed → drop the line quietly".

⚠️ **Accepted price, ruled on explicitly by vjt rather than discovered:** the
registration-phase `CAP * LS` blob has been landing in `$server` on **every
connect** since the catch-all existed — `IRC.Client` forwards every parsed line
to the Session before running the FSM step, and no phase gate stands between
there and the persist. **That row stops being written.** Rows already in
scrollback are untouched.

## Tests: the reds were run, not predicted

With the cure stashed: **11 failures**. With it: **0**. All eleven were the new
tests — no collateral. The identity test is the sharpest reading: the same
snapshot field is `identified: true` on the parent commit and `false` here.

Two of the new tests were written with a **defective positive control** — they
asserted a `CAP LS ` line that this fixture's credential never sends, since it
negotiates no caps at all — and went red for that reason. The control caught
itself. They now assert the PONG barrier line is present in the sample, which is
the stronger control: it proves the observation window **covers** the point
where a re-REQ would have appeared, which is what an assertion of absence needs
and a handshake line from before the feed does not give.

## Not claimed

* **No production measurement.** m42 is unreachable from the agent, so the only
  field evidence is the two lines in the issue.
* **The `CAP LS`-on-every-connect leak is read from the code path, not observed
  in the field.** No user ever reported it; the unit test is what makes the claim
  falsifiable.
* **The surfacing path coincides, it was not executed** (see the top section).
* The `labels_pending` residue is bounded and accepted, not eliminated.
