### PR TITLE
salvage(2089): two DCC parser properties and the upload-store rationale

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -55301,3 +55301,71 @@ string.
 Not established, unchanged from #2089 and #2089a: `scripts/integration.sh`
 has still not been run, nothing was measured against a real DCC peer, and
 nothing was measured on m42.
+<!-- entry #2089d -->
+
+---
+
+## 2026-09-13 — #2089d: why the DCC spool is not the upload store, written down late
+
+The code has held this decision since the slice shipped: DCC bytes go to
+`Grappa.Dcc`'s own spool, its own root, its own cap, its own reaper and
+its own authenticated route. What was never written down is WHY, and the
+reason it matters is that the issue body asked for the opposite — the
+bytes were to "land in the existing upload store as if the user had
+uploaded it". A decision that reversed the spec and left no argument
+behind is one rewrite away from being reversed back by someone reading
+the issue and not the code. **The defect recorded here is the missing
+reason, not the behaviour.**
+
+Salvaged from the superseded first iteration of this slice (branch
+`w1-2089`, never merged), whose entry carried the argument and was
+rewritten out.
+
+### Two measurements against reusing the upload store
+
+**The MIME allowlist is CLOSED, and a `DCC SEND` carries no MIME at
+all.** `UploadsController`'s `@mime_categories` is commented in the
+source as exactly that — *"Closed allowlist: unknown MIME → 415"* — over
+image / video / document / audio. A DCC offer carries a filename, an
+address, a port and a size; there is no content type anywhere in the
+wire shape. So reuse forces a choice between refusing everything outside
+the allowlist, which rejects the archives that are most of real DCC
+traffic, and punching a hole in the allowlist, which weakens the upload
+surface that already exists for everybody. Neither is a trade this slice
+is entitled to make on the uploads context's behalf.
+
+**`GET /uploads/:slug` is public and unauthenticated by design.** The
+router says so in as many words (*"NO `:authn`"*), and it is safe there
+because the 26-char base32 slug is a capability: `Uploads.get_by_slug/2`
+collapses FOUR distinct rejections into one `{:error, :not_found}` so
+the route offers no existence oracle. That posture is right for content
+a user chose to publish and wrong for bytes a stranger pushed at them —
+committing those there makes grappa an anonymous public file host, with
+the host's own users carrying the consequences.
+
+### The third argument was already on main, and I nearly missed it
+
+Entry #1280's closing paragraph already reserves the *"public,
+unauthenticated `GET /uploads/:slug` route ... for content the
+operator's own users chose to publish — never a proxy for arbitrary
+third-party URLs"*, and its 2089 amendment says the ruling REINFORCES
+that rather than bending it. So it is cited here, not restated.
+
+⚠️ Worth recording as method: the grep that went looking for that
+sentence came back EMPTY, and the sentence is right there. It is wrapped
+across a line break, so no line contains the phrase being searched for.
+The only thing that stopped a false "not documented anywhere" was a
+positive control confirming entry #1280 existed at all, which made the
+empty result implausible enough to look again by hand. **A grep over
+prose is a grep over LINES; an absence verdict on wrapped text needs a
+control that proves the search could have succeeded.**
+
+### The rejected alternative, and the precedent that settles it
+
+`Grappa.Avatars` faced the same question — a stranger-declared resource
+that grappa fetches — and answered it the same way: its own context, own
+storage root, own caps deliberately independent of the uploads budget,
+own TTL, own reaper. A shared data model with a type flag across two
+trust domains is the boundary violation CLAUDE.md names, not the reuse
+it encourages. The HTTP READ path from the issue survives intact; only
+the STORE was refused.

--- a/test/grappa/irc/dcc_test.exs
+++ b/test/grappa/irc/dcc_test.exs
@@ -1,5 +1,6 @@
 defmodule Grappa.IRC.DCCTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias Grappa.IRC.DCC
   alias Grappa.IRC.DCC.Offer
@@ -156,6 +157,46 @@ defmodule Grappa.IRC.DCCTest do
 
     test "an unterminated quoted filename is malformed" do
       assert {:error, :malformed} = DCC.parse(~s{SEND "unterminated #{@v4_int} 5000 12345})
+    end
+  end
+
+  # Salvaged from the superseded first iteration of this slice (branch
+  # `w1-2089`, never merged), where they were written and then lost when
+  # the parser was rewritten. Two of that branch's three properties are
+  # here; the third asserted that an unquoted spaced filename is recovered
+  # by a right-to-left split, and the parser this file tests REFUSES that
+  # input deliberately — see "an unquoted filename containing spaces is
+  # refused rather than guessed" above. Porting it would assert a
+  # behaviour the code rejects on purpose, which is asserting a bug.
+  describe "parse/1 — properties over generated input" do
+    property "any four octets round-trip through the 32-bit integer field" do
+      # The example-based tests pin ONE address (1.2.3.4). Byte order is
+      # the kind of thing a single example cannot police: a little-endian
+      # decode of 16909060 answers {4, 3, 2, 1}, which is also a valid
+      # tuple, so only the whole space distinguishes them.
+      check all(
+              a <- integer(0..255),
+              b <- integer(0..255),
+              c <- integer(0..255),
+              d <- integer(0..255)
+            ) do
+        n = a * 16_777_216 + b * 65_536 + c * 256 + d
+
+        assert {:ok, %Offer{ip: {^a, ^b, ^c, ^d}}} = DCC.parse("SEND f #{n} 5000 1")
+      end
+    end
+
+    property "never raises on arbitrary argument bytes" do
+      # The argument string comes off a stranger's socket, and `parse/1`
+      # is called from `EventRouter`, inside the session process. A raise
+      # here is not a malformed offer — it is a killed session on a line
+      # any nick on the network can send (the #1988 failure mode). Total
+      # over its input type is therefore a property of the process tree,
+      # not a tidiness of the parser.
+      check all(args <- string(:printable, max_length: 40)) do
+        assert match?({:ok, %Offer{}}, DCC.parse(args)) or
+                 match?({:error, _}, DCC.parse(args))
+      end
     end
   end
 end


### PR DESCRIPTION
# Salvage from the superseded DCC branch: two properties and one rationale

`issue 2089` is closed and this does not reopen it. Branch `w1-2089` — the
first, never-merged iteration of that slice — carries two things the
landed rewrite did not, and this recovers them so the branch can be
pruned. Nothing here changes behaviour: the diff is `test/**` and
`docs/**` only.

The audit that found them distinguished FUNCTIONALITY from COVERAGE by
executing main's parser rather than reading it — 225 four-octet
combinations, 0 discrepancies — so the verdict "superseded in code" is
measured, not argued. What follows is the remainder.

---

## 1. Two StreamData properties over `Grappa.IRC.DCC.parse/1`

**The gap, measured on the base:** 10 test files dedicated to DCC on
`origin/main`, **0 properties between them**. CLAUDE.md requires
StreamData *"for any function with non-trivial input shape (parser,
pagination boundary, etc.)"* and names the parser as the example, so this
is a gap against a rule.

The count ships with a **positive control run through the same loop** —
`scrollback_test.exs` reports 1 and `identifier_test.exs` reports 8 —
because a counting command that answers 0 everywhere is more often broken
than right. (It was, twice, during this work: see the note at the end.)

**Both properties earn their place by killing a mutant**, each restored
`cmp` byte-identical afterwards:

| property | mutant | result |
|---|---|---|
| four octets round-trip through the 32-bit integer field | `unsigned-big-integer` → `unsigned-little-integer` | fails **by name** |
| never raises on arbitrary argument bytes | `{:error, :malformed}` → `raise` on the branch every spaceless input reaches | fails **by name** |

Byte order is precisely what one example cannot police: a little-endian
decode of `16909060` is `{4, 3, 2, 1}`, itself a valid tuple.

The totality property is not tidiness. `parse/1` runs inside the session
process, on an argument string off a stranger's socket — a raise there is
a killed session on a line any nick on the network can send, which is the
#1988 failure mode this slice already reproduced once by mutation.

**Two of three, and the third stays dead.** The omitted property asserted
that an unquoted filename containing spaces is recovered by a
right-to-left split. This parser refuses that input deliberately —
*"Guessing an unquoted split would make the ADDRESS field's position
depend on the filename's content"* — and pins the refusal in its own
example test. Porting it would assert a behaviour the code rejects on
purpose, which is asserting a bug.

## 2. `#2089d` — why the DCC spool is not the upload store

The code has held this since the slice shipped. The argument never landed,
and the issue body asked for the **opposite** ("land in the existing
upload store as if the user had uploaded it"). A decision that reverses
its spec and leaves no reason behind is one rewrite from being reversed
back by someone reading the issue instead of the code. **The defect is the
missing reason, not the behaviour.**

Two measurements, both **re-verified against current code** rather than
copied from the old branch:

- `UploadsController`'s `@mime_categories` is commented in the source as a
  closed allowlist, unknown MIME → 415 — while a `DCC SEND` carries no
  content type at all. Reuse forces either refusing the archives that are
  most of real DCC traffic, or holing the allowlist that protects the
  existing upload surface.
- `GET /uploads/:slug` is unauthenticated by design (*"NO `:authn`"* in the
  router) because the base32 slug is a capability, with `get_by_slug/2`
  collapsing four rejections into one `:not_found` so the route is no
  existence oracle. Right for content a user chose to publish; wrong for
  bytes a stranger pushed.

**The third argument was already on main** — entry #1280's closing
paragraph, whose 2089 amendment says this ruling reinforces it. Cited, not
restated; the entry is shorter than planned because of it.

---

## Method notes, because two measurements of mine were wrong first

Both were caught by controls, not by luck, and both are recorded rather
than quietly fixed:

- **A grep over prose is a grep over LINES.** The search for #1280's
  sentence came back empty while the sentence was there — it wraps across
  a line break. Only a positive control proving entry #1280 existed made
  the empty result implausible enough to look again. An absence verdict
  over wrapped text needs a control showing the search could have
  succeeded.
- **zsh does not word-split.** `for f in $FILES` over a multi-line list
  saw one element and reported `0` properties for everything. The positive
  control (`scrollback_test.exs` = 1) is what exposed it. The earlier
  `grep -E '^\s*…'` failure is the same family: BSD `grep` has no `\s`
  class, so the anchor silently skipped every indented line and reported a
  plausible wrong count.
- **A bad mutant is not a weak property.** The first totality mutant went
  into `parse_size/1` and the suite stayed green — that function sits
  behind `parse_address` in the `with`, so generated input almost never
  reaches it. The mutant had to move to a branch the generator hits.

## Verification

Gates, rc read from each run's own log, never a task notification:

- **`scripts/check.sh` FULL: rc=0** on the final merged HEAD with a clean
  tree (cwd + HEAD printed outside the redirect and checked).
- server suite: 8 doctests, **67 properties** (65 on the base, +2 here),
  7502 tests, 0 failures — the property count rising is an independent
  confirmation the two were collected.
- `mix dialyzer`: Total errors: 0 · `credo --strict`: no issues ·
  `design-notes-gate.sh`: rc=0, "1 new entry heading", run AFTER the
  commit (on a working tree it answers `nothing to check`, a vacuous
  green).

**`origin/main` moved mid-flight** (`#2089c` landed), so the branch was
brought up by **merge, never rebase**, with the DESIGN_NOTES arithmetic
PREDICTED before the merge and then measured:

```
predicted 3235143 bytes / 55482 lines      (main 3231511+55414, entry 3632+68)
measured  3235143 bytes / 55482 lines      → neither lost nor duplicated
numstat   68 0  before  →  68 0  after     → additions unchanged AND deletions zero
```

Boundary shape re-read on the real file for BOTH `#2089c` and `#2089d`:
full stop / marker with no blank before it / blank / `---` / blank /
heading. `#2089d` checked for uniqueness against main's CURRENT tip (0
occurrences, positive control: 376 markers). Pure-append proved by `cmp`
of main's file against this branch's prefix, with a negative control at
one byte short showing the `cmp` can say no.

⚠️ An earlier arithmetic check on this branch **could not have failed** —
the merge at that point was `Already up to date`, so main contributed no
bytes. It is called out as vacuous rather than counted as evidence; the
run above is the one that means something.

ⓘ Non-blocking observation, no action taken: in the merged file `#2089d`
sits ABOVE `#2089c` because append order and entry date diverge under
`merge=union`. That is the open chronology question, not a defect of
either entry.

## Not claimed

- `scripts/integration.sh` was not run. The diff is `test/**` + `docs/**`,
  which is outside that workflow's `paths:`, so ~4 checks are expected on
  CI and a missing `integration` is not a gap.
- Nothing measured against a real DCC peer, and nothing on m42 — unchanged
  from the parent slice.
